### PR TITLE
fix: publisher encoding bug

### DIFF
--- a/crates/publish/bookmark/src/lib.rs
+++ b/crates/publish/bookmark/src/lib.rs
@@ -2,6 +2,8 @@ mod error;
 
 pub use error::{BookmarkError, Result};
 
+use std::future::Future;
+
 use regex::Regex;
 use scraper::{Html, Selector};
 use std::sync::LazyLock;
@@ -267,28 +269,31 @@ fn html_escape(text: &str) -> String {
     // Additional escaping for backticks and newlines is unnecessary for the current use case.
 }
 
-/// Replaces simple bookmark markup with rich bookmark cards fetched from OGP metadata.
-pub async fn convert_simple_bookmarks_to_rich(html_content: &str) -> Result<String> {
+/// Internal loop that drives bookmark substitution.
+///
+/// `fetch_data(url, original_title)` is called for each matched bookmark and must
+/// return a `BookmarkData` (already with fallback applied if necessary).
+async fn convert_bookmarks_with<F, Fut>(html_content: &str, fetch_data: F) -> Result<String>
+where
+    F: Fn(String, String) -> Fut,
+    Fut: Future<Output = BookmarkData>,
+{
     static BOOKMARK_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r#"<div class="bookmark">\s*<a href="([^"]+)">([^<]*)</a>\s*</div>"#)
             .expect("Invalid bookmark regex pattern")
     });
 
     let mut result = String::with_capacity(html_content.len() + HTML_EXTENSION_CAPACITY);
-    let mut last_end = 0; // End position of the previous match.
+    let mut last_end = 0;
 
     for capture in BOOKMARK_REGEX.captures_iter(html_content) {
         let full_match = capture.get(0).unwrap();
-        let url = &capture[1];
-        let original_title = &capture[2];
+        let url = capture[1].to_string();
+        let original_title = capture[2].to_string();
 
         result.push_str(&html_content[last_end..full_match.start()]);
 
-        let bookmark_data = fetch_ogp_metadata(url).await.unwrap_or_else(|e| {
-            log::warn!("Warning: Failed to fetch OGP metadata for '{url}': {e}");
-            create_fallback_bookmark_data(url, original_title)
-        });
-
+        let bookmark_data = fetch_data(url, original_title).await;
         let rich_bookmark_html = generate_rich_bookmark(&bookmark_data);
         result.push_str(&rich_bookmark_html);
 
@@ -298,6 +303,30 @@ pub async fn convert_simple_bookmarks_to_rich(html_content: &str) -> Result<Stri
     result.push_str(&html_content[last_end..]);
 
     Ok(result)
+}
+
+/// Replaces simple bookmark markup with rich bookmark cards fetched from OGP metadata.
+pub async fn convert_simple_bookmarks_to_rich(html_content: &str) -> Result<String> {
+    convert_bookmarks_with(html_content, |url, original_title| async move {
+        fetch_ogp_metadata(&url).await.unwrap_or_else(|e| {
+            log::warn!("Warning: Failed to fetch OGP metadata for '{url}': {e}");
+            create_fallback_bookmark_data(&url, &original_title)
+        })
+    })
+    .await
+}
+
+/// Converts simple bookmark markup to rich cards using fallback data only,
+/// without making any network requests.
+///
+/// The URL and link text from the original markup are used directly as the
+/// card title; OGP metadata is never fetched. Intended for offline environments
+/// and integration tests where real HTTP access must be avoided.
+pub async fn convert_simple_bookmarks_to_rich_offline(html_content: &str) -> Result<String> {
+    convert_bookmarks_with(html_content, |url, original_title| async move {
+        create_fallback_bookmark_data(&url, &original_title)
+    })
+    .await
 }
 
 /// Creates fallback bookmark data.

--- a/crates/publish/bookmark/src/lib.rs
+++ b/crates/publish/bookmark/src/lib.rs
@@ -8,12 +8,9 @@ use regex::Regex;
 use scraper::{Html, Selector};
 use std::sync::LazyLock;
 
-/// Initial capacity for generated HTML.
 const HTML_INITIAL_CAPACITY: usize = 1024;
-/// Extra capacity reserved for metadata expansion.
 const HTML_EXTENSION_CAPACITY: usize = 2048;
 
-/// Metadata used to render a rich bookmark card.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BookmarkData {
     pub url: String,
@@ -38,7 +35,6 @@ pub async fn fetch_ogp_metadata(url: &str) -> Result<BookmarkData> {
     })
 }
 
-/// Builds the HTTP client.
 fn create_http_client() -> Result<reqwest::Client> {
     // Use a standard User-Agent format without exposing internal package details.
     let user_agent = "publisher-bookmark/1.0 (+https://github.com/okawak/okawak_blog)";
@@ -50,14 +46,12 @@ fn create_http_client() -> Result<reqwest::Client> {
         .map_err(Into::into)
 }
 
-/// Fetches HTML content.
 async fn fetch_html_content(client: &reqwest::Client, url: &str) -> Result<String> {
     let response = client.get(url).send().await?;
 
     response.text().await.map_err(Into::into)
 }
 
-/// Extracts a title from an HTML document.
 fn extract_title(document: &Html) -> Option<String> {
     extract_meta_content(document, "meta[property='og:title']")
         .or_else(|| extract_meta_content(document, "meta[name='twitter:title']"))
@@ -81,7 +75,6 @@ fn extract_meta_content(document: &Html, selector: &str) -> Option<String> {
     }
 }
 
-/// Extracts the text content of the `title` tag.
 fn extract_title_tag(document: &Html) -> Option<String> {
     let selector = Selector::parse("title").ok()?;
     let title_text = document
@@ -98,14 +91,12 @@ fn extract_title_tag(document: &Html) -> Option<String> {
     }
 }
 
-/// Extracts a description from an HTML document.
 fn extract_description(document: &Html) -> Option<String> {
     extract_meta_content(document, "meta[property='og:description']")
         .or_else(|| extract_meta_content(document, "meta[name='twitter:description']"))
         .or_else(|| extract_meta_content(document, "meta[name='description']"))
 }
 
-/// Extracts an image URL from an HTML document.
 fn extract_image(document: &Html, base_url: &str) -> Option<String> {
     use url::Url;
 
@@ -123,7 +114,6 @@ fn extract_image(document: &Html, base_url: &str) -> Option<String> {
         })
 }
 
