### PR TITLE
test: tighten site reader smoke coverage

### DIFF
--- a/crates/site/server/src/handlers/api.rs
+++ b/crates/site/server/src/handlers/api.rs
@@ -31,7 +31,7 @@ mod tests {
     };
     use domain::{ArticlePageDocument, CategoryPageDocument, HomePageDocument};
     use infra::LocalArtifactReader;
-    use std::sync::Arc;
+    use std::{fs, sync::Arc};
     use tempfile::TempDir;
     use tower::util::ServiceExt;
 
@@ -128,6 +128,44 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/page/categories/unknown")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_api_router_returns_not_found_for_missing_article_html_artifact() {
+        let temp_dir = TempDir::new().unwrap();
+        write_fixture_site(temp_dir.path());
+        fs::remove_file(temp_dir.path().join("articles/sample0000001.html")).unwrap();
+
+        let response = create_test_router(temp_dir.path())
+            .oneshot(
+                Request::builder()
+                    .uri("/page/articles/sample0000001")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_api_router_returns_not_found_for_missing_category_artifact() {
+        let temp_dir = TempDir::new().unwrap();
+        write_fixture_site(temp_dir.path());
+        fs::remove_file(temp_dir.path().join("categories/tech.json")).unwrap();
+
+        let response = create_test_router(temp_dir.path())
+            .oneshot(
+                Request::builder()
+                    .uri("/page/categories/tech")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/site/server/src/handlers/api/pages.rs
+++ b/crates/site/server/src/handlers/api/pages.rs
@@ -74,7 +74,7 @@ mod tests {
     use super::*;
     use crate::test_support::write_fixture_site;
     use infra::LocalArtifactReader;
-    use std::sync::Arc;
+    use std::{fs, sync::Arc};
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -132,6 +132,36 @@ mod tests {
 
         let result = get_category_page(
             Path("../secrets".to_string()),
+            Extension(Arc::new(LocalArtifactReader::new(temp_dir.path()))),
+        )
+        .await;
+
+        assert!(matches!(result, Err(StatusCode::NOT_FOUND)));
+    }
+
+    #[tokio::test]
+    async fn test_get_article_page_returns_not_found_when_html_artifact_is_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        write_fixture_site(temp_dir.path());
+        fs::remove_file(temp_dir.path().join("articles/sample0000001.html")).unwrap();
+
+        let result = get_article_page(
+            Path("sample0000001".to_string()),
+            Extension(Arc::new(LocalArtifactReader::new(temp_dir.path()))),
+        )
+        .await;
+
+        assert!(matches!(result, Err(StatusCode::NOT_FOUND)));
+    }
+
+    #[tokio::test]
+    async fn test_get_category_page_returns_not_found_when_category_artifact_is_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        write_fixture_site(temp_dir.path());
+        fs::remove_file(temp_dir.path().join("categories/tech.json")).unwrap();
+
+        let result = get_category_page(
+            Path("tech".to_string()),
             Extension(Arc::new(LocalArtifactReader::new(temp_dir.path()))),
         )
         .await;

--- a/service/okawak_blog.service
+++ b/service/okawak_blog.service
@@ -16,7 +16,8 @@ TimeoutStopSec=30
 
 Environment=AWS_PROFILE=blog-s3
 Environment=AWS_REGION=ap-northeast-1
-Environment=AWS_BUCKET_NAME=okawak-blog-resources-bucket
+Environment=OKAWAK_BLOG_ARTIFACT_SOURCE=s3
+Environment=OKAWAK_BLOG_ARTIFACT_BUCKET=okawak-blog-resources-bucket
 Environment=OKAWAK_BLOG_SITE_ORIGIN=https://www.okawak.net
 
 StateDirectory=okawak_blog


### PR DESCRIPTION
## Summary
- align the production service unit with the artifact reader environment variables
- extend page API smoke tests to cover missing HTML/category artifacts as 404s
- keep reader role assumptions explicit in both runtime config and tests

## Context
- continues Phase 2 in issue #37
- focuses on the remaining reader-path and smoke-test scope

## Verification
- `cargo test -p infra`
- `cargo check -p server`
- `cargo clippy -p infra -p server --all-targets -- -D warnings`
- `cargo check --workspace`