### PR TITLE
fix: repair client-side site navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.128.0"
+version = "1.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99304b64672e0d81a3c100a589b93d9ef5e9c0ce12e21c848fd39e50f493c2a1"
+checksum = "6d4e8410fadbc0ee453145dd77a4958227b18b05bf67c2795d0a8b8596c9aa0f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -709,9 +709,9 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1288,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1602,6 +1602,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -2000,12 +2006,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2182,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2879,7 +2885,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3355,7 +3361,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -3396,7 +3402,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3421,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4196,9 +4202,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -4326,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4694,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4707,9 +4713,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4717,9 +4723,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4727,9 +4733,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4740,9 +4746,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4846,9 +4852,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/site/web/src/app.rs
+++ b/crates/site/web/src/app.rs
@@ -7,10 +7,7 @@ use crate::routes::home::HomePage;
 use crate::routes::not_found::NotFoundPage;
 use leptos::prelude::*;
 use leptos_meta::{MetaTags, Stylesheet, Title, provide_meta_context};
-use leptos_router::{
-    ParamSegment, StaticSegment,
-    components::{Route, Router, Routes},
-};
+use leptos_router::{components::{Route, Router, Routes}, path};
 
 /// Shell function used for server-side rendering.
 /// This function renders the full HTML document.