-/// Extracts a favicon URL from an HTML document.
 fn extract_favicon(document: &Html, base_url: &str) -> Option<String> {
     use url::Url;
 
@@ -154,7 +144,6 @@ fn extract_favicon(document: &Html, base_url: &str) -> Option<String> {
     Some(base.join("/favicon.ico").unwrap().to_string())
 }
 
-/// Extracts the `href` attribute from a `link` tag.
 fn extract_link_href(document: &Html, selector: &str) -> Option<String> {
     let selector = Selector::parse(selector).ok()?;
     document
@@ -181,7 +170,6 @@ pub fn generate_rich_bookmark(data: &BookmarkData) -> String {
     html
 }
 
-/// Extracts the domain from a URL.
 fn extract_domain(url: &str) -> String {
     use url::Url;
 
@@ -191,7 +179,6 @@ fn extract_domain(url: &str) -> String {
         .unwrap_or_else(|| url.to_string())
 }
 
-/// Writes the opening bookmark link tag.
 fn write_bookmark_link(html: &mut String, url: &str) {
     html.push_str(&format!(
         "  <a href=\"{}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"bookmark-link\">\n",
@@ -199,7 +186,6 @@ fn write_bookmark_link(html: &mut String, url: &str) {
     ));
 }
 
-/// Writes the bookmark container.
 fn write_bookmark_container(html: &mut String, data: &BookmarkData, domain: &str) {
     html.push_str("    <div class=\"bookmark-container\">\n");
 
@@ -209,7 +195,6 @@ fn write_bookmark_container(html: &mut String, data: &BookmarkData, domain: &str
     html.push_str("    </div>\n");
 }
 
-/// Writes the bookmark information section.
 fn write_bookmark_info(html: &mut String, data: &BookmarkData, domain: &str) {
     html.push_str("      <div class=\"bookmark-info\">\n");
     html.push_str(&format!(
@@ -228,7 +213,6 @@ fn write_bookmark_info(html: &mut String, data: &BookmarkData, domain: &str) {
     html.push_str("      </div>\n");
 }
 
-/// Writes the bookmark link metadata.
 fn write_bookmark_link_info(html: &mut String, data: &BookmarkData, domain: &str) {
     html.push_str("        <div class=\"bookmark-link-info\">\n");
 
@@ -246,7 +230,6 @@ fn write_bookmark_link_info(html: &mut String, data: &BookmarkData, domain: &str
     html.push_str("        </div>\n");
 }
 
-/// Writes the bookmark image section.
 fn write_bookmark_image(html: &mut String, data: &BookmarkData) {
     if let Some(image_url) = &data.image_url {
         html.push_str("      <div class=\"bookmark-image\">\n");
@@ -266,13 +249,9 @@ fn html_escape(text: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#x27;")
-    // Additional escaping for backticks and newlines is unnecessary for the current use case.
 }
 
-/// Internal loop that drives bookmark substitution.
-///
-/// `fetch_data(url, original_title)` is called for each matched bookmark and must
-/// return a `BookmarkData` (already with fallback applied if necessary).
+/// Core substitution loop; calls `fetch_data(url, title)` per match to obtain `BookmarkData`.
 async fn convert_bookmarks_with<F, Fut>(html_content: &str, fetch_data: F) -> Result<String>
 where
     F: Fn(String, String) -> Fut,
@@ -316,12 +295,7 @@ pub async fn convert_simple_bookmarks_to_rich(html_content: &str) -> Result<Stri
     .await
 }
 
-/// Converts simple bookmark markup to rich cards using fallback data only,
-/// without making any network requests.
-///
-/// The URL and link text from the original markup are used directly as the
-/// card title; OGP metadata is never fetched. Intended for offline environments
-/// and integration tests where real HTTP access must be avoided.
+/// Like `convert_simple_bookmarks_to_rich` but uses fallback data only; no network requests.
 pub async fn convert_simple_bookmarks_to_rich_offline(html_content: &str) -> Result<String> {
     convert_bookmarks_with(html_content, |url, original_title| async move {
         create_fallback_bookmark_data(&url, &original_title)
@@ -329,7 +303,6 @@ pub async fn convert_simple_bookmarks_to_rich_offline(html_content: &str) -> Res
     .await
 }
 
-/// Creates fallback bookmark data.
 pub fn create_fallback_bookmark_data(url: &str, original_title: &str) -> BookmarkData {
     BookmarkData {
         url: url.to_string(),

--- a/crates/publish/ingest/src/converter.rs
+++ b/crates/publish/ingest/src/converter.rs
@@ -31,27 +31,45 @@ pub fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
 /// Escapes raw HTML events (XSS protection) while letting `<div class="bookmark">`
 /// blocks pass through as `Event::Html` for downstream enrichment.
 fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> impl Iterator<Item = Event<'a>> {
-    // Owned by the FnMut closure via `move`; `map` reuses the same closure
+    // Owned by the FnMut closure via `move`; `flat_map` reuses the same closure
     // instance per event, so mutations persist across calls.
     let mut in_bookmark = false;
 
-    parser.map(move |event| match event {
-        Event::Html(html) | Event::InlineHtml(html) => {
-            if html.trim_start().starts_with(r#"<div class="bookmark">"#) {
-                in_bookmark = true;
-            }
-
-            if in_bookmark {
-                // Check AFTER setting the flag to handle single-line bookmarks.
-                if html.contains("</div>") {
-                    in_bookmark = false;
+    parser.flat_map(move |event| {
+        let out: Vec<Event<'a>> = match event {
+            Event::Html(html) | Event::InlineHtml(html) => {
+                // pulldown-cmark emits indented HTML (up to 3 spaces) as inline events
+                // with leading whitespace stripped, so `starts_with` matches regardless
+                // of indentation. BOOKMARK_REGEX has no `^` anchor, so indented
+                // bookmarks are correctly converted by downstream processing.
+                if html.starts_with(r#"<div class="bookmark">"#) {
+                    in_bookmark = true;
                 }
-                Event::Html(html)
-            } else {
-                Event::Text(html) // escape non-bookmark HTML
+
+                if in_bookmark {
+                    // Check AFTER setting the flag to handle single-line bookmarks.
+                    if let Some(close) = html.find("</div>") {
+                        in_bookmark = false;
+                        let safe_end = close + "</div>".len();
+                        if html[safe_end..].is_empty() {
+                            vec![Event::Html(html)]
+                        } else {
+                            // Escape any trailing content after the closing tag.
+                            vec![
+                                Event::Html(html[..safe_end].to_string().into()),
+                                Event::Text(html[safe_end..].to_string().into()),
+                            ]
+                        }
+                    } else {
+                        vec![Event::Html(html)]
+                    }
+                } else {
+                    vec![Event::Text(html)]
+                }
             }
-        }
-        other => other,
+            other => vec![other],
+        };
+        out
     })
 }
 
@@ -198,6 +216,7 @@ pub fn generate_html_file(frontmatter_yaml: &str, html_body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indoc::indoc;
     use rstest::*;
 
     #[rstest]
@@ -433,6 +452,94 @@ This is a test with [[Another Article|link]] and **bold** text.
         assert!(
             result.contains("&lt;script&gt;"),
             "script tag should appear as entities; got:\n{result}"
+        );
+    }
+
+    /// Raw HTML on the same line after `</div>` must be escaped even though
+    /// the bookmark block itself passes through (P1 XSS fix).
+    #[rstest]
+    fn test_trailing_content_after_bookmark_close_is_escaped() {
+        let markdown = "<div class=\"bookmark\"><a href=\"https://example.com\">X</a></div><script>bad()</script>\n";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            result.contains(r#"<div class="bookmark">"#),
+            "bookmark should pass through; got:\n{result}"
+        );
+        assert!(
+            !result.contains("<script>"),
+            "trailing script tag should be escaped; got:\n{result}"
+        );
+        assert!(
+            result.contains("&lt;script&gt;"),
+            "trailing script tag should appear as entities; got:\n{result}"
+        );
+    }
+
+    /// When the markdown contains multiple bookmark blocks, every block must
+    /// reach the output HTML unescaped so that the downstream bookmark enricher
+    /// can find and convert each one. The stateful `in_bookmark` filter inside
+    /// `sanitize_html` must reset correctly after each block closes.
+    ///
+    /// Three cases are exercised:
+    /// - two bookmarks separated only by a blank line
+    /// - two bookmarks with prose text between them
+    /// - three consecutive bookmarks (verifies the flag resets more than once)
+    #[rstest]
+    #[case::two_bookmarks_blank_line_between(
+        indoc! {r#"
+            <div class="bookmark">
+              <a href="https://example.com">Example</a>
+            </div>
+
+            <div class="bookmark">
+              <a href="https://github.com">GitHub</a>
+            </div>
+        "#}
+    )]
+    #[case::two_bookmarks_prose_between(
+        indoc! {r#"
+            <div class="bookmark">
+              <a href="https://example.com">Example</a>
+            </div>
+
+            Some prose text here.
+
+            <div class="bookmark">
+              <a href="https://github.com">GitHub</a>
+            </div>
+        "#}
+    )]
+    #[case::three_bookmarks_in_sequence(
+        indoc! {r#"
+            <div class="bookmark">
+              <a href="https://example.com">Example</a>
+            </div>
+
+            <div class="bookmark">
+              <a href="https://github.com">GitHub</a>
+            </div>
+
+            <div class="bookmark">
+              <a href="https://rust-lang.org">Rust</a>
+            </div>
+        "#}
+    )]
+    fn test_multiple_bookmarks_all_pass_through_unescaped(#[case] markdown: &str) {
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        let input_count = markdown.matches(r#"<div class="bookmark">"#).count();
+        let output_count = result.matches(r#"<div class="bookmark">"#).count();
+
+        assert_eq!(
+            output_count, input_count,
+            "all {input_count} bookmark block(s) should pass through unescaped, \
+             but only {output_count} did; got:\n{result}"
+        );
+        assert!(
+            !result.contains("&lt;div"),
+            "no bookmark div should be HTML-escaped; got:\n{result}"
         );
     }
 

--- a/crates/publish/ingest/src/converter.rs
+++ b/crates/publish/ingest/src/converter.rs
@@ -3,6 +3,21 @@ use pulldown_cmark::{Event, Options, Parser, html};
 use regex::Regex;
 use std::{collections::HashMap, sync::LazyLock};
 
+/// Byte overhead added by a single `<span class="katex-inline">…</span>` wrapper
+/// over the original `$…$` delimiters.
+/// `<span class="katex-inline">` (27 bytes) + `</span>` (7 bytes) − `$` + `$` (2 bytes) = 32.
+const KATEX_INLINE_OVERHEAD: usize = 32;
+
+/// Byte overhead added by a single `<div class="katex-display">…</div>` wrapper
+/// over the original `$$…$$` delimiters.
+/// `<div class="katex-display">` (27 bytes) + `</div>` (6 bytes) − `$$` + `$$` (4 bytes) = 29.
+const KATEX_DISPLAY_OVERHEAD: usize = 29;
+
+/// Extra capacity budgeted per `apply_katex_math` call.
+/// Sized for up to 6 inline expressions and 2 display expressions without reallocation.
+/// 32 × 6 + 29 × 2 = 250 bytes. Documents with more expressions will simply reallocate.
+const KATEX_EXTRA_CAPACITY: usize = KATEX_INLINE_OVERHEAD * 6 + KATEX_DISPLAY_OVERHEAD * 2;
+
 /// Mapping from an Obsidian file path without extension to a published slug.
 pub type FileMapping = HashMap<String, String>;
 
@@ -76,7 +91,7 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> impl Iterator<I
 /// Replaces KaTeX delimiters in `html_content`, skipping `<code>` / `<pre>`
 /// blocks. `<pre` covers its nested `<code>` automatically.
 fn process_katex_math(html_content: &str) -> String {
-    let mut result = String::with_capacity(html_content.len() + 200);
+    let mut result = String::with_capacity(html_content.len() + KATEX_EXTRA_CAPACITY);
     let mut remaining = html_content;
 
     loop {
@@ -121,7 +136,7 @@ fn process_katex_math(html_content: &str) -> String {
 /// Replaces `$$...$$` and `$...$` with KaTeX class wrappers.
 /// Only call on fragments with no `<code>` / `<pre>`; use `process_katex_math` for full HTML.
 fn apply_katex_math(text: &str) -> String {
-    let mut result = String::with_capacity(text.len() + 200);
+    let mut result = String::with_capacity(text.len() + KATEX_EXTRA_CAPACITY);
     result.push_str(text);
 
     // Block math first to avoid matching the inner `$` of `$$`.

--- a/crates/publish/ingest/src/converter.rs
+++ b/crates/publish/ingest/src/converter.rs
@@ -19,29 +19,97 @@ pub fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
     options.insert(Options::ENABLE_TASKLISTS);
     options.insert(Options::ENABLE_SMART_PUNCTUATION);
 
-    let parser = Parser::new_ext(markdown_content, options).map(disable_raw_html);
+    let parser = Parser::new_ext(markdown_content, options);
     let mut html_output = String::with_capacity(markdown_content.len() * 2);
-    html::push_html(&mut html_output, parser);
+    html::push_html(&mut html_output, sanitize_html(parser));
 
     let html_with_katex = process_katex_math(&html_output);
 
     Ok(html_with_katex)
 }
 
-fn disable_raw_html(event: Event<'_>) -> Event<'_> {
-    match event {
-        Event::Html(html) | Event::InlineHtml(html) => Event::Text(html),
+/// Escapes raw HTML events (XSS protection) while letting `<div class="bookmark">`
+/// blocks pass through as `Event::Html` for downstream enrichment.
+fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> impl Iterator<Item = Event<'a>> {
+    // Owned by the FnMut closure via `move`; `map` reuses the same closure
+    // instance per event, so mutations persist across calls.
+    let mut in_bookmark = false;
+
+    parser.map(move |event| match event {
+        Event::Html(html) | Event::InlineHtml(html) => {
+            if html.trim_start().starts_with(r#"<div class="bookmark">"#) {
+                in_bookmark = true;
+            }
+
+            if in_bookmark {
+                // Check AFTER setting the flag to handle single-line bookmarks.
+                if html.contains("</div>") {
+                    in_bookmark = false;
+                }
+                Event::Html(html)
+            } else {
+                Event::Text(html) // escape non-bookmark HTML
+            }
+        }
         other => other,
-    }
+    })
 }
 
+/// Replaces KaTeX delimiters in `html_content`, skipping `<code>` / `<pre>`
+/// blocks. `<pre` covers its nested `<code>` automatically.
 fn process_katex_math(html_content: &str) -> String {
     let mut result = String::with_capacity(html_content.len() + 200);
-    result.push_str(html_content);
+    let mut remaining = html_content;
 
+    loop {
+        // Find the earlier of the next <code> or <pre> start.
+        let code_start = [remaining.find("<pre"), remaining.find("<code")]
+            .into_iter()
+            .flatten()
+            .min();
+
+        match code_start {
+            None => {
+                result.push_str(&apply_katex_math(remaining));
+                break;
+            }
+            Some(start) => {
+                result.push_str(&apply_katex_math(&remaining[..start]));
+
+                let close_tag = if remaining[start..].starts_with("<pre") {
+                    "</pre>"
+                } else {
+                    "</code>"
+                };
+
+                match remaining[start..].find(close_tag) {
+                    Some(close_offset) => {
+                        let end = start + close_offset + close_tag.len();
+                        result.push_str(&remaining[start..end]); // verbatim
+                        remaining = &remaining[end..];
+                    }
+                    None => {
+                        result.push_str(&remaining[start..]); // verbatim
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    result
+}
+
+/// Replaces `$$...$$` and `$...$` with KaTeX class wrappers.
+/// Only call on fragments with no `<code>` / `<pre>`; use `process_katex_math` for full HTML.
+fn apply_katex_math(text: &str) -> String {
+    let mut result = String::with_capacity(text.len() + 200);
+    result.push_str(text);
+
+    // Block math first to avoid matching the inner `$` of `$$`.
     while let Some(start) = result.find("$$") {
         if let Some(end) = result[start + 2..].find("$$") {
-            let math_content = &result[start + 2..start + 2 + end];
+            let math_content = result[start + 2..start + 2 + end].to_string();
             let replacement = format!(r#"<div class="katex-display">{math_content}</div>"#);
             result.replace_range(start..start + 2 + end + 2, &replacement);
         } else {
@@ -49,12 +117,13 @@ fn process_katex_math(html_content: &str) -> String {
         }
     }
 
+    // Inline math.
     let mut pos = 0;
     while let Some(start) = result[pos..].find('$') {
         let actual_start = pos + start;
         if let Some(end) = result[actual_start + 1..].find('$') {
             let actual_end = actual_start + 1 + end;
-            let math_content = &result[actual_start + 1..actual_end];
+            let math_content = result[actual_start + 1..actual_end].to_string();
             let replacement = format!(r#"<span class="katex-inline">{math_content}</span>"#);
             result.replace_range(actual_start..actual_end + 1, &replacement);
             pos = actual_start + replacement.len();
@@ -273,5 +342,179 @@ This is a test with [[Another Article|link]] and **bold** text.
         assert!(result.contains("Hello &lt;span&gt;world&lt;/span&gt;"));
         assert!(!result.contains("<script>"));
         assert!(!result.contains("<span>world</span>"));
+    }
+
+    // -----------------------------------------------------------------
+    // bookmark sanitize_html tests
+    // -----------------------------------------------------------------
+
+    /// The full bookmark block (opening tag, inner content, closing tag)
+    /// must pass through `convert_markdown_to_html` without any HTML escaping
+    /// so that the downstream `convert_simple_bookmarks_to_rich` can find it.
+    #[rstest]
+    fn test_bookmark_html_passes_through_unescaped() {
+        // Multi-line bookmark – pulldown-cmark emits this as several
+        // `Event::Html` events (one per line), so the stateful filter must
+        // keep all of them unescaped.
+        let markdown = "<div class=\"bookmark\">\n  <a href=\"https://example.com\">Example Site</a>\n</div>\n";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            result.contains("<div class=\"bookmark\">"),
+            "bookmark opening tag should not be escaped; got:\n{result}"
+        );
+        assert!(
+            result.contains(r#"<a href="https://example.com">"#),
+            "bookmark anchor tag should not be escaped; got:\n{result}"
+        );
+        assert!(
+            result.contains("</div>"),
+            "bookmark closing tag should not be escaped; got:\n{result}"
+        );
+        assert!(
+            !result.contains("&lt;div"),
+            "no HTML entities expected for bookmark block; got:\n{result}"
+        );
+    }
+
+    /// A single-line bookmark (`<div class="bookmark">…</div>` on one line)
+    /// must also pass through unescaped.
+    #[rstest]
+    fn test_single_line_bookmark_passes_through_unescaped() {
+        let markdown =
+            "<div class=\"bookmark\"><a href=\"https://example.com\">Example</a></div>\n";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            result.contains("<div class=\"bookmark\">"),
+            "single-line bookmark should not be escaped; got:\n{result}"
+        );
+        assert!(
+            !result.contains("&lt;div"),
+            "no HTML entities expected; got:\n{result}"
+        );
+    }
+
+    /// Raw HTML that is NOT a bookmark must still be escaped (XSS protection).
+    #[rstest]
+    #[case::div_with_other_class("<div class=\"custom\"><span>hello</span></div>")]
+    #[case::script_tag("<script>alert('xss')</script>")]
+    #[case::inline_span("<span>inline</span>")]
+    fn test_non_bookmark_raw_html_is_still_escaped(#[case] markdown: &str) {
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            result.contains("&lt;"),
+            "non-bookmark HTML should be escaped; got:\n{result}"
+        );
+        // No literal opening angle bracket from the raw HTML should survive.
+        // We cannot check for a specific tag because the test is parameterised,
+        // but the presence of `&lt;` proves escaping happened.
+    }
+
+    /// Content AFTER a correctly closed bookmark block must NOT be affected by
+    /// the bookmark filter (i.e. regular HTML after the block is still escaped).
+    #[rstest]
+    fn test_html_after_bookmark_is_escaped() {
+        let markdown = "<div class=\"bookmark\">\n  <a href=\"https://example.com\">X</a>\n</div>\n\n<script>bad()</script>\n";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            result.contains("<div class=\"bookmark\">"),
+            "bookmark block should pass through; got:\n{result}"
+        );
+        assert!(
+            !result.contains("<script>"),
+            "script tag after bookmark should be escaped; got:\n{result}"
+        );
+        assert!(
+            result.contains("&lt;script&gt;"),
+            "script tag should appear as entities; got:\n{result}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // KaTeX + code block tests
+    // -----------------------------------------------------------------
+
+    /// Inline code (backtick) containing `$...$` must NOT be converted to a
+    /// KaTeX span – the dollar signs are part of the code, not math.
+    #[rstest]
+    fn test_katex_not_processed_in_inline_code() {
+        let markdown = "See `$x^2$` for the formula.";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            result.contains("<code>$x^2$</code>"),
+            "inline code content should not be KaTeX-processed; got:\n{result}"
+        );
+        assert!(
+            !result.contains("katex-inline"),
+            "no KaTeX span expected inside inline code; got:\n{result}"
+        );
+    }
+
+    /// Fenced code blocks containing `$...$` or `$$...$$` must NOT produce
+    /// any KaTeX wrappers.
+    #[rstest]
+    fn test_katex_not_processed_in_fenced_code_block() {
+        let markdown = "```\n$x^2$ and $$block$$ formula\n```";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            !result.contains("katex-display"),
+            "fenced code block should not produce KaTeX display; got:\n{result}"
+        );
+        assert!(
+            !result.contains("katex-inline"),
+            "fenced code block should not produce KaTeX inline; got:\n{result}"
+        );
+        assert!(
+            result.contains("$x^2$"),
+            "dollar signs should remain verbatim in code block; got:\n{result}"
+        );
+    }
+
+    /// Math markers that appear OUTSIDE code elements must still be converted
+    /// even when code elements are present in the same document.
+    #[rstest]
+    fn test_katex_processed_in_text_adjacent_to_code() {
+        let markdown = "The formula $a+b$ is useful. Code: `$not_math$`.";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            result.contains(r#"<span class="katex-inline">a+b</span>"#),
+            "math outside code should be converted to KaTeX span; got:\n{result}"
+        );
+        assert!(
+            result.contains("<code>$not_math$</code>"),
+            "dollar signs inside inline code should remain untouched; got:\n{result}"
+        );
+    }
+
+    /// Verify `process_katex_math` directly on raw HTML fragments that mix
+    /// math-bearing text with code elements.
+    #[rstest]
+    #[case::math_before_code(
+        "Inline <span>$a$</span> then <code>$b$</code>",
+        "Inline <span><span class=\"katex-inline\">a</span></span> then <code>$b$</code>"
+    )]
+    #[case::math_after_code(
+        "<code>$b$</code> then $a$",
+        "<code>$b$</code> then <span class=\"katex-inline\">a</span>"
+    )]
+    #[case::pre_block_skipped(
+        "$x$ <pre><code>$y$</code></pre> $z$",
+        "<span class=\"katex-inline\">x</span> <pre><code>$y$</code></pre> <span class=\"katex-inline\">z</span>"
+    )]
+    fn test_process_katex_math_skips_code_elements(#[case] input: &str, #[case] expected: &str) {
+        let result = super::process_katex_math(input);
+        assert_eq!(result, expected);
     }
 }

--- a/crates/publish/ingest/src/converter.rs
+++ b/crates/publish/ingest/src/converter.rs
@@ -3,26 +3,16 @@ use pulldown_cmark::{Event, Options, Parser, html};
 use regex::Regex;
 use std::{collections::HashMap, sync::LazyLock};
 
-/// Byte overhead added by a single `<span class="katex-inline">…</span>` wrapper
-/// over the original `$…$` delimiters.
-/// `<span class="katex-inline">` (27 bytes) + `</span>` (7 bytes) − `$` + `$` (2 bytes) = 32.
+/// Net bytes added per `$…$` replacement: 34-byte wrapper minus 2-byte delimiters.
 const KATEX_INLINE_OVERHEAD: usize = 32;
 
-/// Byte overhead added by a single `<div class="katex-display">…</div>` wrapper
-/// over the original `$$…$$` delimiters.
-/// `<div class="katex-display">` (27 bytes) + `</div>` (6 bytes) − `$$` + `$$` (4 bytes) = 29.
+/// Net bytes added per `$$…$$` replacement: 33-byte wrapper minus 4-byte delimiters.
 const KATEX_DISPLAY_OVERHEAD: usize = 29;
 
-/// Extra capacity budgeted per `apply_katex_math` call.
-/// Sized for up to 6 inline expressions and 2 display expressions without reallocation.
-/// 32 × 6 + 29 × 2 = 250 bytes. Documents with more expressions will simply reallocate.
+/// Extra capacity per `apply_katex_math` call; sized for ~6 inline + 2 display expressions.
 const KATEX_EXTRA_CAPACITY: usize = KATEX_INLINE_OVERHEAD * 6 + KATEX_DISPLAY_OVERHEAD * 2;
 
-/// Strict allow-list regex for a `<div class="bookmark">` block.
-/// Only `<div class="bookmark"> <a href="URL">TITLE</a> </div>` passes through;
-/// any extra tags, extra attributes, or missing structure causes the block to be
-/// HTML-escaped instead. Used by `sanitize_html` to validate complete bookmark
-/// blocks before emitting them as raw HTML.
+/// Allow-list regex for bookmark blocks; anything beyond `<a href="URL">TITLE</a>` is escaped.
 static SAFE_BOOKMARK_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"\A\s*<div class="bookmark">\s*<a href="[^"]+">[^<]*</a>\s*</div>\s*\z"#)
         .expect("Invalid safe bookmark regex")
@@ -35,7 +25,6 @@ fn generate_article_href(slug: &str) -> String {
     format!("/articles/{slug}")
 }
 
-/// Convert markdown content into HTML and apply KaTeX markers.
 pub fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
@@ -53,17 +42,8 @@ pub fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
     Ok(html_with_katex)
 }
 
-/// Escapes raw HTML events (XSS protection) while letting strictly valid
-/// `<div class="bookmark">` blocks pass through as `Event::Html` for downstream
-/// enrichment.
-///
-/// Each potential bookmark block is accumulated in a buffer until the first
-/// `</div>` is found. The complete buffer is then validated against
-/// [`SAFE_BOOKMARK_RE`]. Only if it matches exactly the expected structure
-/// (`<div class="bookmark"><a href="URL">TITLE</a></div>`, with optional
-/// whitespace) is it emitted as raw HTML. Any deviation — extra tags, extra
-/// attributes, nested HTML, or an unclosed block — is emitted as `Event::Text`
-/// and therefore HTML-escaped by the renderer.
+/// Escapes all raw HTML events except valid `<div class="bookmark">` blocks.
+/// Accumulates each potential bookmark block and validates with SAFE_BOOKMARK_RE before passing through.
 fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> {
     let mut result: Vec<Event<'a>> = Vec::new();
     let mut in_bookmark = false;
@@ -73,16 +53,13 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
         match event {
             Event::Html(html) | Event::InlineHtml(html) => {
                 if !in_bookmark && !html.trim_start().starts_with(r#"<div class="bookmark">"#) {
-                    // Not a bookmark opening – escape it.
                     result.push(Event::Text(html));
                 } else {
-                    // Starting a new bookmark block or continuing to accumulate one.
                     if !in_bookmark {
                         in_bookmark = true;
                     }
                     bookmark_buffer.push_str(&html);
 
-                    // Check whether the accumulated buffer now contains the closing tag.
                     if let Some(close) = bookmark_buffer.find("</div>") {
                         in_bookmark = false;
                         let safe_end = close + "</div>".len();
@@ -93,21 +70,16 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
                         if SAFE_BOOKMARK_RE.is_match(&bookmark_part) {
                             result.push(Event::Html(bookmark_part.into()));
                         } else {
-                            // Structure does not match the strict allow-list – escape it.
                             result.push(Event::Text(bookmark_part.into()));
                         }
 
                         if !rest.is_empty() {
-                            // Trailing content after </div> is always escaped.
                             result.push(Event::Text(rest.into()));
                         }
                     }
-                    // No closing tag yet – keep accumulating; emit nothing for now.
                 }
             }
             other => {
-                // A non-HTML event arrived while inside an open bookmark block.
-                // Flush the partial buffer as escaped text and process the event normally.
                 if in_bookmark {
                     in_bookmark = false;
                     let buffer = std::mem::take(&mut bookmark_buffer);
@@ -120,8 +92,7 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
         }
     }
 
-    // An unclosed bookmark was never terminated by </div>.
-    // Emit the entire accumulated buffer as escaped text (fail-safe).
+    // Unclosed bookmark: flush buffer as escaped text.
     if !bookmark_buffer.is_empty() {
         result.push(Event::Text(bookmark_buffer.into()));
     }
@@ -129,14 +100,12 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
     result
 }
 
-/// Replaces KaTeX delimiters in `html_content`, skipping `<code>` / `<pre>`
-/// blocks. `<pre` covers its nested `<code>` automatically.
+/// Replaces `$…$` / `$$…$$` with KaTeX HTML wrappers, skipping `<code>` / `<pre>` blocks.
 fn process_katex_math(html_content: &str) -> String {
     let mut result = String::with_capacity(html_content.len() + KATEX_EXTRA_CAPACITY);
     let mut remaining = html_content;
 
     loop {
-        // Find the earlier of the next <code> or <pre> start.
         let code_start = [remaining.find("<pre"), remaining.find("<code")]
             .into_iter()
             .flatten()

--- a/crates/publish/ingest/src/converter.rs
+++ b/crates/publish/ingest/src/converter.rs
@@ -18,6 +18,16 @@ const KATEX_DISPLAY_OVERHEAD: usize = 29;
 /// 32 × 6 + 29 × 2 = 250 bytes. Documents with more expressions will simply reallocate.
 const KATEX_EXTRA_CAPACITY: usize = KATEX_INLINE_OVERHEAD * 6 + KATEX_DISPLAY_OVERHEAD * 2;
 
+/// Strict allow-list regex for a `<div class="bookmark">` block.
+/// Only `<div class="bookmark"> <a href="URL">TITLE</a> </div>` passes through;
+/// any extra tags, extra attributes, or missing structure causes the block to be
+/// HTML-escaped instead. Used by `sanitize_html` to validate complete bookmark
+/// blocks before emitting them as raw HTML.
+static SAFE_BOOKMARK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"\A\s*<div class="bookmark">\s*<a href="[^"]+">[^<]*</a>\s*</div>\s*\z"#)
+        .expect("Invalid safe bookmark regex")
+});
+
 /// Mapping from an Obsidian file path without extension to a published slug.
 pub type FileMapping = HashMap<String, String>;
 
@@ -36,56 +46,87 @@ pub fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
 
     let parser = Parser::new_ext(markdown_content, options);
     let mut html_output = String::with_capacity(markdown_content.len() * 2);
-    html::push_html(&mut html_output, sanitize_html(parser));
+    html::push_html(&mut html_output, sanitize_html(parser).into_iter());
 
     let html_with_katex = process_katex_math(&html_output);
 
     Ok(html_with_katex)
 }
 
-/// Escapes raw HTML events (XSS protection) while letting `<div class="bookmark">`
-/// blocks pass through as `Event::Html` for downstream enrichment.
-fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> impl Iterator<Item = Event<'a>> {
-    // Owned by the FnMut closure via `move`; `flat_map` reuses the same closure
-    // instance per event, so mutations persist across calls.
+/// Escapes raw HTML events (XSS protection) while letting strictly valid
+/// `<div class="bookmark">` blocks pass through as `Event::Html` for downstream
+/// enrichment.
+///
+/// Each potential bookmark block is accumulated in a buffer until the first
+/// `</div>` is found. The complete buffer is then validated against
+/// [`SAFE_BOOKMARK_RE`]. Only if it matches exactly the expected structure
+/// (`<div class="bookmark"><a href="URL">TITLE</a></div>`, with optional
+/// whitespace) is it emitted as raw HTML. Any deviation — extra tags, extra
+/// attributes, nested HTML, or an unclosed block — is emitted as `Event::Text`
+/// and therefore HTML-escaped by the renderer.
+fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> {
+    let mut result: Vec<Event<'a>> = Vec::new();
     let mut in_bookmark = false;
+    let mut bookmark_buffer = String::new();
 
-    parser.flat_map(move |event| {
-        let out: Vec<Event<'a>> = match event {
+    for event in parser {
+        match event {
             Event::Html(html) | Event::InlineHtml(html) => {
-                // pulldown-cmark emits indented HTML (up to 3 spaces) as inline events
-                // with leading whitespace stripped, so `starts_with` matches regardless
-                // of indentation. BOOKMARK_REGEX has no `^` anchor, so indented
-                // bookmarks are correctly converted by downstream processing.
-                if html.starts_with(r#"<div class="bookmark">"#) {
-                    in_bookmark = true;
-                }
+                if !in_bookmark && !html.trim_start().starts_with(r#"<div class="bookmark">"#) {
+                    // Not a bookmark opening – escape it.
+                    result.push(Event::Text(html));
+                } else {
+                    // Starting a new bookmark block or continuing to accumulate one.
+                    if !in_bookmark {
+                        in_bookmark = true;
+                    }
+                    bookmark_buffer.push_str(&html);
 
-                if in_bookmark {
-                    // Check AFTER setting the flag to handle single-line bookmarks.
-                    if let Some(close) = html.find("</div>") {
+                    // Check whether the accumulated buffer now contains the closing tag.
+                    if let Some(close) = bookmark_buffer.find("</div>") {
                         in_bookmark = false;
                         let safe_end = close + "</div>".len();
-                        if html[safe_end..].is_empty() {
-                            vec![Event::Html(html)]
+                        let bookmark_part = bookmark_buffer[..safe_end].to_string();
+                        let rest = bookmark_buffer[safe_end..].to_string();
+                        bookmark_buffer.clear();
+
+                        if SAFE_BOOKMARK_RE.is_match(&bookmark_part) {
+                            result.push(Event::Html(bookmark_part.into()));
                         } else {
-                            // Escape any trailing content after the closing tag.
-                            vec![
-                                Event::Html(html[..safe_end].to_string().into()),
-                                Event::Text(html[safe_end..].to_string().into()),
-                            ]
+                            // Structure does not match the strict allow-list – escape it.
+                            result.push(Event::Text(bookmark_part.into()));
                         }
-                    } else {
-                        vec![Event::Html(html)]
+
+                        if !rest.is_empty() {
+                            // Trailing content after </div> is always escaped.
+                            result.push(Event::Text(rest.into()));
+                        }
                     }
-                } else {
-                    vec![Event::Text(html)]
+                    // No closing tag yet – keep accumulating; emit nothing for now.
                 }
             }
-            other => vec![other],
-        };
-        out
-    })
+            other => {
+                // A non-HTML event arrived while inside an open bookmark block.
+                // Flush the partial buffer as escaped text and process the event normally.
+                if in_bookmark {
+                    in_bookmark = false;
+                    let buffer = std::mem::take(&mut bookmark_buffer);
+                    if !buffer.is_empty() {
+                        result.push(Event::Text(buffer.into()));
+                    }
+                }
+                result.push(other);
+            }
+        }
+    }
+
+    // An unclosed bookmark was never terminated by </div>.
+    // Emit the entire accumulated buffer as escaped text (fail-safe).
+    if !bookmark_buffer.is_empty() {
+        result.push(Event::Text(bookmark_buffer.into()));
+    }
+
+    result
 }
 
 /// Replaces KaTeX delimiters in `html_content`, skipping `<code>` / `<pre>`
@@ -489,6 +530,51 @@ This is a test with [[Another Article|link]] and **bold** text.
         assert!(
             result.contains("&lt;script&gt;"),
             "trailing script tag should appear as entities; got:\n{result}"
+        );
+    }
+
+    /// Bookmark blocks that contain unexpected HTML (e.g. a `<script>` tag as a
+    /// sibling of `<a>`, or extra event-handler attributes on `<a>`) must be
+    /// HTML-escaped. Only the strict `<div class="bookmark"><a href="…">…</a></div>`
+    /// structure may pass through as raw HTML.
+    #[rstest]
+    #[case::script_sibling(r#"<div class="bookmark"><script>alert('xss')</script></div>"#)]
+    #[case::extra_attribute_on_anchor(
+        r#"<div class="bookmark"><a href="https://example.com" onmouseover="alert(1)">Hover</a></div>"#
+    )]
+    #[case::nested_div_inside_bookmark(
+        "<div class=\"bookmark\"><div><a href=\"https://example.com\">Title</a></div></div>"
+    )]
+    fn test_bookmark_with_unexpected_html_is_escaped(#[case] markdown: &str) {
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            !result.contains(r#"<div class="bookmark">"#),
+            "unexpected bookmark content should cause the block to be escaped; got:\n{result}"
+        );
+        assert!(
+            result.contains("&lt;"),
+            "escaped block should contain HTML entities; got:\n{result}"
+        );
+    }
+
+    /// A bookmark block that is never closed with `</div>` must be HTML-escaped
+    /// in its entirety. The filter must not leave `in_bookmark = true` at
+    /// end-of-stream and silently discard the buffered content.
+    #[rstest]
+    fn test_unclosed_bookmark_is_escaped() {
+        // Deliberately omit the closing </div>.
+        let markdown = "<div class=\"bookmark\">\n  <a href=\"https://example.com\">Title</a>\n";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(
+            !result.contains(r#"<div class="bookmark">"#),
+            "unclosed bookmark opening tag should be escaped; got:\n{result}"
+        );
+        assert!(
+            result.contains("&lt;div"),
+            "unclosed bookmark should appear as HTML entities; got:\n{result}"
         );
     }
 

--- a/crates/publish/ingest/src/lib.rs
+++ b/crates/publish/ingest/src/lib.rs
@@ -7,5 +7,5 @@ pub use converter::{
     FileMapping, convert_markdown_to_html, convert_obsidian_links, generate_html_file,
 };
 pub use error::{IngestError, Result};
-pub use parser::{ObsidianFrontMatter, ParsedObsidianFile, parse_frontmatter, parse_obsidian_file};
+pub use parser::{ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file};
 pub use scanner::scan_obsidian_files;

--- a/crates/publish/ingest/src/parser.rs
+++ b/crates/publish/ingest/src/parser.rs
@@ -45,22 +45,6 @@ pub fn parse_obsidian_file(path: impl AsRef<Path>) -> Result<Option<ParsedObsidi
     }
 }
 
-/// Parse front matter from a string content.
-pub fn parse_frontmatter(content: &str) -> Result<Option<ObsidianFrontMatter>> {
-    extract_yaml_frontmatter(content)?
-        .map(|yaml| serde_yaml::from_str::<ObsidianFrontMatter>(yaml).map_err(Into::into))
-        .transpose()
-}
-
-/// Extract YAML frontmatter from the content.
-fn extract_yaml_frontmatter(text: &str) -> Result<Option<&str>> {
-    match split_frontmatter(text) {
-        FrontmatterSplit::Complete { yaml, .. } => Ok(Some(yaml)),
-        FrontmatterSplit::NoFrontmatter => Ok(None),
-        FrontmatterSplit::Unterminated => Err(unterminated_frontmatter_error()),
-    }
-}
-
 fn split_frontmatter(content: &str) -> FrontmatterSplit<'_> {
     let trimmed = content.trim_start();
     let Some(rest) = trimmed.strip_prefix("---\n") else {
@@ -87,6 +71,20 @@ mod tests {
     use indoc::indoc;
     use rstest::*;
     use tempfile::TempDir;
+
+    fn extract_yaml_frontmatter(text: &str) -> Result<Option<&str>> {
+        match split_frontmatter(text) {
+            FrontmatterSplit::Complete { yaml, .. } => Ok(Some(yaml)),
+            FrontmatterSplit::NoFrontmatter => Ok(None),
+            FrontmatterSplit::Unterminated => Err(unterminated_frontmatter_error()),
+        }
+    }
+
+    fn parse_frontmatter(content: &str) -> Result<Option<ObsidianFrontMatter>> {
+        extract_yaml_frontmatter(content)?
+            .map(|yaml| serde_yaml::from_str::<ObsidianFrontMatter>(yaml).map_err(Into::into))
+            .transpose()
+    }
 
     #[rstest]
     #[case::full_frontmatter( indoc! {r#"

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -18,17 +18,14 @@ use artifacts::{SiteDirectories, build_site_artifacts, write_article_page, write
 pub use config::Config;
 use domain::{ArticleBody, ArticleMeta, ArticleMetaInput, Category, Slug, Title};
 pub use error::{ObsidianError, Result};
-pub use ingest::ObsidianFrontMatter;
 use ingest::{
-    FileMapping, ParsedObsidianFile, convert_markdown_to_html, convert_obsidian_links,
-    parse_obsidian_file, scan_obsidian_files,
+    FileMapping, ObsidianFrontMatter, ParsedObsidianFile, convert_markdown_to_html,
+    convert_obsidian_links, parse_obsidian_file, scan_obsidian_files,
 };
 
-use futures::future::BoxFuture;
-use futures::{StreamExt, TryStreamExt, stream};
+use futures::{StreamExt, TryStreamExt, future::BoxFuture, stream};
 use log::{error, info, warn};
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 struct RenderedArticle {
     meta: ArticleMeta,
@@ -36,8 +33,8 @@ struct RenderedArticle {
 }
 
 struct ParsedFile {
-    file_path: PathBuf,
     slug: String,
+    mapping_key: String,
     markdown_body: String,
     front_matter: ObsidianFrontMatter,
 }
@@ -93,7 +90,7 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
         warn!("Error files: {error_count}");
     }
 
-    let file_mapping = build_file_mapping(config, &valid_files)?;
+    let file_mapping = build_file_mapping(&valid_files);
     let site_directories = SiteDirectories::prepare(&config.output_dir)?;
 
     const CONCURRENT_LIMIT: usize = 4;
@@ -167,10 +164,11 @@ fn process_valid_file(
         relative_path,
         &parsed_file.front_matter.created,
     )?;
+    let mapping_key = normalize_path_for_url(&relative_path.with_extension(""));
 
     Ok(ParsedFile {
-        file_path: file_path.to_path_buf(),
         slug,
+        mapping_key,
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })
@@ -192,17 +190,14 @@ fn get_relative_path<'a>(file_path: &'a Path, base_dir: &Path) -> Result<&'a Pat
     })
 }
 
-fn build_file_mapping(config: &Config, valid_files: &[ParsedFile]) -> Result<FileMapping> {
+fn build_file_mapping(valid_files: &[ParsedFile]) -> FileMapping {
     let mut mapping = FileMapping::with_capacity(valid_files.len());
 
     for parsed_file in valid_files {
-        let relative_path = get_relative_path(&parsed_file.file_path, &config.obsidian_dir)?;
-        let relative_path_no_ext = relative_path.with_extension("");
-        let mapping_key = normalize_path_for_url(&relative_path_no_ext);
-        mapping.insert(mapping_key, parsed_file.slug.clone());
+        mapping.insert(parsed_file.mapping_key.clone(), parsed_file.slug.clone());
     }
 
-    Ok(mapping)
+    mapping
 }
 
 async fn process_parsed_file(
@@ -260,18 +255,9 @@ fn parse_category(front_matter: &ObsidianFrontMatter) -> Result<Category> {
 mod tests {
     use super::*;
     use rstest::*;
-    use std::path::PathBuf;
-    use tempfile::TempDir;
 
     #[rstest]
     fn test_build_file_mapping_success() {
-        let temp_dir = TempDir::new().unwrap();
-        let config = Config {
-            obsidian_dir: temp_dir.path().to_path_buf(),
-            output_dir: PathBuf::from("output"),
-        };
-
-        let file_path = temp_dir.path().join("test.md");
         let front_matter = ObsidianFrontMatter {
             title: "Test Article".to_string(),
             tags: Some(vec!["test".to_string()]),
@@ -284,48 +270,28 @@ mod tests {
         };
 
         let parsed_file = ParsedFile {
-            file_path,
             slug: "slug".to_string(),
+            mapping_key: "test".to_string(),
             markdown_body: "# Test Content".to_string(),
             front_matter,
         };
         let valid_files = vec![parsed_file];
-        let result = build_file_mapping(&config, &valid_files);
+        let mapping = build_file_mapping(&valid_files);
 
-        assert!(result.is_ok());
-        let mapping = result.unwrap();
         assert_eq!(mapping.len(), 1);
-        assert!(mapping.contains_key("test")); // ファイル名がキーとなる
+        assert!(mapping.contains_key("test"));
     }
 
     #[rstest]
     fn test_build_file_mapping_empty() {
-        let temp_dir = TempDir::new().unwrap();
-        let config = Config {
-            obsidian_dir: temp_dir.path().to_path_buf(),
-            output_dir: PathBuf::from("output"),
-        };
-
         let valid_files: Vec<ParsedFile> = vec![];
-        let result = build_file_mapping(&config, &valid_files);
+        let mapping = build_file_mapping(&valid_files);
 
-        assert!(result.is_ok());
-        let mapping = result.unwrap();
         assert_eq!(mapping.len(), 0);
     }
 
     #[rstest]
     fn test_build_file_mapping_path_collision() {
-        let temp_dir = TempDir::new().unwrap();
-        let config = Config {
-            obsidian_dir: temp_dir.path().to_path_buf(),
-            output_dir: PathBuf::from("output"),
-        };
-
-        // Files with the same name in different directories.
-        let file_path1 = temp_dir.path().join("dir1").join("test.md");
-        let file_path2 = temp_dir.path().join("dir2").join("test.md");
-
         let front_matter1 = ObsidianFrontMatter {
             title: "Test Article 1".to_string(),
             tags: Some(vec!["test1".to_string()]),
@@ -349,22 +315,20 @@ mod tests {
         };
 
         let parsed_file1 = ParsedFile {
-            file_path: file_path1,
             slug: "slug1".to_string(),
+            mapping_key: "dir1/test".to_string(),
             markdown_body: "# Test Content 1".to_string(),
             front_matter: front_matter1,
         };
         let parsed_file2 = ParsedFile {
-            file_path: file_path2,
             slug: "slug2".to_string(),
+            mapping_key: "dir2/test".to_string(),
             markdown_body: "# Test Content 2".to_string(),
             front_matter: front_matter2,
         };
         let valid_files = vec![parsed_file1, parsed_file2];
-        let result = build_file_mapping(&config, &valid_files);
+        let mapping = build_file_mapping(&valid_files);
 
-        assert!(result.is_ok());
-        let mapping = result.unwrap();
         // Using the full relative path as the key prevents collisions.
         assert_eq!(mapping.len(), 2);
         assert!(mapping.contains_key("dir1/test"));
@@ -373,13 +337,6 @@ mod tests {
 
     #[rstest]
     fn test_build_file_mapping_url_normalization() {
-        let temp_dir = TempDir::new().unwrap();
-        let config = Config {
-            obsidian_dir: temp_dir.path().to_path_buf(),
-            output_dir: PathBuf::from("output"),
-        };
-
-        let file_path = temp_dir.path().join("sub").join("dir").join("test.md");
         let front_matter = ObsidianFrontMatter {
             title: "URL Test".to_string(),
             tags: None,
@@ -392,20 +349,15 @@ mod tests {
         };
 
         let parsed_file = ParsedFile {
-            file_path,
             slug: "slug".to_string(),
+            mapping_key: "sub/dir/test".to_string(),
             markdown_body: "# URL Test Content".to_string(),
             front_matter,
         };
         let valid_files = vec![parsed_file];
-        let result = build_file_mapping(&config, &valid_files);
+        let mapping = build_file_mapping(&valid_files);
 
-        assert!(result.is_ok());
-        let mapping = result.unwrap();
         let slug = mapping.get("sub/dir/test").unwrap();
-
-        // Verify URL normalization uses Unix-style separators.
-        // Ensure the slug is present.
         assert!(!slug.is_empty());
     }
 }

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -2,15 +2,12 @@ pub mod config;
 pub mod error;
 pub mod slug;
 
-/// A bookmark enricher takes raw page HTML (owned) and returns the enriched HTML.
-///
-/// The default implementation fetches OGP metadata over HTTP.
-/// Use [`offline_bookmark_enricher`] in integration tests to avoid any network access.
+/// Async fn that takes page HTML and returns enriched HTML with rich bookmark cards.
+/// Use `offline_bookmark_enricher` in tests to avoid network access.
 pub type BookmarkEnricher =
     Arc<dyn Fn(String) -> BoxFuture<'static, bookmark::Result<String>> + Send + Sync>;
 
-/// Creates a [`BookmarkEnricher`] that converts bookmarks using fallback data only,
-/// without making any network requests. Intended for integration tests.
+/// Returns a `BookmarkEnricher` that uses fallback data only; no network requests.
 pub fn offline_bookmark_enricher() -> BookmarkEnricher {
     Arc::new(|html: String| {
         Box::pin(async move { bookmark::convert_simple_bookmarks_to_rich_offline(&html).await })
@@ -38,7 +35,6 @@ struct RenderedArticle {
     html: String,
 }
 
-/// Holds the parsed file data used by the publisher flow.
 struct ParsedFile {
     file_path: PathBuf,
     slug: String,

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -2,8 +2,22 @@ pub mod config;
 pub mod error;
 pub mod slug;
 
+/// A bookmark enricher takes raw page HTML (owned) and returns the enriched HTML.
+///
+/// The default implementation fetches OGP metadata over HTTP.
+/// Use [`offline_bookmark_enricher`] in integration tests to avoid any network access.
+pub type BookmarkEnricher =
+    Arc<dyn Fn(String) -> BoxFuture<'static, bookmark::Result<String>> + Send + Sync>;
+
+/// Creates a [`BookmarkEnricher`] that converts bookmarks using fallback data only,
+/// without making any network requests. Intended for integration tests.
+pub fn offline_bookmark_enricher() -> BookmarkEnricher {
+    Arc::new(|html: String| {
+        Box::pin(async move { bookmark::convert_simple_bookmarks_to_rich_offline(&html).await })
+    })
+}
+
 use artifacts::{SiteDirectories, build_site_artifacts, write_article_page, write_site_artifacts};
-use bookmark::convert_simple_bookmarks_to_rich;
 pub use config::Config;
 use domain::{ArticleBody, ArticleMeta, ArticleMetaInput, Category, Slug, Title};
 pub use error::{ObsidianError, Result};
@@ -13,9 +27,11 @@ use ingest::{
     parse_obsidian_file, scan_obsidian_files,
 };
 
+use futures::future::BoxFuture;
 use futures::{StreamExt, TryStreamExt, stream};
 use log::{error, info, warn};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 struct RenderedArticle {
     meta: ArticleMeta,
@@ -31,6 +47,13 @@ struct ParsedFile {
 }
 
 pub async fn run_main(config: &Config) -> Result<()> {
+    let enrich: BookmarkEnricher = Arc::new(|html: String| {
+        Box::pin(async move { bookmark::convert_simple_bookmarks_to_rich(&html).await })
+    });
+    run_with_enricher(config, enrich).await
+}
+
+pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Result<()> {
     let start_time = std::time::Instant::now();
     info!("=== Publisher Started ===");
     info!("Input directory: {}", config.obsidian_dir.display());
@@ -79,7 +102,10 @@ pub async fn run_main(config: &Config) -> Result<()> {
 
     const CONCURRENT_LIMIT: usize = 4;
     let article_metas: Vec<ArticleMeta> = stream::iter(valid_files)
-        .map(|parsed_file| render_publishable_article(parsed_file, &file_mapping))
+        .map(|parsed_file| {
+            let enrich = Arc::clone(&enrich);
+            render_publishable_article(parsed_file, &file_mapping, enrich)
+        })
         .buffer_unordered(CONCURRENT_LIMIT)
         .try_fold(Vec::new(), |mut article_metas, rendered_article| {
             let site_directories = site_directories.clone();
@@ -99,6 +125,7 @@ pub async fn run_main(config: &Config) -> Result<()> {
             }
         })
         .await?;
+
     let site_artifacts = build_site_artifacts(article_metas);
     let site_directories_for_write = site_directories.clone();
     let site_artifacts = tokio::task::spawn_blocking(move || {
@@ -185,17 +212,17 @@ fn build_file_mapping(config: &Config, valid_files: &[ParsedFile]) -> Result<Fil
 async fn process_parsed_file(
     parsed_file: ParsedFile,
     file_mapping: &FileMapping,
+    enrich: &BookmarkEnricher,
 ) -> Result<RenderedArticle> {
     let markdown_with_links = convert_obsidian_links(&parsed_file.markdown_body, file_mapping);
     let html_body = convert_markdown_to_html(&markdown_with_links)?;
 
     // Convert simple bookmark markup into rich bookmark cards after rendering HTML.
-    let html_with_rich_bookmarks = convert_simple_bookmarks_to_rich(&html_body)
-        .await
-        .unwrap_or_else(|e| {
-            warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
-            html_body
-        });
+    let fallback = html_body.clone();
+    let html_with_rich_bookmarks = enrich(html_body).await.unwrap_or_else(|e| {
+        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
+        fallback
+    });
 
     let category = parse_category(&parsed_file.front_matter)?;
     let meta = ArticleMeta::new(ArticleMetaInput {
@@ -219,8 +246,9 @@ async fn process_parsed_file(
 async fn render_publishable_article(
     parsed_file: ParsedFile,
     file_mapping: &FileMapping,
+    enrich: BookmarkEnricher,
 ) -> Result<RenderedArticle> {
-    process_parsed_file(parsed_file, file_mapping).await
+    process_parsed_file(parsed_file, file_mapping, &enrich).await
 }
 
 fn parse_category(front_matter: &ObsidianFrontMatter) -> Result<Category> {

--- a/crates/publish/publisher/src/slug.rs
+++ b/crates/publish/publisher/src/slug.rs
@@ -32,11 +32,6 @@ pub fn generate_slug<P: AsRef<Path>>(
     Ok(slug)
 }
 
-/// Validates slug uniqueness for future extensions.
-pub fn validate_slug_uniqueness(slug: &str, existing_slugs: &[String]) -> bool {
-    !existing_slugs.contains(&slug.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -74,17 +69,6 @@ mod tests {
         assert_ne!(slug1, slug3);
 
         Ok(())
-    }
-
-    #[rstest]
-    #[case::existing_slug("abc123def456", false)]
-    #[case::new_slug("new123slug45", true)]
-    fn test_validate_slug_uniqueness(#[case] slug: &str, #[case] should_be_unique: bool) {
-        let existing_slugs = vec!["abc123def456".to_string(), "789xyz012tuv".to_string()];
-        assert_eq!(
-            validate_slug_uniqueness(slug, &existing_slugs),
-            should_be_unique
-        );
     }
 
     #[rstest]

--- a/crates/publish/publisher/tests/integration_test.rs
+++ b/crates/publish/publisher/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use indoc::indoc;
-use publisher::{Config, run_main};
+use publisher::{Config, offline_bookmark_enricher, run_main, run_with_enricher};
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -163,9 +163,8 @@ async fn test_run_main_with_bookmark_article() {
 
     fs::create_dir_all(&obsidian_dir).unwrap();
 
-    // Use a localhost URL that refuses connections immediately so the OGP fetch
-    // fails fast and the fallback rich-bookmark path is exercised without
-    // any real network access.
+    // Use an offline enricher that converts bookmarks with fallback data only,
+    // so no network request is made and the test never waits for a timeout.
     let sample_content = indoc! {r#"
         ---
         title: "Bookmark Article"
@@ -181,7 +180,7 @@ async fn test_run_main_with_bookmark_article() {
         Here is a bookmark:
 
         <div class="bookmark">
-          <a href="http://127.0.0.1:19999">Fallback Bookmark</a>
+          <a href="https://example.com">Fallback Bookmark</a>
         </div>
     "#};
 
@@ -193,7 +192,7 @@ async fn test_run_main_with_bookmark_article() {
         output_dir: output_dir.clone(),
     };
 
-    let result = run_main(&config).await;
+    let result = run_with_enricher(&config, offline_bookmark_enricher()).await;
     assert!(result.is_ok());
 
     let articles_dir = output_dir.join("site").join("articles");

--- a/crates/publish/publisher/tests/integration_test.rs
+++ b/crates/publish/publisher/tests/integration_test.rs
@@ -156,7 +156,7 @@ fn test_config_validation() {
 }
 
 #[tokio::test]
-async fn test_run_main_with_bookmark_article() {
+async fn test_run_with_enricher_with_bookmark_article() {
     let temp_dir = TempDir::new().unwrap();
     let obsidian_dir = temp_dir.path().join("obsidian");
     let output_dir = temp_dir.path().join("dist");

--- a/crates/publish/publisher/tests/integration_test.rs
+++ b/crates/publish/publisher/tests/integration_test.rs
@@ -154,3 +154,73 @@ fn test_config_validation() {
     // `validate` is not called directly here, so assert the missing-path behavior instead.
     assert!(!config.obsidian_dir.exists());
 }
+
+#[tokio::test]
+async fn test_run_main_with_bookmark_article() {
+    let temp_dir = TempDir::new().unwrap();
+    let obsidian_dir = temp_dir.path().join("obsidian");
+    let output_dir = temp_dir.path().join("dist");
+
+    fs::create_dir_all(&obsidian_dir).unwrap();
+
+    // Use a localhost URL that refuses connections immediately so the OGP fetch
+    // fails fast and the fallback rich-bookmark path is exercised without
+    // any real network access.
+    let sample_content = indoc! {r#"
+        ---
+        title: "Bookmark Article"
+        tags: ["test"]
+        summary: "Article containing a bookmark block"
+        priority: 1
+        created: "2025-01-01T00:00:00+09:00"
+        updated: "2025-01-01T00:00:00+09:00"
+        is_completed: true
+        category: "tech"
+        ---
+
+        Here is a bookmark:
+
+        <div class="bookmark">
+          <a href="http://127.0.0.1:19999">Fallback Bookmark</a>
+        </div>
+    "#};
+
+    let sample_file = obsidian_dir.join("bookmark.md");
+    fs::write(&sample_file, sample_content).unwrap();
+
+    let config = Config {
+        obsidian_dir,
+        output_dir: output_dir.clone(),
+    };
+
+    let result = run_main(&config).await;
+    assert!(result.is_ok());
+
+    let articles_dir = output_dir.join("site").join("articles");
+    let html_files: Vec<_> = fs::read_dir(&articles_dir)
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "html"))
+        .collect();
+
+    assert!(!html_files.is_empty(), "HTML file should be generated");
+
+    let html_content = fs::read_to_string(html_files[0].path()).unwrap();
+
+    // The bookmark should NOT remain as escaped HTML.
+    assert!(
+        !html_content.contains("&lt;div class=&quot;bookmark&quot;&gt;"),
+        "bookmark HTML should not be escaped; got: {html_content}"
+    );
+
+    // The bookmark should have been converted to the rich card format
+    // (fallback data is used when the OGP fetch fails).
+    assert!(
+        html_content.contains(r#"class="bookmark-link""#),
+        "bookmark should be converted to rich format; got: {html_content}"
+    );
+    assert!(
+        html_content.contains(r#"class="bookmark-domain""#),
+        "bookmark should contain domain info; got: {html_content}"
+    );
+}

--- a/mise.toml
+++ b/mise.toml
@@ -29,7 +29,7 @@ bun install
 '''
 
 [tasks.web-update]
-description = "Update web package.json dependencies to the latest versions with bun"
+description = "Update web package.json dependencies within their declared version ranges with bun"
 run = '''
 cd crates/site/web
 bun update
@@ -44,7 +44,7 @@ bun outdated
 
 [tasks.sync-obsidian]
 description = "Initialize and update the private Obsidian submodule"
-run = "git submodule update --remote --merge --recursive"
+run = "git submodule update --init --remote --merge --recursive"
 
 [tasks.publish-local]
 description = "Generate local site artifacts from the Obsidian submodule"

--- a/mise.toml
+++ b/mise.toml
@@ -32,7 +32,7 @@ bun install
 description = "Update web package.json dependencies to the latest versions with bun"
 run = '''
 cd crates/site/web
-bun update --latest
+bun update
 '''
 
 [tasks.web-outdated]
@@ -44,11 +44,11 @@ bun outdated
 
 [tasks.sync-obsidian]
 description = "Initialize and update the private Obsidian submodule"
-run = "git submodule update --init --recursive"
+run = "git submodule update --remote --merge --recursive"
 
 [tasks.publish-local]
 description = "Generate local site artifacts from the Obsidian submodule"
-depends = ["sync-obsidian"]
+depends = ["sync-obsidian", "clean-dist"]
 env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "crates/publish/publisher/dist/site", OKAWAK_BLOG_SITE_ORIGIN = "http://127.0.0.1:8008" }
 run = "cargo run -p publisher"
 
@@ -85,6 +85,10 @@ description = "Watch the project and rebuild with local artifacts"
 depends = ["check-deps", "format"]
 env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "crates/publish/publisher/dist/site", OKAWAK_BLOG_SITE_ORIGIN = "http://127.0.0.1:8008" }
 run = "cargo leptos watch -p server"
+
+[tasks.clean-dist]
+description = "Remove generated dist artifacts"
+run = "rm -rf crates/publish/publisher/dist"
 
 [tasks.clean-project]
 description = "Clean the Cargo build artifacts"


### PR DESCRIPTION
bookmarkで処理したhtmlが、pulldown_cmarkの処理で、encodingされてしまって、htmlタグがうまく動作されないのを修正しました。そのたkatexの問題(コードブロック内の`$`も解釈される)を修正しました。