### PR TITLE
feat: add category landing artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ site/
 │   ├── <slug>.html
 │   └── index.json
 ├── categories/
-│   ├── tech.json
-│   ├── daily.json
+│   ├── <category>/
+│   │   ├── index.json
+│   │   └── page.html
 │   └── ...
+├── pages/
+│   └── <page>.json
 ├── tags/
 │   └── index.json
 ├── assets/

--- a/crates/domain/src/artifact_document.rs
+++ b/crates/domain/src/artifact_document.rs
@@ -51,7 +51,7 @@ impl From<&[PublishedArticleSummary]> for ArticleIndexDocument {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CategoryIndexDocument {
     pub category: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,

--- a/crates/domain/src/artifact_document.rs
+++ b/crates/domain/src/artifact_document.rs
@@ -51,6 +51,12 @@ impl From<&[PublishedArticleSummary]> for ArticleIndexDocument {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CategoryIndexDocument {
     pub category: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
     pub articles: Vec<ArticleSummaryDocument>,
 }
 
@@ -58,6 +64,9 @@ impl From<&CategoryIndex> for CategoryIndexDocument {
     fn from(index: &CategoryIndex) -> Self {
         Self {
             category: index.category.as_str().to_string(),
+            title: None,
+            description: None,
+            updated_at: None,
             articles: index
                 .articles
                 .iter()
@@ -184,5 +193,19 @@ mod tests {
         assert!(json.contains("\"page\":\"about\""));
         assert!(json.contains("\"title\":\"About\""));
         assert!(json.contains("\"html\":\"<h1>About</h1>\""));
+    }
+
+    #[test]
+    fn test_category_index_document_deserialization_defaults_missing_metadata() {
+        let json = r#"{
+            "category":"tech",
+            "articles":[]
+        }"#;
+
+        let document: CategoryIndexDocument = serde_json::from_str(json).unwrap();
+
+        assert_eq!(document.title, None);
+        assert_eq!(document.description, None);
+        assert_eq!(document.updated_at, None);
     }
 }

--- a/crates/domain/src/site_page.rs
+++ b/crates/domain/src/site_page.rs
@@ -297,7 +297,7 @@ fn build_category_section_groups(articles: &[SiteArticleCard]) -> Vec<CategorySe
 
 fn build_section_heading(section_path: &[String]) -> String {
     if section_path.is_empty() {
-        "General".to_string()
+        "全般".to_string()
     } else {
         section_path.join(" / ")
     }
@@ -630,7 +630,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(document.sections.len(), 3);
-        assert_eq!(document.sections[0].heading, "General");
+        assert_eq!(document.sections[0].heading, "全般");
         assert_eq!(document.sections[1].heading, "rust");
         assert_eq!(document.sections[2].heading, "rust / async");
     }

--- a/crates/domain/src/site_page.rs
+++ b/crates/domain/src/site_page.rs
@@ -65,7 +65,11 @@ pub struct ArticlePageDocument {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CategoryPageDocument {
     pub category: Category,
+    pub title: String,
     pub category_display_name: String,
+    pub description: Option<String>,
+    pub html: String,
+    pub sections: Vec<CategorySectionGroup>,
     pub articles: Vec<SiteArticleCard>,
 }
 
@@ -75,6 +79,13 @@ pub struct StaticPageDocument {
     pub title: String,
     pub description: Option<String>,
     pub html: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CategorySectionGroup {
+    pub section_path: Vec<String>,
+    pub heading: String,
+    pub articles: Vec<SiteArticleCard>,
 }
 
 pub fn build_home_page_title(site_name: &str) -> String {
@@ -117,15 +128,22 @@ pub fn build_article_page_canonical_path(document: &ArticlePageDocument) -> Stri
 }
 
 pub fn build_category_page_title(document: &CategoryPageDocument, site_name: &str) -> String {
-    format!("{} | {}", document.category_display_name, site_name)
+    format!("{} | {}", document.title, site_name)
 }
 
 pub fn build_category_page_description(document: &CategoryPageDocument) -> String {
-    format!(
-        "{}カテゴリの記事一覧です。{}件の記事があります。",
-        document.category_display_name,
-        document.articles.len()
-    )
+    document
+        .description
+        .as_deref()
+        .filter(|description| !description.trim().is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            format!(
+                "{}カテゴリの記事一覧です。{}件の記事があります。",
+                document.category_display_name,
+                document.articles.len()
+            )
+        })
 }
 
 pub fn build_category_page_canonical_path(document: &CategoryPageDocument) -> String {
@@ -192,17 +210,36 @@ pub fn build_article_page_document(
     })
 }
 
-pub fn build_category_page_document(index: &CategoryIndexDocument) -> Result<CategoryPageDocument> {
+pub fn build_category_page_document(
+    index: &CategoryIndexDocument,
+    html: &str,
+) -> Result<CategoryPageDocument> {
     let category = Category::from_str(&index.category)?;
+    let html = html.trim();
+    if html.is_empty() {
+        return Err(DomainError::validation("html"));
+    }
+
     let articles = index
         .articles
         .iter()
         .map(SiteArticleCard::try_from)
         .collect::<Result<Vec<_>>>()?;
+    let title = index
+        .title
+        .as_deref()
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or(category.display_name())
+        .to_string();
+    let sections = build_category_section_groups(&articles);
 
     Ok(CategoryPageDocument {
         category,
+        title,
         category_display_name: category.display_name().to_string(),
+        description: index.description.clone(),
+        html: html.to_string(),
+        sections,
         articles,
     })
 }
@@ -235,6 +272,35 @@ pub fn find_article_summary<'a>(
         .articles
         .iter()
         .find(|article| article.slug == slug.as_str())
+}
+
+fn build_category_section_groups(articles: &[SiteArticleCard]) -> Vec<CategorySectionGroup> {
+    use std::collections::BTreeMap;
+
+    let mut grouped: BTreeMap<Vec<String>, Vec<SiteArticleCard>> = BTreeMap::new();
+    for article in articles {
+        grouped
+            .entry(article.section_path.clone())
+            .or_default()
+            .push(article.clone());
+    }
+
+    grouped
+        .into_iter()
+        .map(|(section_path, articles)| CategorySectionGroup {
+            heading: build_section_heading(&section_path),
+            section_path,
+            articles,
+        })
+        .collect()
+}
+
+fn build_section_heading(section_path: &[String]) -> String {
+    if section_path.is_empty() {
+        "General".to_string()
+    } else {
+        section_path.join(" / ")
+    }
 }
 
 #[cfg(test)]
@@ -307,18 +373,29 @@ mod tests {
 
     #[test]
     fn test_build_category_page_document() {
-        let document = build_category_page_document(&CategoryIndexDocument {
-            category: "daily".to_string(),
-            articles: vec![ArticleSummaryDocument {
+        let document = build_category_page_document(
+            &CategoryIndexDocument {
                 category: "daily".to_string(),
-                ..sample_summary()
-            }],
-        })
+                title: Some("Daily Notes".to_string()),
+                description: Some("Daily landing".to_string()),
+                updated_at: Some("2025-01-01T00:00:00+09:00".to_string()),
+                articles: vec![ArticleSummaryDocument {
+                    category: "daily".to_string(),
+                    ..sample_summary()
+                }],
+            },
+            "<article><h1>Daily Notes</h1></article>",
+        )
         .unwrap();
 
         assert_eq!(document.category, Category::Daily);
+        assert_eq!(document.title, "Daily Notes");
         assert_eq!(document.category_display_name, "日常");
+        assert_eq!(document.description, Some("Daily landing".to_string()));
+        assert!(document.html.contains("Daily Notes"));
         assert_eq!(document.articles.len(), 1);
+        assert_eq!(document.sections.len(), 1);
+        assert_eq!(document.sections[0].heading, "block");
     }
 
     #[test]
@@ -445,24 +522,117 @@ mod tests {
 
     #[test]
     fn test_build_category_page_metadata() {
-        let document = build_category_page_document(&CategoryIndexDocument {
-            category: "tech".to_string(),
-            articles: vec![sample_summary()],
-        })
+        let document = build_category_page_document(
+            &CategoryIndexDocument {
+                category: "tech".to_string(),
+                title: Some("Rust".to_string()),
+                description: Some("Rust articles".to_string()),
+                updated_at: Some("2025-01-01T00:00:00+09:00".to_string()),
+                articles: vec![sample_summary()],
+            },
+            "<article><h1>Rust</h1></article>",
+        )
         .unwrap();
 
         assert_eq!(
             build_category_page_title(&document, "ぶくせんの探窟メモ"),
-            "技術 | ぶくせんの探窟メモ"
+            "Rust | ぶくせんの探窟メモ"
         );
-        assert_eq!(
-            build_category_page_description(&document),
-            "技術カテゴリの記事一覧です。1件の記事があります。"
-        );
+        assert_eq!(build_category_page_description(&document), "Rust articles");
         assert_eq!(
             build_category_page_canonical_path(&document),
             "/categories/tech"
         );
+    }
+
+    #[test]
+    fn test_build_category_page_description_falls_back_when_missing() {
+        let document = build_category_page_document(
+            &CategoryIndexDocument {
+                category: "tech".to_string(),
+                title: None,
+                description: None,
+                updated_at: None,
+                articles: vec![sample_summary()],
+            },
+            "<article><h1>Tech</h1></article>",
+        )
+        .unwrap();
+
+        assert_eq!(
+            build_category_page_description(&document),
+            "技術カテゴリの記事一覧です。1件の記事があります。"
+        );
+    }
+
+    #[test]
+    fn test_build_category_page_document_rejects_blank_html() {
+        let result = build_category_page_document(
+            &CategoryIndexDocument {
+                category: "tech".to_string(),
+                title: None,
+                description: None,
+                updated_at: None,
+                articles: vec![sample_summary()],
+            },
+            "  ",
+        );
+
+        assert_eq!(result, Err(DomainError::validation("html")));
+    }
+
+    #[test]
+    fn test_build_category_page_document_groups_articles_by_section_path() {
+        let document = build_category_page_document(
+            &CategoryIndexDocument {
+                category: "tech".to_string(),
+                title: Some("Tech".to_string()),
+                description: None,
+                updated_at: None,
+                articles: vec![
+                    ArticleSummaryDocument {
+                        slug: "alpha0000001".to_string(),
+                        title: "Alpha".to_string(),
+                        category: "tech".to_string(),
+                        section_path: vec!["rust".to_string()],
+                        description: None,
+                        tags: vec![],
+                        priority: None,
+                        created_at: "2025-01-01T00:00:00+09:00".to_string(),
+                        updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+                    },
+                    ArticleSummaryDocument {
+                        slug: "beta00000001".to_string(),
+                        title: "Beta".to_string(),
+                        category: "tech".to_string(),
+                        section_path: vec!["rust".to_string(), "async".to_string()],
+                        description: None,
+                        tags: vec![],
+                        priority: None,
+                        created_at: "2025-01-01T00:00:00+09:00".to_string(),
+                        updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+                    },
+                    ArticleSummaryDocument {
+                        slug: "gamma0000001".to_string(),
+                        title: "Gamma".to_string(),
+                        category: "tech".to_string(),
+                        section_path: vec![],
+                        description: None,
+                        tags: vec![],
+                        priority: None,
+                        created_at: "2025-01-01T00:00:00+09:00".to_string(),
+                        updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+                    },
+                ],
+            },
+            "<article><h1>Tech</h1></article>",
+        )
+        .unwrap();
+
+        assert_eq!(document.sections.len(), 3);
+        assert_eq!(document.sections[0].heading, "General");
+        assert_eq!(document.sections[1].heading, "rust");
+        assert_eq!(document.sections[2].heading, "rust / async");
     }
 
     #[test]

--- a/crates/publish/artifacts/src/lib.rs
+++ b/crates/publish/artifacts/src/lib.rs
@@ -3,8 +3,9 @@ mod error;
 pub use error::{ArtifactsError, Result};
 
 use domain::{
-    ArticleIndexDocument, ArticleMeta, CategoryIndexDocument, PageArtifactDocument, SiteMetadata,
-    SiteMetadataDocument, Slug, build_article_index, build_category_indexes, build_site_metadata,
+    ArticleIndexDocument, ArticleMeta, Category, CategoryIndexDocument, PageArtifactDocument,
+    SiteMetadata, SiteMetadataDocument, Slug, build_article_index, build_category_indexes,
+    build_site_metadata,
 };
 use serde::Serialize;
 use std::{
@@ -18,7 +19,16 @@ use std::{
 pub struct SiteArtifacts {
     pub article_index: Vec<domain::PublishedArticleSummary>,
     pub category_indexes: Vec<domain::CategoryIndex>,
+    pub category_landings: Vec<CategoryLandingMetadata>,
     pub site_metadata: SiteMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryLandingMetadata {
+    pub category: Category,
+    pub title: String,
+    pub description: Option<String>,
+    pub updated_at: String,
 }
 
 /// Output directories for generated local site artifacts.
@@ -49,14 +59,47 @@ impl SiteDirectories {
     }
 }
 
-pub fn build_site_artifacts(article_metas: Vec<ArticleMeta>) -> SiteArtifacts {
+pub fn build_site_artifacts(
+    article_metas: Vec<ArticleMeta>,
+    mut category_landings: Vec<CategoryLandingMetadata>,
+) -> SiteArtifacts {
     let article_index = build_article_index(&article_metas);
-    let category_indexes = build_category_indexes(&article_metas);
-    let site_metadata = build_site_metadata(&article_metas);
+    let mut category_indexes = build_category_indexes(&article_metas);
+    let mut site_metadata = build_site_metadata(&article_metas);
+
+    category_landings.sort_by(|a, b| a.category.as_str().cmp(b.category.as_str()));
+    for landing in &category_landings {
+        if category_indexes
+            .iter()
+            .all(|index| index.category != landing.category)
+        {
+            category_indexes.push(domain::CategoryIndex {
+                category: landing.category,
+                articles: vec![],
+            });
+        }
+
+        if site_metadata
+            .categories
+            .iter()
+            .all(|metadata| metadata.category != landing.category)
+        {
+            site_metadata.categories.push(domain::CategoryMetadata {
+                category: landing.category,
+                article_count: 0,
+            });
+        }
+    }
+
+    category_indexes.sort_by(|a, b| a.category.as_str().cmp(b.category.as_str()));
+    site_metadata
+        .categories
+        .sort_by(|a, b| a.category.as_str().cmp(b.category.as_str()));
 
     SiteArtifacts {
         article_index,
         category_indexes,
+        category_landings,
         site_metadata,
     }
 }
@@ -84,6 +127,18 @@ pub fn write_page_document(
     Ok(output_file_path)
 }
 
+pub fn write_category_page(
+    site_directories: &SiteDirectories,
+    category: Category,
+    html: &str,
+) -> Result<PathBuf> {
+    let category_dir = site_directories.categories_dir.join(category.as_str());
+    fs::create_dir_all(&category_dir)?;
+    let output_file_path = category_dir.join("page.html");
+    fs::write(&output_file_path, html)?;
+    Ok(output_file_path)
+}
+
 pub fn write_site_artifacts(
     site_directories: &SiteDirectories,
     site_artifacts: &SiteArtifacts,
@@ -94,11 +149,27 @@ pub fn write_site_artifacts(
     )?;
 
     for category_index in &site_artifacts.category_indexes {
+        let category_dir = site_directories
+            .categories_dir
+            .join(category_index.category.as_str());
+        fs::create_dir_all(&category_dir)?;
+        let landing = site_artifacts
+            .category_landings
+            .iter()
+            .find(|landing| landing.category == category_index.category);
         write_json_pretty(
-            &site_directories
-                .categories_dir
-                .join(format!("{}.json", category_index.category.as_str())),
-            &CategoryIndexDocument::from(category_index),
+            &category_dir.join("index.json"),
+            &CategoryIndexDocument {
+                category: category_index.category.as_str().to_string(),
+                title: landing.map(|landing| landing.title.clone()),
+                description: landing.and_then(|landing| landing.description.clone()),
+                updated_at: landing.map(|landing| landing.updated_at.clone()),
+                articles: category_index
+                    .articles
+                    .iter()
+                    .map(domain::ArticleSummaryDocument::from)
+                    .collect(),
+            },
         )?;
     }
 
@@ -146,25 +217,29 @@ mod tests {
 
     #[test]
     fn test_build_site_artifacts() {
-        let artifacts = build_site_artifacts(vec![
-            build_article_meta(
-                "First",
-                "first0000001",
-                Category::Tech,
-                Some(1),
-                "2025-01-01T00:00:00+09:00",
-            ),
-            build_article_meta(
-                "Second",
-                "second000002",
-                Category::Daily,
-                Some(10),
-                "2025-01-02T00:00:00+09:00",
-            ),
-        ]);
+        let artifacts = build_site_artifacts(
+            vec![
+                build_article_meta(
+                    "First",
+                    "first0000001",
+                    Category::Tech,
+                    Some(1),
+                    "2025-01-01T00:00:00+09:00",
+                ),
+                build_article_meta(
+                    "Second",
+                    "second000002",
+                    Category::Daily,
+                    Some(10),
+                    "2025-01-02T00:00:00+09:00",
+                ),
+            ],
+            vec![],
+        );
 
         assert_eq!(artifacts.article_index.len(), 2);
         assert_eq!(artifacts.category_indexes.len(), 2);
+        assert!(artifacts.category_landings.is_empty());
         assert_eq!(artifacts.site_metadata.total_articles, 2);
         assert_eq!(artifacts.article_index[0].slug.as_str(), "second000002");
     }
@@ -180,7 +255,15 @@ mod tests {
             Some(1),
             "2025-01-01T00:00:00+09:00",
         );
-        let site_artifacts = build_site_artifacts(vec![article_meta.clone()]);
+        let site_artifacts = build_site_artifacts(
+            vec![article_meta.clone()],
+            vec![CategoryLandingMetadata {
+                category: Category::Tech,
+                title: "Tech".to_string(),
+                description: Some("Tech landing".to_string()),
+                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+            }],
+        );
 
         let article_path = write_article_page(
             &site_directories,
@@ -188,16 +271,29 @@ mod tests {
             "<h1>Artifact Test</h1>",
         )
         .unwrap();
+        let category_page_path =
+            write_category_page(&site_directories, Category::Tech, "<h1>Tech</h1>").unwrap();
         write_site_artifacts(&site_directories, &site_artifacts).unwrap();
 
         assert!(article_path.exists());
+        assert!(category_page_path.exists());
         assert!(
             site_directories.articles_dir.join("index.json").exists(),
             "articles/index.json should exist"
         );
         assert!(
-            site_directories.categories_dir.join("tech.json").exists(),
-            "categories/tech.json should exist"
+            site_directories
+                .categories_dir
+                .join("tech/index.json")
+                .exists(),
+            "categories/tech/index.json should exist"
+        );
+        assert!(
+            site_directories
+                .categories_dir
+                .join("tech/page.html")
+                .exists(),
+            "categories/tech/page.html should exist"
         );
         assert!(
             site_directories.metadata_dir.join("site.json").exists(),
@@ -228,5 +324,23 @@ mod tests {
 
         assert_eq!(output_path, site_directories.pages_dir.join("about.json"));
         assert!(output_path.exists());
+    }
+
+    #[test]
+    fn test_build_site_artifacts_includes_landing_only_category_in_indexes_and_metadata() {
+        let artifacts = build_site_artifacts(
+            vec![],
+            vec![CategoryLandingMetadata {
+                category: Category::Physics,
+                title: "Physics".to_string(),
+                description: None,
+                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+            }],
+        );
+
+        assert_eq!(artifacts.category_indexes.len(), 1);
+        assert_eq!(artifacts.category_indexes[0].category, Category::Physics);
+        assert_eq!(artifacts.site_metadata.categories.len(), 1);
+        assert_eq!(artifacts.site_metadata.categories[0].article_count, 0);
     }
 }

--- a/crates/publish/artifacts/src/lib.rs
+++ b/crates/publish/artifacts/src/lib.rs
@@ -9,6 +9,7 @@ use domain::{
 };
 use serde::Serialize;
 use std::{
+    collections::HashMap,
     fs::{self, File},
     io::BufWriter,
     path::{Path, PathBuf},
@@ -147,16 +148,20 @@ pub fn write_site_artifacts(
         &site_directories.articles_dir.join("index.json"),
         &ArticleIndexDocument::from(site_artifacts.article_index.as_slice()),
     )?;
+    let category_landings_by_category: HashMap<_, _> = site_artifacts
+        .category_landings
+        .iter()
+        .map(|landing| (landing.category, landing))
+        .collect();
 
     for category_index in &site_artifacts.category_indexes {
         let category_dir = site_directories
             .categories_dir
             .join(category_index.category.as_str());
         fs::create_dir_all(&category_dir)?;
-        let landing = site_artifacts
-            .category_landings
-            .iter()
-            .find(|landing| landing.category == category_index.category);
+        let landing = category_landings_by_category
+            .get(&category_index.category)
+            .copied();
         write_json_pretty(
             &category_dir.join("index.json"),
             &CategoryIndexDocument {

--- a/crates/publish/artifacts/src/lib.rs
+++ b/crates/publish/artifacts/src/lib.rs
@@ -171,6 +171,13 @@ pub fn write_site_artifacts(
                     .collect(),
             },
         )?;
+
+        if landing.is_none() {
+            fs::write(
+                category_dir.join("page.html"),
+                build_fallback_category_page_html(category_index),
+            )?;
+        }
     }
 
     write_json_pretty(
@@ -186,6 +193,14 @@ fn write_json_pretty(path: &Path, value: &impl Serialize) -> Result<()> {
     let writer = BufWriter::new(file);
     serde_json::to_writer_pretty(writer, value)?;
     Ok(())
+}
+
+fn build_fallback_category_page_html(category_index: &domain::CategoryIndex) -> String {
+    format!(
+        "<article><h1>{}</h1><p>{}カテゴリの記事一覧です。</p></article>",
+        category_index.category.display_name(),
+        category_index.category.display_name(),
+    )
 }
 
 #[cfg(test)]
@@ -342,5 +357,32 @@ mod tests {
         assert_eq!(artifacts.category_indexes[0].category, Category::Physics);
         assert_eq!(artifacts.site_metadata.categories.len(), 1);
         assert_eq!(artifacts.site_metadata.categories[0].article_count, 0);
+    }
+
+    #[test]
+    fn test_write_site_artifacts_creates_fallback_category_page_when_landing_is_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
+        let article_meta = build_article_meta(
+            "Artifact Test",
+            "artifact00001",
+            Category::Tech,
+            Some(1),
+            "2025-01-01T00:00:00+09:00",
+        );
+        let site_artifacts = build_site_artifacts(vec![article_meta], vec![]);
+
+        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
+
+        let fallback_html = fs::read_to_string(
+            site_directories
+                .categories_dir
+                .join("tech")
+                .join("page.html"),
+        )
+        .unwrap();
+
+        assert!(fallback_html.contains("<h1>技術</h1>"));
+        assert!(fallback_html.contains("技術カテゴリの記事一覧です。"));
     }
 }

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -459,6 +459,15 @@ async fn process_category_file(
         warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
         fallback
     });
+    let html = if html_with_rich_bookmarks.trim().is_empty() {
+        build_fallback_category_landing_html(
+            parsed_file.category,
+            &parsed_file.front_matter.title,
+            parsed_file.front_matter.summary.as_deref(),
+        )
+    } else {
+        html_with_rich_bookmarks
+    };
 
     Ok(RenderedCategoryLanding {
         metadata: CategoryLandingMetadata {
@@ -467,7 +476,7 @@ async fn process_category_file(
             description: parsed_file.front_matter.summary,
             updated_at: parsed_file.front_matter.updated,
         },
-        html: html_with_rich_bookmarks,
+        html,
     })
 }
 
@@ -494,6 +503,26 @@ fn parse_page_key(front_matter: &ObsidianFrontMatter) -> Result<PageKey> {
         .as_deref()
         .ok_or_else(|| ObsidianError::Parse("Completed pages require a page key".to_string()))?;
     PageKey::new(page.trim().to_string()).map_err(|error| ObsidianError::Parse(error.to_string()))
+}
+
+fn build_fallback_category_landing_html(
+    category: Category,
+    title: &str,
+    description: Option<&str>,
+) -> String {
+    let heading = if title.trim().is_empty() {
+        category.display_name()
+    } else {
+        title.trim()
+    };
+
+    let body = description
+        .filter(|description| !description.trim().is_empty())
+        .map(str::trim)
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("{}カテゴリの記事一覧です。", category.display_name()));
+
+    format!("<article><h1>{heading}</h1><p>{body}</p></article>")
 }
 
 #[cfg(test)]
@@ -660,6 +689,26 @@ mod tests {
         assert!(
             matches!(result, Err(ObsidianError::Parse(message)) if message.contains("Duplicate category landing"))
         );
+    }
+
+    #[test]
+    fn test_build_fallback_category_landing_html_uses_title_and_summary() {
+        let html = build_fallback_category_landing_html(
+            Category::Tech,
+            "Tech",
+            Some("Technology landing"),
+        );
+
+        assert!(html.contains("<h1>Tech</h1>"));
+        assert!(html.contains("<p>Technology landing</p>"));
+    }
+
+    #[test]
+    fn test_build_fallback_category_landing_html_falls_back_to_category_display_name() {
+        let html = build_fallback_category_landing_html(Category::Physics, "   ", None);
+
+        assert!(html.contains("<h1>物理学</h1>"));
+        assert!(html.contains("物理学カテゴリの記事一覧です。"));
     }
 
     #[test]

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -521,8 +521,18 @@ fn build_fallback_category_landing_html(
         .map(str::trim)
         .map(str::to_owned)
         .unwrap_or_else(|| format!("{}カテゴリの記事一覧です。", category.display_name()));
+    let heading = html_escape(heading);
+    let body = html_escape(&body);
 
     format!("<article><h1>{heading}</h1><p>{body}</p></article>")
+}
+
+fn html_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
 }
 
 #[cfg(test)]
@@ -709,6 +719,19 @@ mod tests {
 
         assert!(html.contains("<h1>物理学</h1>"));
         assert!(html.contains("物理学カテゴリの記事一覧です。"));
+    }
+
+    #[test]
+    fn test_build_fallback_category_landing_html_escapes_frontmatter_text() {
+        let html = build_fallback_category_landing_html(
+            Category::Tech,
+            "<script>alert(1)</script>",
+            Some("\"quoted\" & <tag>"),
+        );
+
+        assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assert!(html.contains("&quot;quoted&quot; &amp; &lt;tag&gt;"));
+        assert!(!html.contains("<script>alert(1)</script>"));
     }
 
     #[test]

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -15,8 +15,8 @@ pub fn offline_bookmark_enricher() -> BookmarkEnricher {
 }
 
 use artifacts::{
-    SiteDirectories, build_site_artifacts, write_article_page, write_page_document,
-    write_site_artifacts,
+    CategoryLandingMetadata, SiteDirectories, build_site_artifacts, write_article_page,
+    write_category_page, write_page_document, write_site_artifacts,
 };
 pub use config::Config;
 use domain::{
@@ -42,6 +42,11 @@ struct RenderedPage {
     document: PageArtifactDocument,
 }
 
+struct RenderedCategoryLanding {
+    metadata: CategoryLandingMetadata,
+    html: String,
+}
+
 struct ParsedArticleFile {
     slug: String,
     mapping_key: String,
@@ -52,6 +57,12 @@ struct ParsedArticleFile {
 
 struct ParsedPageFile {
     page: PageKey,
+    markdown_body: String,
+    front_matter: ObsidianFrontMatter,
+}
+
+struct ParsedCategoryFile {
+    category: Category,
     markdown_body: String,
     front_matter: ObsidianFrontMatter,
 }
@@ -77,6 +88,7 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
 
     let mut valid_articles = Vec::new();
     let mut valid_pages = Vec::new();
+    let mut valid_categories = Vec::new();
     for file_path in markdown_files {
         match parse_obsidian_file(&file_path) {
             Ok(Some(parsed_file)) if parsed_file.front_matter.is_completed => {
@@ -92,6 +104,13 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
                     }
                     ContentKind::Page => match process_valid_page_file(parsed_file) {
                         Ok(parsed_file) => valid_pages.push(parsed_file),
+                        Err(e) => {
+                            error_count += 1;
+                            error!("Error processing {}: {}", file_path.display(), e);
+                        }
+                    },
+                    ContentKind::Category => match process_valid_category_file(parsed_file) {
+                        Ok(parsed_file) => valid_categories.push(parsed_file),
                         Err(e) => {
                             error_count += 1;
                             error!("Error processing {}: {}", file_path.display(), e);
@@ -120,12 +139,14 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
 
     info!("Valid article files: {}", valid_articles.len());
     info!("Valid page files: {}", valid_pages.len());
+    info!("Valid category files: {}", valid_categories.len());
     info!("Skipped files: {skipped_count}");
     if error_count > 0 {
         warn!("Error files: {error_count}");
     }
 
     ensure_unique_page_keys(&valid_pages)?;
+    ensure_unique_category_landings(&valid_categories)?;
 
     let file_mapping = build_file_mapping(&valid_articles);
     let site_directories = SiteDirectories::prepare(&config.output_dir)?;
@@ -165,6 +186,15 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
         .try_collect()
         .await?;
 
+    let rendered_categories: Vec<RenderedCategoryLanding> = stream::iter(valid_categories)
+        .map(|parsed_file| {
+            let enrich = Arc::clone(&enrich);
+            render_category_landing(parsed_file, &file_mapping, enrich)
+        })
+        .buffer_unordered(CONCURRENT_LIMIT)
+        .try_collect()
+        .await?;
+
     for rendered_page in rendered_pages {
         let site_directories = site_directories.clone();
         let output_file_path = tokio::task::spawn_blocking(move || {
@@ -174,7 +204,23 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
         info!("...processed {}", output_file_path.display());
     }
 
-    let site_artifacts = build_site_artifacts(article_metas);
+    let mut category_landings = Vec::with_capacity(rendered_categories.len());
+    for rendered_category in rendered_categories {
+        let site_directories = site_directories.clone();
+        let (metadata, output_file_path) = tokio::task::spawn_blocking(move || {
+            let output_file_path = write_category_page(
+                &site_directories,
+                rendered_category.metadata.category,
+                &rendered_category.html,
+            )?;
+            Ok::<_, artifacts::ArtifactsError>((rendered_category.metadata, output_file_path))
+        })
+        .await??;
+        info!("...processed {}", output_file_path.display());
+        category_landings.push(metadata);
+    }
+
+    let site_artifacts = build_site_artifacts(article_metas, category_landings);
     let site_directories_for_write = site_directories.clone();
     let site_artifacts = tokio::task::spawn_blocking(move || {
         write_site_artifacts(&site_directories_for_write, &site_artifacts)?;
@@ -240,6 +286,14 @@ fn process_valid_page_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPage
     })
 }
 
+fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<ParsedCategoryFile> {
+    Ok(ParsedCategoryFile {
+        category: parse_category(&parsed_file.front_matter)?,
+        markdown_body: parsed_file.markdown_body,
+        front_matter: parsed_file.front_matter,
+    })
+}
+
 /// Normalizes a path for use in URLs by converting OS-specific separators to `/`.
 fn normalize_path_for_url(path: &Path) -> String {
     let path_str = path.to_string_lossy();
@@ -294,6 +348,21 @@ fn ensure_unique_page_keys(valid_pages: &[ParsedPageFile]) -> Result<()> {
             return Err(ObsidianError::Parse(format!(
                 "Duplicate page key detected: {}",
                 parsed_page.page.as_str()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_unique_category_landings(valid_categories: &[ParsedCategoryFile]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(valid_categories.len());
+
+    for parsed_category in valid_categories {
+        if !seen.insert(parsed_category.category.as_str()) {
+            return Err(ObsidianError::Parse(format!(
+                "Duplicate category landing detected: {}",
+                parsed_category.category.as_str()
             )));
         }
     }
@@ -375,6 +444,39 @@ async fn render_static_page(
     enrich: BookmarkEnricher,
 ) -> Result<RenderedPage> {
     process_page_file(parsed_file, file_mapping, &enrich).await
+}
+
+async fn process_category_file(
+    parsed_file: ParsedCategoryFile,
+    file_mapping: &FileMapping,
+    enrich: &BookmarkEnricher,
+) -> Result<RenderedCategoryLanding> {
+    let markdown_with_links = convert_obsidian_links(&parsed_file.markdown_body, file_mapping);
+    let html_body = convert_markdown_to_html(&markdown_with_links)?;
+
+    let fallback = html_body.clone();
+    let html_with_rich_bookmarks = enrich(html_body).await.unwrap_or_else(|e| {
+        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
+        fallback
+    });
+
+    Ok(RenderedCategoryLanding {
+        metadata: CategoryLandingMetadata {
+            category: parsed_file.category,
+            title: parsed_file.front_matter.title,
+            description: parsed_file.front_matter.summary,
+            updated_at: parsed_file.front_matter.updated,
+        },
+        html: html_with_rich_bookmarks,
+    })
+}
+
+async fn render_category_landing(
+    parsed_file: ParsedCategoryFile,
+    file_mapping: &FileMapping,
+    enrich: BookmarkEnricher,
+) -> Result<RenderedCategoryLanding> {
+    process_category_file(parsed_file, file_mapping, &enrich).await
 }
 
 fn parse_category(front_matter: &ObsidianFrontMatter) -> Result<Category> {
@@ -514,6 +616,50 @@ mod tests {
 
         let slug = mapping.get("sub/dir/test").unwrap();
         assert!(!slug.is_empty());
+    }
+
+    #[test]
+    fn test_ensure_unique_category_landings_rejects_duplicates() {
+        let valid_categories = vec![
+            ParsedCategoryFile {
+                category: Category::Tech,
+                markdown_body: "# Tech".to_string(),
+                front_matter: ObsidianFrontMatter {
+                    title: "Tech".to_string(),
+                    kind: ContentKind::Category,
+                    tags: None,
+                    summary: None,
+                    is_completed: true,
+                    priority: None,
+                    created: "2025-01-01T00:00:00+09:00".to_string(),
+                    updated: "2025-01-01T00:00:00+09:00".to_string(),
+                    category: Some("tech".to_string()),
+                    page: None,
+                },
+            },
+            ParsedCategoryFile {
+                category: Category::Tech,
+                markdown_body: "# Tech again".to_string(),
+                front_matter: ObsidianFrontMatter {
+                    title: "Tech Again".to_string(),
+                    kind: ContentKind::Category,
+                    tags: None,
+                    summary: None,
+                    is_completed: true,
+                    priority: None,
+                    created: "2025-01-01T00:00:00+09:00".to_string(),
+                    updated: "2025-01-01T00:00:00+09:00".to_string(),
+                    category: Some("tech".to_string()),
+                    page: None,
+                },
+            },
+        ];
+
+        let result = ensure_unique_category_landings(&valid_categories);
+
+        assert!(
+            matches!(result, Err(ObsidianError::Parse(message)) if message.contains("Duplicate category landing"))
+        );
     }
 
     #[test]

--- a/crates/publish/publisher/tests/e2e_test.rs
+++ b/crates/publish/publisher/tests/e2e_test.rs
@@ -334,7 +334,7 @@ async fn test_end_to_end_obsidian_processing() {
     assert!(article_index.contains(&memory_slug));
 
     let tech_category_index =
-        fs::read_to_string(site_root.join("categories").join("tech.json")).unwrap();
+        fs::read_to_string(site_root.join("categories").join("tech").join("index.json")).unwrap();
     assert!(tech_category_index.contains("\"category\": \"tech\""));
 
     let site_metadata = fs::read_to_string(site_root.join("metadata").join("site.json")).unwrap();

--- a/crates/publish/publisher/tests/integration_test.rs
+++ b/crates/publish/publisher/tests/integration_test.rs
@@ -183,6 +183,78 @@ async fn test_run_main_with_static_page_file() {
     assert!(page_document.contains("This page is generated from markdown."));
 }
 
+#[tokio::test]
+async fn test_run_main_with_category_landing_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let obsidian_dir = temp_dir.path().join("obsidian");
+    let output_dir = temp_dir.path().join("dist");
+
+    fs::create_dir_all(obsidian_dir.join("tech")).unwrap();
+
+    let article_content = indoc! {r#"
+        ---
+        title: "Rust Intro"
+        summary: "Rust article"
+        created: "2025-01-01T00:00:00+09:00"
+        updated: "2025-01-01T00:00:00+09:00"
+        is_completed: true
+        category: "tech"
+        ---
+
+        # Rust Intro
+
+        Article content.
+    "#};
+    let category_content = indoc! {r#"
+        ---
+        title: "Tech"
+        kind: category
+        category: tech
+        summary: "Technology landing"
+        created: "2025-01-01T00:00:00+09:00"
+        updated: "2025-01-01T00:00:00+09:00"
+        is_completed: true
+        ---
+
+        # Tech
+
+        Welcome to the category landing page.
+    "#};
+
+    fs::write(obsidian_dir.join("tech/article.md"), article_content).unwrap();
+    fs::write(obsidian_dir.join("tech/index.md"), category_content).unwrap();
+
+    let config = Config {
+        obsidian_dir,
+        output_dir: output_dir.clone(),
+    };
+
+    let result = run_main(&config).await;
+    assert!(result.is_ok());
+
+    let category_index = fs::read_to_string(
+        output_dir
+            .join("site")
+            .join("categories")
+            .join("tech")
+            .join("index.json"),
+    )
+    .unwrap();
+    let category_page = fs::read_to_string(
+        output_dir
+            .join("site")
+            .join("categories")
+            .join("tech")
+            .join("page.html"),
+    )
+    .unwrap();
+
+    assert!(category_index.contains("\"category\": \"tech\""));
+    assert!(category_index.contains("\"title\": \"Tech\""));
+    assert!(category_index.contains("\"description\": \"Technology landing\""));
+    assert!(category_page.contains("Welcome to the category landing page."));
+}
+
 #[test]
 fn test_config_validation() {
     // Verify config behavior with a non-existent directory.

--- a/crates/site/infra/src/lib.rs
+++ b/crates/site/infra/src/lib.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::Client;
 use domain::{
-    ArticleIndexDocument, CategoryIndexDocument, PageArtifactDocument, PageKey,
+    ArticleIndexDocument, Category, CategoryIndexDocument, PageArtifactDocument, PageKey,
     SiteMetadataDocument, Slug,
 };
 use std::{
@@ -27,6 +27,7 @@ pub type DynArtifactReader = Arc<dyn ArtifactReader>;
 pub trait ArtifactReader: Send + Sync {
     async fn read_article_index(&self) -> Result<ArticleIndexDocument>;
     async fn read_category_index(&self, category: &str) -> Result<CategoryIndexDocument>;
+    async fn read_category_html(&self, category: &Category) -> Result<String>;
     async fn read_site_metadata(&self) -> Result<SiteMetadataDocument>;
     async fn read_article_html(&self, slug: &Slug) -> Result<String>;
     async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument>;
@@ -68,7 +69,15 @@ impl ArtifactReader for LocalArtifactReader {
     }
 
     async fn read_category_index(&self, category: &str) -> Result<CategoryIndexDocument> {
-        self.read_json(&format!("categories/{category}.json")).await
+        self.read_json(&format!("categories/{category}/index.json"))
+            .await
+    }
+
+    async fn read_category_html(&self, category: &Category) -> Result<String> {
+        Ok(tokio::fs::read_to_string(
+            self.artifact_path(&format!("categories/{}/page.html", category.as_str())),
+        )
+        .await?)
     }
 
     async fn read_site_metadata(&self) -> Result<SiteMetadataDocument> {
@@ -171,7 +180,13 @@ impl ArtifactReader for S3ArtifactReader {
     }
 
     async fn read_category_index(&self, category: &str) -> Result<CategoryIndexDocument> {
-        self.read_json(&format!("categories/{category}.json")).await
+        self.read_json(&format!("categories/{category}/index.json"))
+            .await
+    }
+
+    async fn read_category_html(&self, category: &Category) -> Result<String> {
+        self.read_text(&format!("categories/{}/page.html", category.as_str()))
+            .await
     }
 
     async fn read_site_metadata(&self) -> Result<SiteMetadataDocument> {
@@ -253,7 +268,7 @@ mod tests {
 
     fn write_fixture_site(root: &Path) {
         fs::create_dir_all(root.join("articles")).unwrap();
-        fs::create_dir_all(root.join("categories")).unwrap();
+        fs::create_dir_all(root.join("categories/tech")).unwrap();
         fs::create_dir_all(root.join("metadata")).unwrap();
         fs::create_dir_all(root.join("pages")).unwrap();
 
@@ -276,9 +291,12 @@ mod tests {
         )
         .unwrap();
         fs::write(
-            root.join("categories/tech.json"),
+            root.join("categories/tech/index.json"),
             serde_json::to_string_pretty(&CategoryIndexDocument {
                 category: "tech".to_string(),
+                title: Some("Tech".to_string()),
+                description: Some("Tech landing".to_string()),
+                updated_at: Some("2025-01-01T00:00:00+09:00".to_string()),
                 articles: vec![ArticleSummaryDocument {
                     slug: "intro00000001".to_string(),
                     title: "Intro".to_string(),
@@ -292,6 +310,11 @@ mod tests {
                 }],
             })
             .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            root.join("categories/tech/page.html"),
+            "<article><h1>Tech</h1></article>",
         )
         .unwrap();
         fs::write(
@@ -329,6 +352,7 @@ mod tests {
 
         let document = reader.read_article_index().await.unwrap();
         let category = reader.read_category_index("tech").await.unwrap();
+        let category_html = reader.read_category_html(&Category::Tech).await.unwrap();
         let metadata = reader.read_site_metadata().await.unwrap();
         let html = reader
             .read_article_html(&Slug::new("intro00000001".to_string()).unwrap())
@@ -342,6 +366,8 @@ mod tests {
         assert_eq!(document.articles.len(), 1);
         assert_eq!(document.articles[0].slug, "intro00000001");
         assert_eq!(category.category, "tech");
+        assert_eq!(category.title.as_deref(), Some("Tech"));
+        assert_eq!(category_html, "<article><h1>Tech</h1></article>");
         assert_eq!(metadata.total_articles, 1);
         assert_eq!(html, "<h1>Intro</h1>");
         assert_eq!(page.page.as_str(), "about");

--- a/crates/site/server/src/handlers/api.rs
+++ b/crates/site/server/src/handlers/api.rs
@@ -117,6 +117,8 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(document.category_display_name, "技術");
+        assert_eq!(document.title, "Tech");
+        assert!(document.html.contains("Category landing"));
         assert_eq!(document.articles.len(), 1);
     }
 
@@ -161,7 +163,26 @@ mod tests {
     async fn test_api_router_returns_not_found_for_missing_category_artifact() {
         let temp_dir = TempDir::new().unwrap();
         write_fixture_site(temp_dir.path());
-        fs::remove_file(temp_dir.path().join("categories/tech.json")).unwrap();
+        fs::remove_file(temp_dir.path().join("categories/tech/index.json")).unwrap();
+
+        let response = create_test_router(temp_dir.path())
+            .oneshot(
+                Request::builder()
+                    .uri("/page/categories/tech")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_api_router_returns_not_found_for_missing_category_page_html() {
+        let temp_dir = TempDir::new().unwrap();
+        write_fixture_site(temp_dir.path());
+        fs::remove_file(temp_dir.path().join("categories/tech/page.html")).unwrap();
 
         let response = create_test_router(temp_dir.path())
             .oneshot(

--- a/crates/site/server/src/handlers/api/pages.rs
+++ b/crates/site/server/src/handlers/api/pages.rs
@@ -55,7 +55,11 @@ pub async fn get_category_page(
         .read_category_index(category.as_str())
         .await
         .map_err(map_infra_error)?;
-    let page = build_category_page_document(&category_index)
+    let html = artifact_reader
+        .read_category_html(&category)
+        .await
+        .map_err(map_infra_error)?;
+    let page = build_category_page_document(&category_index, &html)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(page))
@@ -137,7 +141,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(page.category_display_name, "技術");
+        assert_eq!(page.title, "Tech");
+        assert!(page.html.contains("Category landing"));
         assert_eq!(page.articles.len(), 1);
+        assert_eq!(page.sections.len(), 1);
     }
 
     #[tokio::test]
@@ -173,7 +180,22 @@ mod tests {
     async fn test_get_category_page_returns_not_found_when_category_artifact_is_missing() {
         let temp_dir = TempDir::new().unwrap();
         write_fixture_site(temp_dir.path());
-        fs::remove_file(temp_dir.path().join("categories/tech.json")).unwrap();
+        fs::remove_file(temp_dir.path().join("categories/tech/index.json")).unwrap();
+
+        let result = get_category_page(
+            Path("tech".to_string()),
+            Extension(Arc::new(LocalArtifactReader::new(temp_dir.path()))),
+        )
+        .await;
+
+        assert!(matches!(result, Err(StatusCode::NOT_FOUND)));
+    }
+
+    #[tokio::test]
+    async fn test_get_category_page_returns_not_found_when_category_page_html_is_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        write_fixture_site(temp_dir.path());
+        fs::remove_file(temp_dir.path().join("categories/tech/page.html")).unwrap();
 
         let result = get_category_page(
             Path("tech".to_string()),

--- a/crates/site/server/src/test_support.rs
+++ b/crates/site/server/src/test_support.rs
@@ -6,7 +6,7 @@ use std::{fs, path::Path};
 
 pub(crate) fn write_fixture_site(root: &Path) {
     fs::create_dir_all(root.join("articles")).unwrap();
-    fs::create_dir_all(root.join("categories")).unwrap();
+    fs::create_dir_all(root.join("categories/tech")).unwrap();
     fs::create_dir_all(root.join("metadata")).unwrap();
     fs::create_dir_all(root.join("pages")).unwrap();
 
@@ -29,9 +29,12 @@ pub(crate) fn write_fixture_site(root: &Path) {
     )
     .unwrap();
     fs::write(
-        root.join("categories/tech.json"),
+        root.join("categories/tech/index.json"),
         serde_json::to_string_pretty(&CategoryIndexDocument {
             category: "tech".to_string(),
+            title: Some("Tech".to_string()),
+            description: Some("Tech landing".to_string()),
+            updated_at: Some("2025-01-01T00:00:00+09:00".to_string()),
             articles: vec![ArticleSummaryDocument {
                 slug: "sample0000001".to_string(),
                 title: "Sample".to_string(),
@@ -45,6 +48,11 @@ pub(crate) fn write_fixture_site(root: &Path) {
             }],
         })
         .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        root.join("categories/tech/page.html"),
+        "<article><h1>Tech</h1><p>Category landing</p></article>",
     )
     .unwrap();
     fs::write(

--- a/crates/site/web/src/routes/about.rs
+++ b/crates/site/web/src/routes/about.rs
@@ -3,7 +3,9 @@ use crate::routes::not_found::NotFoundPage;
 use crate::{SITE_NAME, build_site_url};
 #[cfg(feature = "ssr")]
 use axum::http::StatusCode;
-use domain::{PageKey, StaticPageDocument};
+#[cfg(feature = "ssr")]
+use domain::PageKey;
+use domain::StaticPageDocument;
 use domain::{
     build_static_page_canonical_path, build_static_page_description, build_static_page_title,
 };

--- a/crates/site/web/src/routes/category.module.scss
+++ b/crates/site/web/src/routes/category.module.scss
@@ -44,6 +44,21 @@
     gap: 1rem;
 }
 
+.section-list {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.section-group {
+    display: grid;
+    gap: 1rem;
+}
+
+.section-heading {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
 .article-card {
     display: flex;
     flex-direction: column;
@@ -66,6 +81,25 @@
 .article-description {
     line-height: 1.8;
     color: var(--color-text-soft);
+}
+
+.landing-content {
+    padding: 1.5rem;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+}
+
+.landing-content :global(*) {
+    max-width: 100%;
+}
+
+.landing-content :global(:first-child) {
+    margin-top: 0;
+}
+
+.landing-content :global(:last-child) {
+    margin-bottom: 0;
 }
 
 .loading,

--- a/crates/site/web/src/routes/category.module.scss
+++ b/crates/site/web/src/routes/category.module.scss
@@ -94,11 +94,11 @@
     max-width: 100%;
 }
 
-.landing-content :global(:first-child) {
+.landing-content :global(> :first-child) {
     margin-top: 0;
 }
 
-.landing-content :global(:last-child) {
+.landing-content :global(> :last-child) {
     margin-bottom: 0;
 }
 

--- a/crates/site/web/src/routes/category.rs
+++ b/crates/site/web/src/routes/category.rs
@@ -64,10 +64,13 @@ fn CategoryPageContent(document: CategoryPageDocument) -> impl IntoView {
     let page_title = build_category_page_title(&document, SITE_NAME);
     let page_description: Arc<str> = build_category_page_description(&document).into();
     let canonical_url = build_site_url(&build_category_page_canonical_path(&document));
-    let title = document.title.clone();
-    let landing_html = document.html.clone();
-    let section_items = document
-        .sections
+    let CategoryPageDocument {
+        title,
+        html: landing_html,
+        sections,
+        ..
+    } = document;
+    let section_items = sections
         .into_iter()
         .map(|section| {
             let section_heading = section.heading;

--- a/crates/site/web/src/routes/category.rs
+++ b/crates/site/web/src/routes/category.rs
@@ -41,8 +41,13 @@ pub async fn get_category_page_document(
             Err(error) if error.is_not_found() => return Ok(None),
             Err(error) => return Err(error.into()),
         };
+        let html = match artifact_reader.read_category_html(&category).await {
+            Ok(html) => html,
+            Err(error) if error.is_not_found() => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
 
-        Ok(Some(build_category_page_document(&category_index)?))
+        Ok(Some(build_category_page_document(&category_index, &html)?))
     }
 
     #[cfg(not(feature = "ssr"))]
@@ -59,28 +64,43 @@ fn CategoryPageContent(document: CategoryPageDocument) -> impl IntoView {
     let page_title = build_category_page_title(&document, SITE_NAME);
     let page_description: Arc<str> = build_category_page_description(&document).into();
     let canonical_url = build_site_url(&build_category_page_canonical_path(&document));
-    let title = document.category_display_name;
-    let article_items = document
-        .articles
+    let title = document.title.clone();
+    let landing_html = document.html.clone();
+    let section_items = document
+        .sections
         .into_iter()
-        .map(|article| {
-            let href = format!("/articles/{}", article.slug.as_str());
-            let title = article.title.as_str().to_string();
-            let description = article
-                .description
-                .unwrap_or_else(|| "説明はまだありません。".to_string());
-            let updated_at = article.updated_at;
+        .map(|section| {
+            let section_heading = section.heading;
+            let article_items = section
+                .articles
+                .into_iter()
+                .map(|article| {
+                    let href = format!("/articles/{}", article.slug.as_str());
+                    let title = article.title.as_str().to_string();
+                    let description = article
+                        .description
+                        .unwrap_or_else(|| "説明はまだありません。".to_string());
+                    let updated_at = article.updated_at;
+
+                    view! {
+                        <article class=category_style::article_card>
+                            <h3 class=category_style::article_title>
+                                <A href={href} {..} class=category_style::article_link>
+                                    {title}
+                                </A>
+                            </h3>
+                            <p class=category_style::article_description>{description}</p>
+                            <p class=category_style::article_meta>{format!("更新 {}", updated_at)}</p>
+                        </article>
+                    }
+                })
+                .collect_view();
 
             view! {
-                <article class=category_style::article_card>
-                    <h2 class=category_style::article_title>
-                        <A href={href} {..} class=category_style::article_link>
-                            {title}
-                        </A>
-                    </h2>
-                    <p class=category_style::article_description>{description}</p>
-                    <p class=category_style::article_meta>{format!("更新 {}", updated_at)}</p>
-                </article>
+                <section class=category_style::section_group>
+                    <h2 class=category_style::section_heading>{section_heading}</h2>
+                    <div class=category_style::article_list>{article_items}</div>
+                </section>
             }
         })
         .collect_view();
@@ -95,7 +115,10 @@ fn CategoryPageContent(document: CategoryPageDocument) -> impl IntoView {
                 <p class=category_style::category_description>{page_description}</p>
             </header>
 
-            <section class=category_style::article_list>{article_items}</section>
+            // Publisher artifacts escape raw HTML and neutralize unsafe links before persistence.
+            <section class=category_style::landing_content inner_html=landing_html></section>
+
+            <div class=category_style::section_list>{section_items}</div>
         </div>
     }
 }

--- a/crates/site/web/src/routes/category.rs
+++ b/crates/site/web/src/routes/category.rs
@@ -114,7 +114,7 @@ fn CategoryPageContent(document: CategoryPageDocument) -> impl IntoView {
         <div class=category_style::category_page>
             <header class=category_style::category_header>
                 <p class=category_style::eyebrow>{"Category"}</p>
-                <h1 class=category_style::category_title>{title}</h1>
+                <p class=category_style::category_title>{title}</p>
                 <p class=category_style::category_description>{page_description}</p>
             </header>
 

--- a/docs/architecture/re-architecture.md
+++ b/docs/architecture/re-architecture.md
@@ -376,10 +376,12 @@ site/
 │   ├── <slug>.html
 │   └── index.json
 ├── categories/
-│   ├── tech.json
-│   ├── daily.json
-│   ├── statistics.json
-│   └── physics.json
+│   ├── <category>/
+│   │   ├── index.json
+│   │   └── page.html
+│   └── ...
+├── pages/
+│   └── <page>.json
 ├── tags/
 │   └── index.json
 ├── assets/


### PR DESCRIPTION
## Summary
- add `kind=category` handling to publisher and generate nested category artifacts
- store category landing metadata in `index.json` and body HTML in `page.html`
- update site infra/server/web to read and render category landing pages with section-based grouping

## Testing
- `cargo test -p domain -p artifacts -p infra -p publisher -p server`
- `cargo check -p web --features ssr`
- `cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate`
- `cargo clippy -p domain -p artifacts -p infra -p publisher -p server -p web --all-targets -- -D warnings`
- `cargo check --workspace`

## Notes
- local submodule drift in `crates/publish/publisher/obsidian` is intentionally not included in this PR
- route migration to `/:category` and `/:category/:slug` is left for the next Phase 3 slice