@@ -99,16 +96,10 @@ pub fn App() -> impl IntoView {
                     <Routes fallback=|| {
                         view! { <NotFoundPage /> }
                     }>
-                        <Route path=StaticSegment("") view=HomePage />
-                        <Route path=StaticSegment("about") view=AboutPage />
-                        <Route
-                            path=(StaticSegment("articles"), ParamSegment("slug"))
-                            view=ArticlePage
-                        />
-                        <Route
-                            path=(StaticSegment("categories"), ParamSegment("category"))
-                            view=CategoryPage
-                        />
+                        <Route path=path!("/") view=HomePage />
+                        <Route path=path!("/about") view=AboutPage />
+                        <Route path=path!("/articles/:slug") view=ArticlePage />
+                        <Route path=path!("/categories/:category") view=CategoryPage />
                     </Routes>
                 </main>
             </Router>

--- a/crates/site/web/src/app.rs
+++ b/crates/site/web/src/app.rs
@@ -8,7 +8,7 @@ use crate::routes::not_found::NotFoundPage;
 use leptos::prelude::*;
 use leptos_meta::{MetaTags, Stylesheet, Title, provide_meta_context};
 use leptos_router::{
-    components::{Route, Router, Routes},
+    components::{FlatRoutes, Route, Router},
     path,
 };
 
@@ -96,14 +96,14 @@ pub fn App() -> impl IntoView {
             <Router>
                 <Header />
                 <main class="content-container">
-                    <Routes fallback=|| {
+                    <FlatRoutes fallback=|| {
                         view! { <NotFoundPage /> }
                     }>
-                        <Route path=path!("/") view=HomePage />
-                        <Route path=path!("/about") view=AboutPage />
-                        <Route path=path!("/articles/:slug") view=ArticlePage />
-                        <Route path=path!("/categories/:category") view=CategoryPage />
-                    </Routes>
+                        <Route path=path!("") view=HomePage />
+                        <Route path=path!("about") view=AboutPage />
+                        <Route path=path!("articles/:slug") view=ArticlePage />
+                        <Route path=path!("categories/:category") view=CategoryPage />
+                    </FlatRoutes>
                 </main>
             </Router>
             <Footer />

--- a/crates/site/web/src/app.rs
+++ b/crates/site/web/src/app.rs
@@ -7,7 +7,10 @@ use crate::routes::home::HomePage;
 use crate::routes::not_found::NotFoundPage;
 use leptos::prelude::*;
 use leptos_meta::{MetaTags, Stylesheet, Title, provide_meta_context};
-use leptos_router::{components::{Route, Router, Routes}, path};
+use leptos_router::{
+    components::{Route, Router, Routes},
+    path,
+};
 
 /// Shell function used for server-side rendering.
 /// This function renders the full HTML document.

--- a/crates/site/web/src/components/header.rs
+++ b/crates/site/web/src/components/header.rs
@@ -69,7 +69,7 @@ pub fn Header() -> impl IntoView {
                                 view! {
                                     <li class=active_class>
                                         <A
-                                            href=move || href.clone()
+                                            href={href}
                                             {..}
                                             class=header_style::nav_link
                                             on:click=move |_| set_menu_open.set(false)

--- a/crates/site/web/src/components/header.rs
+++ b/crates/site/web/src/components/header.rs
@@ -2,6 +2,7 @@ use crate::SITE_NAME;
 use crate::components::ui::button::{Button, ButtonSize, ButtonVariant};
 use crate::components::{NavigationItem, get_main_nav_items};
 use leptos::prelude::*;
+use leptos_router::components::A;
 use leptos_router::hooks::use_location;
 use stylance::import_style;
 
@@ -20,9 +21,9 @@ pub fn Header() -> impl IntoView {
     view! {
         <header class=header_style::header class:open=move || menu_open.get()>
             <div class=header_style::container>
-                <a href="/">
+                <A href="/">
                     <h1 class=header_style::logo>{SITE_NAME}</h1>
-                </a>
+                </A>
 
                 <Button
                     class=header_style::menu_toggle
@@ -57,8 +58,9 @@ pub fn Header() -> impl IntoView {
                             key=|item: &NavigationItem| item.href.clone()
                             children=move |child| {
                                 let href = child.href.clone();
+                                let active_href = href.clone();
                                 let active_class = move || {
-                                    if location.pathname.get() == href {
+                                    if location.pathname.get() == active_href {
                                         header_style::nav_item_active
                                     } else {
                                         header_style::nav_item
@@ -66,9 +68,14 @@ pub fn Header() -> impl IntoView {
                                 };
                                 view! {
                                     <li class=active_class>
-                                        <a class=header_style::nav_link href=child.href>
+                                        <A
+                                            href=move || href.clone()
+                                            {..}
+                                            class=header_style::nav_link
+                                            on:click=move |_| set_menu_open.set(false)
+                                        >
                                             {child.title}
-                                        </a>
+                                        </A>
                                     </li>
                                 }
                             }

--- a/crates/site/web/src/components/sidebar.rs
+++ b/crates/site/web/src/components/sidebar.rs
@@ -1,5 +1,6 @@
 use crate::types::ArticleSummary;
 use leptos::prelude::*;
+use leptos_router::components::A;
 use leptos_router::{hooks::use_params_map, params::ParamsMap};
 use stylance::import_style;
 
@@ -33,7 +34,7 @@ fn render_sidebar(articles: Vec<ArticleSummary>) -> impl IntoView {
                         };
                         view! {
                             <li class=link_style>
-                                <a href=link>{article.title.to_string()}</a>
+                                <A href=link>{article.title.to_string()}</A>
                             </li>
                         }
                     })

--- a/crates/site/web/src/components/sidebar.rs
+++ b/crates/site/web/src/components/sidebar.rs
@@ -26,7 +26,7 @@ fn render_sidebar(articles: Vec<ArticleSummary>) -> impl IntoView {
                 {articles
                     .into_iter()
                     .map(|article| {
-                        let link = format!("/{}/{}", article.category, article.slug);
+                        let link = format!("/articles/{}", article.slug);
                         let link_style = if slug() == article.slug {
                             sidebar_style::article_link_active
                         } else {

--- a/crates/site/web/src/error.rs
+++ b/crates/site/web/src/error.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use leptos_router::components::A;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -47,7 +48,7 @@ pub fn ErrorTemplate(#[prop(into)] err: String) -> impl IntoView {
             <div class="error-message">
                 <h1>エラーが発生しました</h1>
                 <p>{err}</p>
-                <a href="/">トップページに戻る</a>
+                <A href="/">トップページに戻る</A>
             </div>
         </div>
     }

--- a/crates/site/web/src/routes/category.rs
+++ b/crates/site/web/src/routes/category.rs
@@ -74,7 +74,7 @@ fn CategoryPageContent(document: CategoryPageDocument) -> impl IntoView {
             view! {
                 <article class=category_style::article_card>
                     <h2 class=category_style::article_title>
-                        <A href=move || href.clone() {..} class=category_style::article_link>
+                        <A href={href} {..} class=category_style::article_link>
                             {title}
                         </A>
                     </h2>

--- a/crates/site/web/src/routes/category.rs
+++ b/crates/site/web/src/routes/category.rs
@@ -14,6 +14,7 @@ use infra::DynArtifactReader;
 use leptos::prelude::*;
 #[cfg(feature = "ssr")]
 use leptos_axum::ResponseOptions;
+use leptos_router::components::A;
 use leptos_router::{hooks::use_params_map, params::ParamsMap};
 #[cfg(feature = "ssr")]
 use std::str::FromStr;
@@ -73,9 +74,9 @@ fn CategoryPageContent(document: CategoryPageDocument) -> impl IntoView {
             view! {
                 <article class=category_style::article_card>
                     <h2 class=category_style::article_title>
-                        <a class=category_style::article_link href=href>
+                        <A href=move || href.clone() {..} class=category_style::article_link>
                             {title}
-                        </a>
+                        </A>
                     </h2>
                     <p class=category_style::article_description>{description}</p>
                     <p class=category_style::article_meta>{format!("更新 {}", updated_at)}</p>

--- a/crates/site/web/src/routes/home.module.scss
+++ b/crates/site/web/src/routes/home.module.scss
@@ -145,6 +145,12 @@
             gap: 1rem;
         }
 
+        .article-card-link {
+            display: block;
+            color: inherit;
+            text-decoration: none;
+        }
+
         .article-card {
             display: flex;
             flex-direction: column;
@@ -154,6 +160,18 @@
             border: 1px solid var(--color-border);
             background: var(--color-surface);
             box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06);
+            transition: transform var(--transition-normal), box-shadow var(--transition-normal), border-color var(--transition-normal);
+        }
+
+        .article-card-link:hover .article-card,
+        .article-card-link:focus-visible .article-card {
+            transform: translateY(-2px);
+            box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+            border-color: var(--color-accent);
+        }
+
+        .article-card-link:focus-visible {
+            outline: none;
         }
 
         .article-meta {
@@ -179,12 +197,8 @@
             font-size: var(--font-size-xl);
         }
 
-        .article-link {
-            color: inherit;
-            text-decoration: none;
-        }
-
-        .article-link:hover {
+        .article-card-link:hover .article-title,
+        .article-card-link:focus-visible .article-title {
             color: var(--color-accent);
         }
 

--- a/crates/site/web/src/routes/home.module.scss
+++ b/crates/site/web/src/routes/home.module.scss
@@ -171,7 +171,8 @@
         }
 
         .article-card-link:focus-visible {
-            outline: none;
+            outline: 2px solid currentColor;
+            outline-offset: 4px;
         }
 
         .article-meta {

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -98,32 +98,30 @@ fn ArticleCard(article: SiteArticleCard) -> impl IntoView {
     let article_href = format!("/articles/{slug}");
 
     view! {
-        <article class=home_style::article_card>
-            <div class=home_style::article_meta>
-                <span class=home_style::article_category>{category}</span>
-                <span class=home_style::category_count>
-                    {format!("公開 {} / 更新 {}", created_at, updated_at)}
-                </span>
-            </div>
+        <A href=move || article_href.clone() {..} class=home_style::article_card_link>
+            <article class=home_style::article_card>
+                <div class=home_style::article_meta>
+                    <span class=home_style::article_category>{category}</span>
+                    <span class=home_style::category_count>
+                        {format!("公開 {} / 更新 {}", created_at, updated_at)}
+                    </span>
+                </div>
 
-            <h3 class=home_style::article_title>
-                <A href=move || article_href.clone() {..} class=home_style::article_link>
-                    {title}
-                </A>
-            </h3>
-            <p class=home_style::article_description>{description}</p>
+                <h3 class=home_style::article_title>{title}</h3>
+                <p class=home_style::article_description>{description}</p>
 
-            <Show when=move || has_tags fallback=|| ()>
-                <ul class=home_style::tag_list>
-                    {tags
-                        .iter()
-                        .map(|tag| {
-                            view! { <li class=home_style::tag>{format!("#{tag}")}</li> }
-                        })
-                        .collect_view()}
-                </ul>
-            </Show>
-        </article>
+                <Show when=move || has_tags fallback=|| ()>
+                    <ul class=home_style::tag_list>
+                        {tags
+                            .iter()
+                            .map(|tag| {
+                                view! { <li class=home_style::tag>{format!("#{tag}")}</li> }
+                            })
+                            .collect_view()}
+                    </ul>
+                </Show>
+            </article>
+        </A>
     }
 }
 

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -7,6 +7,7 @@ use domain::{
     build_home_page_title,
 };
 use leptos::prelude::*;
+use leptos_router::components::A;
 use std::sync::Arc;
 use stylance::import_style;
 
@@ -47,11 +48,11 @@ fn HomePageContent(document: HomePageDocument) -> impl IntoView {
             let href = format!("/categories/{}", category.category.as_str());
             view! {
                 <li class=home_style::category_chip>
-                    <a class=home_style::category_link href=href>
+                    <A href=move || href.clone() {..} class=home_style::category_link>
                         <span class=home_style::category_name>
                             {category.category_display_name}
                         </span>
-                    </a>
+                    </A>
                     <span class=home_style::category_count>
                         {format!("{}本", category.article_count)}
                     </span>
@@ -94,6 +95,7 @@ fn ArticleCard(article: SiteArticleCard) -> impl IntoView {
     let has_tags = !tags.is_empty();
     let created_at = article.created_at;
     let updated_at = article.updated_at;
+    let article_href = format!("/articles/{slug}");
 
     view! {
         <article class=home_style::article_card>
@@ -105,9 +107,9 @@ fn ArticleCard(article: SiteArticleCard) -> impl IntoView {
             </div>
 
             <h3 class=home_style::article_title>
-                <a class=home_style::article_link href=format!("/articles/{slug}")>
+                <A href=move || article_href.clone() {..} class=home_style::article_link>
                     {title}
-                </a>
+                </A>
             </h3>
             <p class=home_style::article_description>{description}</p>
 

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -48,7 +48,7 @@ fn HomePageContent(document: HomePageDocument) -> impl IntoView {
             let href = format!("/categories/{}", category.category.as_str());
             view! {
                 <li class=home_style::category_chip>
-                    <A href=move || href.clone() {..} class=home_style::category_link>
+                    <A href={href} {..} class=home_style::category_link>
                         <span class=home_style::category_name>
                             {category.category_display_name}
                         </span>
@@ -98,7 +98,7 @@ fn ArticleCard(article: SiteArticleCard) -> impl IntoView {
     let article_href = format!("/articles/{slug}");
 
     view! {
-        <A href=move || article_href.clone() {..} class=home_style::article_card_link>
+        <A href={article_href} {..} class=home_style::article_card_link>
             <article class=home_style::article_card>
                 <div class=home_style::article_meta>
                     <span class=home_style::article_category>{category}</span>


### PR DESCRIPTION
## Summary
- switch the top-level Leptos routes to `FlatRoutes` with relative paths
- use router-aware links for internal navigation and make home article cards clickable
- align client-side navigation so article/category/home transitions update without reload

## Verification
- cargo check -p web --features ssr
- cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate
- cargo clippy -p web --all-targets -- -D warnings