### PR TITLE
feat: migrate site routes to category slug paths

### DIFF
--- a/crates/domain/src/site_page.rs
+++ b/crates/domain/src/site_page.rs
@@ -104,6 +104,14 @@ pub fn build_home_page_canonical_path() -> &'static str {
     "/"
 }
 
+pub fn build_category_path(category: &Category) -> String {
+    format!("/{}", category.as_str())
+}
+
+pub fn build_article_path(category: &Category, slug: &Slug) -> String {
+    format!("{}/{}", build_category_path(category), slug.as_str())
+}
+
 pub fn build_article_page_title(document: &ArticlePageDocument, site_name: &str) -> String {
     format!("{} | {}", document.article.title.as_str(), site_name)
 }
@@ -124,7 +132,7 @@ pub fn build_article_page_description(document: &ArticlePageDocument) -> String 
 }
 
 pub fn build_article_page_canonical_path(document: &ArticlePageDocument) -> String {
-    format!("/articles/{}", document.article.slug.as_str())
+    build_article_path(&document.article.category, &document.article.slug)
 }
 
 pub fn build_category_page_title(document: &CategoryPageDocument, site_name: &str) -> String {
@@ -147,7 +155,7 @@ pub fn build_category_page_description(document: &CategoryPageDocument) -> Strin
 }
 
 pub fn build_category_page_canonical_path(document: &CategoryPageDocument) -> String {
-    format!("/categories/{}", document.category.as_str())
+    build_category_path(&document.category)
 }
 
 pub fn build_static_page_title(document: &StaticPageDocument, site_name: &str) -> String {
@@ -266,12 +274,13 @@ pub fn build_static_page_document(artifact: &PageArtifactDocument) -> Result<Sta
 
 pub fn find_article_summary<'a>(
     article_index: &'a ArticleIndexDocument,
+    category: &Category,
     slug: &Slug,
 ) -> Option<&'a ArticleSummaryDocument> {
     article_index
         .articles
         .iter()
-        .find(|article| article.slug == slug.as_str())
+        .find(|article| article.slug == slug.as_str() && article.category == category.as_str())
 }
 
 fn build_category_section_groups(articles: &[SiteArticleCard]) -> Vec<CategorySectionGroup> {
@@ -432,9 +441,10 @@ mod tests {
         let index = ArticleIndexDocument {
             articles: vec![sample_summary()],
         };
+        let category = Category::Tech;
         let slug = Slug::new("intro00000001".to_string()).unwrap();
 
-        let article = find_article_summary(&index, &slug).unwrap();
+        let article = find_article_summary(&index, &category, &slug).unwrap();
 
         assert_eq!(article.title, "Intro");
     }
@@ -482,7 +492,7 @@ mod tests {
         assert_eq!(build_article_page_description(&document), "summary");
         assert_eq!(
             build_article_page_canonical_path(&document),
-            "/articles/intro00000001"
+            "/tech/intro00000001"
         );
     }
 
@@ -539,10 +549,7 @@ mod tests {
             "Rust | ぶくせんの探窟メモ"
         );
         assert_eq!(build_category_page_description(&document), "Rust articles");
-        assert_eq!(
-            build_category_page_canonical_path(&document),
-            "/categories/tech"
-        );
+        assert_eq!(build_category_page_canonical_path(&document), "/tech");
     }
 
     #[test]

--- a/crates/publish/artifacts/src/lib.rs
+++ b/crates/publish/artifacts/src/lib.rs
@@ -107,12 +107,13 @@ pub fn build_site_artifacts(
 
 pub fn write_article_page(
     site_directories: &SiteDirectories,
+    category: Category,
     slug: &Slug,
     html: &str,
 ) -> Result<PathBuf> {
-    let output_file_path = site_directories
-        .articles_dir
-        .join(format!("{}.html", slug.as_str()));
+    let article_dir = site_directories.articles_dir.join(category.as_str());
+    fs::create_dir_all(&article_dir)?;
+    let output_file_path = article_dir.join(format!("{}.html", slug.as_str()));
     fs::write(&output_file_path, html)?;
     Ok(output_file_path)
 }
@@ -287,6 +288,7 @@ mod tests {
 
         let article_path = write_article_page(
             &site_directories,
+            Category::Tech,
             &article_meta.slug,
             "<h1>Artifact Test</h1>",
         )
@@ -296,6 +298,13 @@ mod tests {
         write_site_artifacts(&site_directories, &site_artifacts).unwrap();
 
         assert!(article_path.exists());
+        assert_eq!(
+            article_path,
+            site_directories
+                .articles_dir
+                .join("tech")
+                .join("artifact00001.html")
+        );
         assert!(category_page_path.exists());
         assert!(
             site_directories.articles_dir.join("index.json").exists(),

--- a/crates/publish/ingest/src/converter.rs
+++ b/crates/publish/ingest/src/converter.rs
@@ -20,12 +20,8 @@ static SAFE_BOOKMARK_RE: LazyLock<Regex> = LazyLock::new(|| {
 static HREF_ATTR_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"href="([^"]*)""#).expect("Invalid href regex"));
 
-/// Mapping from an Obsidian file path without extension to a published slug.
+/// Mapping from an Obsidian file path without extension to a published article href.
 pub type FileMapping = HashMap<String, String>;
-
-fn generate_article_href(slug: &str) -> String {
-    format!("/articles/{slug}")
-}
 
 pub fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
     let mut options = Options::empty();
@@ -229,15 +225,15 @@ pub fn convert_obsidian_links(content: &str, file_mapping: &FileMapping) -> Stri
                 (link_content.trim(), link_content.trim())
             };
 
-            let href = if let Some(slug) = file_mapping.get(link_target) {
-                generate_article_href(slug)
+            let href = if let Some(href) = file_mapping.get(link_target) {
+                href.clone()
             } else {
                 let mut found = false;
                 let mut result_href = format!("/{link_target}");
 
-                for (key, slug) in file_mapping {
+                for (key, href) in file_mapping {
                     if key.ends_with(&format!("/{link_target}")) || key == link_target {
-                        result_href = generate_article_href(slug);
+                        result_href = href.clone();
                         found = true;
                         break;
                     }
@@ -308,24 +304,24 @@ mod tests {
     #[rstest]
     fn test_obsidian_links_conversion() {
         let mut file_mapping = FileMapping::new();
-        file_mapping.insert("notes/another-note".to_string(), "abc123def".to_string());
-        file_mapping.insert("docs/filename".to_string(), "xyz789abc".to_string());
-        file_mapping.insert("Another Note".to_string(), "abc123def".to_string());
-        file_mapping.insert("filename".to_string(), "xyz789abc".to_string());
+        file_mapping.insert(
+            "notes/another-note".to_string(),
+            "/tech/abc123def".to_string(),
+        );
+        file_mapping.insert("docs/filename".to_string(), "/daily/xyz789abc".to_string());
+        file_mapping.insert("Another Note".to_string(), "/tech/abc123def".to_string());
+        file_mapping.insert("filename".to_string(), "/daily/xyz789abc".to_string());
 
         let result =
             convert_obsidian_links("Check out [[Another Note]] for more info.", &file_mapping);
         assert_eq!(
             result,
-            "Check out [Another Note](/articles/abc123def) for more info."
+            "Check out [Another Note](/tech/abc123def) for more info."
         );
 
         let result =
             convert_obsidian_links("See [[filename|Custom Display Text]] here.", &file_mapping);
-        assert_eq!(
-            result,
-            "See [Custom Display Text](/articles/xyz789abc) here."
-        );
+        assert_eq!(result, "See [Custom Display Text](/daily/xyz789abc) here.");
 
         let result = convert_obsidian_links("Link to [[nonexistent]] file.", &file_mapping);
         assert_eq!(result, "Link to [nonexistent](/nonexistent) file.");
@@ -367,15 +363,15 @@ This is a test with [[Another Article|link]] and **bold** text.
 - Regular item"#;
 
         let mut file_mapping = FileMapping::new();
-        file_mapping.insert("Another Article".to_string(), "def456".to_string());
-        file_mapping.insert("Reference Note".to_string(), "ghi789".to_string());
+        file_mapping.insert("Another Article".to_string(), "/tech/def456".to_string());
+        file_mapping.insert("Reference Note".to_string(), "/daily/ghi789".to_string());
 
         let with_html_links = convert_obsidian_links(markdown_with_obsidian_links, &file_mapping);
         let html = convert_markdown_to_html(&with_html_links).unwrap();
 
         assert!(html.contains("<h1>My Article</h1>"));
-        assert!(html.contains("<a href=\"/articles/def456\">link</a>"));
-        assert!(html.contains("<a href=\"/articles/ghi789\">Reference Note</a>"));
+        assert!(html.contains("<a href=\"/tech/def456\">link</a>"));
+        assert!(html.contains("<a href=\"/daily/ghi789\">Reference Note</a>"));
         assert!(html.contains("<strong>bold</strong>"));
         assert!(html.contains("<ul>"));
     }
@@ -401,10 +397,10 @@ This is a test with [[Another Article|link]] and **bold** text.
     #[rstest]
     fn test_markdown_link_escaping() {
         let mut file_mapping = FileMapping::new();
-        file_mapping.insert("File with <script>".to_string(), "abc123".to_string());
+        file_mapping.insert("File with <script>".to_string(), "/tech/abc123".to_string());
 
         let result = convert_obsidian_links("[[File with <script>|Display & test]]", &file_mapping);
-        assert_eq!(result, "[Display & test](/articles/abc123)");
+        assert_eq!(result, "[Display & test](/tech/abc123)");
 
         let result =
             convert_obsidian_links("[[File \"quoted\"|Text with 'quotes']]", &file_mapping);

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -48,6 +48,7 @@ struct RenderedCategoryLanding {
 }
 
 struct ParsedArticleFile {
+    category: Category,
     slug: String,
     mapping_key: String,
     section_path: Vec<String>,
@@ -164,6 +165,7 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
                 let (rendered_article, output_file_path) = tokio::task::spawn_blocking(move || {
                     let output_file_path = write_article_page(
                         &site_directories,
+                        rendered_article.meta.category,
                         &rendered_article.meta.slug,
                         &rendered_article.html,
                     )?;
@@ -265,11 +267,13 @@ fn process_valid_article_file(
         relative_path,
         &parsed_file.front_matter.created,
     )?;
+    let category = parse_category(&parsed_file.front_matter)?;
     let mapping_key = normalize_path_for_url(&relative_path.with_extension(""));
     let section_path =
         derive_section_path(relative_path, parsed_file.front_matter.category.as_deref());
 
     Ok(ParsedArticleFile {
+        category,
         slug,
         mapping_key,
         section_path,
@@ -314,7 +318,10 @@ fn build_file_mapping(valid_files: &[ParsedArticleFile]) -> FileMapping {
     let mut mapping = FileMapping::with_capacity(valid_files.len());
 
     for parsed_file in valid_files {
-        mapping.insert(parsed_file.mapping_key.clone(), parsed_file.slug.clone());
+        mapping.insert(
+            parsed_file.mapping_key.clone(),
+            format!("/{}/{}", parsed_file.category.as_str(), parsed_file.slug),
+        );
     }
 
     mapping
@@ -385,11 +392,10 @@ async fn process_parsed_file(
         fallback
     });
 
-    let category = parse_category(&parsed_file.front_matter)?;
     let meta = ArticleMeta::new(ArticleMetaInput {
         slug: Slug::new(parsed_file.slug)?,
         title: Title::new(parsed_file.front_matter.title)?,
-        category,
+        category: parsed_file.category,
         section_path: parsed_file.section_path,
         description: parsed_file.front_matter.summary,
         tags: parsed_file.front_matter.tags.unwrap_or_default(),
@@ -556,6 +562,7 @@ mod tests {
         };
 
         let parsed_file = ParsedArticleFile {
+            category: Category::Tech,
             slug: "slug".to_string(),
             mapping_key: "test".to_string(),
             section_path: vec![],
@@ -567,6 +574,7 @@ mod tests {
 
         assert_eq!(mapping.len(), 1);
         assert!(mapping.contains_key("test"));
+        assert_eq!(mapping.get("test").unwrap(), "/tech/slug");
     }
 
     #[rstest]
@@ -601,11 +609,12 @@ mod tests {
             created: "2025-01-03T00:00:00+09:00".to_string(),
             updated: "2025-01-04T00:00:00+09:00".to_string(),
             is_completed: true,
-            category: Some("blog".to_string()),
+            category: Some("daily".to_string()),
             page: None,
         };
 
         let parsed_file1 = ParsedArticleFile {
+            category: Category::Tech,
             slug: "slug1".to_string(),
             mapping_key: "dir1/test".to_string(),
             section_path: vec!["dir1".to_string()],
@@ -613,6 +622,7 @@ mod tests {
             front_matter: front_matter1,
         };
         let parsed_file2 = ParsedArticleFile {
+            category: Category::Daily,
             slug: "slug2".to_string(),
             mapping_key: "dir2/test".to_string(),
             section_path: vec!["dir2".to_string()],
@@ -639,11 +649,12 @@ mod tests {
             created: "2025-01-01T00:00:00+09:00".to_string(),
             updated: "2025-01-01T00:00:00+09:00".to_string(),
             is_completed: true,
-            category: None,
+            category: Some("tech".to_string()),
             page: None,
         };
 
         let parsed_file = ParsedArticleFile {
+            category: Category::Tech,
             slug: "slug".to_string(),
             mapping_key: "sub/dir/test".to_string(),
             section_path: vec!["sub".to_string(), "dir".to_string()],
@@ -653,8 +664,8 @@ mod tests {
         let valid_files = vec![parsed_file];
         let mapping = build_file_mapping(&valid_files);
 
-        let slug = mapping.get("sub/dir/test").unwrap();
-        assert!(!slug.is_empty());
+        let href = mapping.get("sub/dir/test").unwrap();
+        assert_eq!(href, "/tech/slug");
     }
 
     #[test]

--- a/crates/publish/publisher/tests/e2e_test.rs
+++ b/crates/publish/publisher/tests/e2e_test.rs
@@ -1,27 +1,10 @@
+mod support;
+
 use indoc::indoc;
 use publisher::{Config, run_main, slug};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::Path};
+use support::collect_html_files;
 use tempfile::TempDir;
-
-fn collect_html_files(root: &Path) -> Vec<PathBuf> {
-    let mut html_files = Vec::new();
-
-    if let Ok(entries) = fs::read_dir(root) {
-        for entry in entries.filter_map(Result::ok) {
-            let path = entry.path();
-            if path.is_dir() {
-                html_files.extend(collect_html_files(&path));
-            } else if path.extension().is_some_and(|ext| ext == "html") {
-                html_files.push(path);
-            }
-        }
-    }
-
-    html_files
-}
 
 /// End-to-end test that simulates a realistic Obsidian vault.
 #[tokio::test]

--- a/crates/publish/publisher/tests/e2e_test.rs
+++ b/crates/publish/publisher/tests/e2e_test.rs
@@ -1,7 +1,27 @@
 use indoc::indoc;
 use publisher::{Config, run_main, slug};
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use tempfile::TempDir;
+
+fn collect_html_files(root: &Path) -> Vec<PathBuf> {
+    let mut html_files = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                html_files.extend(collect_html_files(&path));
+            } else if path.extension().is_some_and(|ext| ext == "html") {
+                html_files.push(path);
+            }
+        }
+    }
+
+    html_files
+}
 
 /// End-to-end test that simulates a realistic Obsidian vault.
 #[tokio::test]
@@ -223,9 +243,11 @@ async fn test_end_to_end_obsidian_processing() {
 
     let site_root = output_dir.join("site");
     let articles_dir = site_root.join("articles");
-    let _tech_html = articles_dir.join(format!("{tech_slug}.html"));
-    let _basic_html = articles_dir.join(format!("{basic_slug}.html"));
-    let _memory_html = articles_dir.join(format!("{memory_slug}.html"));
+    let _tech_html = articles_dir.join("tech").join(format!("{tech_slug}.html"));
+    let _basic_html = articles_dir.join("tech").join(format!("{basic_slug}.html"));
+    let _memory_html = articles_dir
+        .join("tech")
+        .join(format!("{memory_slug}.html"));
 
     // Draft article slug. No HTML should be generated because `is_completed` is false.
     let blog_slug = slug::generate_slug(
@@ -234,17 +256,10 @@ async fn test_end_to_end_obsidian_processing() {
         "2025-01-20T20:00:00+09:00",
     )
     .unwrap();
-    let blog_html = articles_dir.join(format!("{blog_slug}.html"));
+    let blog_html = articles_dir.join("blog").join(format!("{blog_slug}.html"));
 
     // Check that completed articles produced HTML by counting files.
-    let mut html_count = 0;
-
-    if let Ok(entries) = fs::read_dir(&articles_dir) {
-        html_count = entries
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "html"))
-            .count();
-    }
+    let html_count = collect_html_files(&articles_dir).len();
 
     // Expected files: two technical articles plus one foundational article.
     assert_eq!(html_count, 3, "Should generate 3 published articles");
@@ -259,19 +274,13 @@ async fn test_end_to_end_obsidian_processing() {
     let mut performance_file_found = false;
     let mut memory_file_found = false;
 
-    if let Ok(entries) = fs::read_dir(&articles_dir) {
-        let files: Vec<_> = entries
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "html"))
-            .collect();
-        println!(
-            "Found HTML files in site/articles: {:?}",
-            files.iter().map(|f| f.path()).collect::<Vec<_>>()
-        );
+    let files = collect_html_files(&articles_dir);
+    if !files.is_empty() {
+        println!("Found HTML files in site/articles: {:?}", files);
 
         for file in files {
-            if let Ok(content) = fs::read_to_string(file.path()) {
-                println!("Checking file: {:?}", file.path());
+            if let Ok(content) = fs::read_to_string(&file) {
+                println!("Checking file: {:?}", file);
 
                 // Safe string slice.
                 let preview_len = content
@@ -311,15 +320,12 @@ async fn test_end_to_end_obsidian_processing() {
     // Verify KaTeX math rendering.
     let mut math_processing_verified = false;
 
-    if let Ok(entries) = fs::read_dir(&articles_dir) {
-        for entry in entries.filter_map(|e| e.ok()) {
-            if entry.path().extension().is_some_and(|ext| ext == "html")
-                && let Ok(content) = fs::read_to_string(entry.path())
-                && content.contains("<div class=\"katex-display\">")
-                && content.contains("<span class=\"katex-inline\">")
-            {
-                math_processing_verified = true;
-            }
+    for path in collect_html_files(&articles_dir) {
+        if let Ok(content) = fs::read_to_string(path)
+            && content.contains("<div class=\"katex-display\">")
+            && content.contains("<span class=\"katex-inline\">")
+        {
+            math_processing_verified = true;
         }
     }
 
@@ -342,11 +348,7 @@ async fn test_end_to_end_obsidian_processing() {
 
     println!(
         "✅ End-to-end test finished: generated {} HTML files",
-        fs::read_dir(&articles_dir)
-            .unwrap()
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "html"))
-            .count()
+        collect_html_files(&articles_dir).len()
     );
 }
 
@@ -424,11 +426,7 @@ async fn test_large_volume_processing() {
     assert!(result.is_ok(), "Large volume processing should succeed");
 
     // Verify the number of generated files.
-    let generated_count = fs::read_dir(output_dir.join("site").join("articles"))
-        .unwrap()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "html"))
-        .count();
+    let generated_count = collect_html_files(&output_dir.join("site").join("articles")).len();
 
     assert_eq!(generated_count, 100, "Should generate 100 HTML files");
 
@@ -530,6 +528,7 @@ async fn test_partial_failure_handling() {
     let valid_html = output_dir
         .join("site")
         .join("articles")
+        .join("tech")
         .join(format!("{valid_slug}.html"));
     assert!(valid_html.exists(), "Valid file should be processed");
 
@@ -543,6 +542,7 @@ async fn test_partial_failure_handling() {
     let invalid_html = output_dir
         .join("site")
         .join("articles")
+        .join("tech")
         .join(format!("{invalid_slug}.html"));
     assert!(
         !invalid_html.exists(),
@@ -553,6 +553,7 @@ async fn test_partial_failure_handling() {
     let incomplete_html = output_dir
         .join("site")
         .join("articles")
+        .join("tech")
         .join("incomplete.html");
     assert!(
         !incomplete_html.exists(),

--- a/crates/publish/publisher/tests/integration_test.rs
+++ b/crates/publish/publisher/tests/integration_test.rs
@@ -1,8 +1,25 @@
 use indoc::indoc;
 use publisher::{Config, offline_bookmark_enricher, run_main, run_with_enricher};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+fn collect_html_files(root: &Path) -> Vec<PathBuf> {
+    let mut html_files = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                html_files.extend(collect_html_files(&path));
+            } else if path.extension().is_some_and(|ext| ext == "html") {
+                html_files.push(path);
+            }
+        }
+    }
+
+    html_files
+}
 
 #[tokio::test]
 async fn test_run_main_with_empty_directory() {
@@ -68,12 +85,7 @@ async fn test_run_main_with_sample_file() {
     let site_root = output_dir.join("site");
     let articles_dir = site_root.join("articles");
 
-    // Verify that at least one slug-based HTML file was generated.
-    let html_files: Vec<_> = fs::read_dir(&articles_dir)
-        .unwrap()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "html"))
-        .collect();
+    let html_files = collect_html_files(&articles_dir);
 
     assert!(
         !html_files.is_empty(),
@@ -81,8 +93,7 @@ async fn test_run_main_with_sample_file() {
     );
 
     // Verify the generated HTML content.
-    let html_file = &html_files[0];
-    let html_content = fs::read_to_string(html_file.path()).unwrap();
+    let html_content = fs::read_to_string(&html_files[0]).unwrap();
     assert!(html_content.contains("Test Article"));
     assert!(html_content.contains("This is a test article"));
 
@@ -136,6 +147,7 @@ async fn test_run_main_with_incomplete_file() {
     let html_file = output_dir
         .join("site")
         .join("articles")
+        .join("tech")
         .join("incomplete.html");
     assert!(!html_file.exists());
 }
@@ -311,15 +323,11 @@ async fn test_run_with_enricher_with_bookmark_article() {
     assert!(result.is_ok());
 
     let articles_dir = output_dir.join("site").join("articles");
-    let html_files: Vec<_> = fs::read_dir(&articles_dir)
-        .unwrap()
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "html"))
-        .collect();
+    let html_files = collect_html_files(&articles_dir);
 
     assert!(!html_files.is_empty(), "HTML file should be generated");
 
-    let html_content = fs::read_to_string(html_files[0].path()).unwrap();
+    let html_content = fs::read_to_string(&html_files[0]).unwrap();
 
     // The bookmark should NOT remain as escaped HTML.
     assert!(

--- a/crates/publish/publisher/tests/integration_test.rs
+++ b/crates/publish/publisher/tests/integration_test.rs
@@ -1,25 +1,11 @@
+mod support;
+
 use indoc::indoc;
 use publisher::{Config, offline_bookmark_enricher, run_main, run_with_enricher};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+use support::collect_html_files;
 use tempfile::TempDir;
-
-fn collect_html_files(root: &Path) -> Vec<PathBuf> {
-    let mut html_files = Vec::new();
-
-    if let Ok(entries) = fs::read_dir(root) {
-        for entry in entries.filter_map(Result::ok) {
-            let path = entry.path();
-            if path.is_dir() {
-                html_files.extend(collect_html_files(&path));
-            } else if path.extension().is_some_and(|ext| ext == "html") {
-                html_files.push(path);
-            }
-        }
-    }
-
-    html_files
-}
 
 #[tokio::test]
 async fn test_run_main_with_empty_directory() {

--- a/crates/publish/publisher/tests/support.rs
+++ b/crates/publish/publisher/tests/support.rs
@@ -1,0 +1,21 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+pub fn collect_html_files(root: &Path) -> Vec<PathBuf> {
+    let mut html_files = Vec::new();
+
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if path.is_dir() {
+                html_files.extend(collect_html_files(&path));
+            } else if path.extension().is_some_and(|ext| ext == "html") {
+                html_files.push(path);
+            }
+        }
+    }
+
+    html_files
+}

--- a/crates/site/infra/src/lib.rs
+++ b/crates/site/infra/src/lib.rs
@@ -29,7 +29,7 @@ pub trait ArtifactReader: Send + Sync {
     async fn read_category_index(&self, category: &str) -> Result<CategoryIndexDocument>;
     async fn read_category_html(&self, category: &Category) -> Result<String>;
     async fn read_site_metadata(&self) -> Result<SiteMetadataDocument>;
-    async fn read_article_html(&self, slug: &Slug) -> Result<String>;
+    async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String>;
     async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument>;
 }
 
@@ -84,10 +84,12 @@ impl ArtifactReader for LocalArtifactReader {
         self.read_json("metadata/site.json").await
     }
 
-    async fn read_article_html(&self, slug: &Slug) -> Result<String> {
-        Ok(tokio::fs::read_to_string(
-            self.artifact_path(&format!("articles/{}.html", slug.as_str())),
-        )
+    async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String> {
+        Ok(tokio::fs::read_to_string(self.artifact_path(&format!(
+            "articles/{}/{}.html",
+            category.as_str(),
+            slug.as_str()
+        )))
         .await?)
     }
 
@@ -193,9 +195,13 @@ impl ArtifactReader for S3ArtifactReader {
         self.read_json("metadata/site.json").await
     }
 
-    async fn read_article_html(&self, slug: &Slug) -> Result<String> {
-        self.read_text(&format!("articles/{}.html", slug.as_str()))
-            .await
+    async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String> {
+        self.read_text(&format!(
+            "articles/{}/{}.html",
+            category.as_str(),
+            slug.as_str()
+        ))
+        .await
     }
 
     async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {
@@ -329,7 +335,12 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
-        fs::write(root.join("articles/intro00000001.html"), "<h1>Intro</h1>").unwrap();
+        fs::create_dir_all(root.join("articles/tech")).unwrap();
+        fs::write(
+            root.join("articles/tech/intro00000001.html"),
+            "<h1>Intro</h1>",
+        )
+        .unwrap();
         fs::write(
             root.join("pages/about.json"),
             serde_json::to_string_pretty(&PageArtifactDocument {
@@ -355,7 +366,10 @@ mod tests {
         let category_html = reader.read_category_html(&Category::Tech).await.unwrap();
         let metadata = reader.read_site_metadata().await.unwrap();
         let html = reader
-            .read_article_html(&Slug::new("intro00000001".to_string()).unwrap())
+            .read_article_html(
+                &Category::Tech,
+                &Slug::new("intro00000001".to_string()).unwrap(),
+            )
             .await
             .unwrap();
         let page = reader

--- a/crates/site/server/src/handlers/api.rs
+++ b/crates/site/server/src/handlers/api.rs
@@ -16,7 +16,10 @@ pub fn create_api_router(artifact_reader: DynArtifactReader) -> Router<LeptosOpt
     Router::new()
         .route("/articles", get(articles::list_articles))
         .route("/page/home", get(pages::get_home_page))
-        .route("/page/articles/{slug}", get(pages::get_article_page))
+        .route(
+            "/page/articles/{category}/{slug}",
+            get(pages::get_article_page),
+        )
         .route("/page/categories/{category}", get(pages::get_category_page))
         .route("/page/pages/{page}", get(pages::get_static_page))
         .layer(Extension(artifact_reader))
@@ -80,7 +83,7 @@ mod tests {
 
         let (status, document): (StatusCode, ArticlePageDocument) = request_json(
             create_test_router(temp_dir.path()),
-            "/page/articles/sample0000001",
+            "/page/articles/tech/sample0000001",
         )
         .await;
 
@@ -97,7 +100,7 @@ mod tests {
         let response = create_test_router(temp_dir.path())
             .oneshot(
                 Request::builder()
-                    .uri("/page/articles/missing000001")
+                    .uri("/page/articles/tech/missing000001")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -144,12 +147,12 @@ mod tests {
     async fn test_api_router_returns_not_found_for_missing_article_html_artifact() {
         let temp_dir = TempDir::new().unwrap();
         write_fixture_site(temp_dir.path());
-        fs::remove_file(temp_dir.path().join("articles/sample0000001.html")).unwrap();
+        fs::remove_file(temp_dir.path().join("articles/tech/sample0000001.html")).unwrap();
 
         let response = create_test_router(temp_dir.path())
             .oneshot(
                 Request::builder()
-                    .uri("/page/articles/sample0000001")
+                    .uri("/page/articles/tech/sample0000001")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/site/server/src/handlers/api/pages.rs
+++ b/crates/site/server/src/handlers/api/pages.rs
@@ -27,17 +27,19 @@ pub async fn get_home_page(
 }
 
 pub async fn get_article_page(
-    Path(slug): Path<String>,
+    Path((category, slug)): Path<(String, String)>,
     Extension(artifact_reader): Extension<DynArtifactReader>,
 ) -> Result<Json<ArticlePageDocument>, StatusCode> {
+    let category = Category::from_str(&category).map_err(|_| StatusCode::NOT_FOUND)?;
     let slug = Slug::new(slug).map_err(|_| StatusCode::NOT_FOUND)?;
     let article_index = artifact_reader
         .read_article_index()
         .await
         .map_err(map_infra_error)?;
-    let summary = find_article_summary(&article_index, &slug).ok_or(StatusCode::NOT_FOUND)?;
+    let summary =
+        find_article_summary(&article_index, &category, &slug).ok_or(StatusCode::NOT_FOUND)?;
     let html = artifact_reader
-        .read_article_html(&slug)
+        .read_article_html(&category, &slug)
         .await
         .map_err(map_infra_error)?;
     let page = build_article_page_document(summary, &html)
@@ -118,7 +120,7 @@ mod tests {
         write_fixture_site(temp_dir.path());
 
         let Json(page) = get_article_page(
-            Path("sample0000001".to_string()),
+            Path(("tech".to_string(), "sample0000001".to_string())),
             Extension(Arc::new(LocalArtifactReader::new(temp_dir.path()))),
         )
         .await
@@ -165,10 +167,10 @@ mod tests {
     async fn test_get_article_page_returns_not_found_when_html_artifact_is_missing() {
         let temp_dir = TempDir::new().unwrap();
         write_fixture_site(temp_dir.path());
-        fs::remove_file(temp_dir.path().join("articles/sample0000001.html")).unwrap();
+        fs::remove_file(temp_dir.path().join("articles/tech/sample0000001.html")).unwrap();
 
         let result = get_article_page(
-            Path("sample0000001".to_string()),
+            Path(("tech".to_string(), "sample0000001".to_string())),
             Extension(Arc::new(LocalArtifactReader::new(temp_dir.path()))),
         )
         .await;

--- a/crates/site/server/src/test_support.rs
+++ b/crates/site/server/src/test_support.rs
@@ -5,7 +5,7 @@ use domain::{
 use std::{fs, path::Path};
 
 pub(crate) fn write_fixture_site(root: &Path) {
-    fs::create_dir_all(root.join("articles")).unwrap();
+    fs::create_dir_all(root.join("articles/tech")).unwrap();
     fs::create_dir_all(root.join("categories/tech")).unwrap();
     fs::create_dir_all(root.join("metadata")).unwrap();
     fs::create_dir_all(root.join("pages")).unwrap();
@@ -68,7 +68,7 @@ pub(crate) fn write_fixture_site(root: &Path) {
     )
     .unwrap();
     fs::write(
-        root.join("articles/sample0000001.html"),
+        root.join("articles/tech/sample0000001.html"),
         "<article><h1>Sample</h1></article>",
     )
     .unwrap();

--- a/crates/site/web/src/app.rs
+++ b/crates/site/web/src/app.rs
@@ -101,8 +101,8 @@ pub fn App() -> impl IntoView {
                     }>
                         <Route path=path!("") view=HomePage />
                         <Route path=path!("about") view=AboutPage />
-                        <Route path=path!("articles/:slug") view=ArticlePage />
-                        <Route path=path!("categories/:category") view=CategoryPage />
+                        <Route path=path!(":category/:slug") view=ArticlePage />
+                        <Route path=path!(":category") view=CategoryPage />
                     </FlatRoutes>
                 </main>
             </Router>

--- a/crates/site/web/src/components/sidebar.rs
+++ b/crates/site/web/src/components/sidebar.rs
@@ -26,7 +26,7 @@ fn render_sidebar(articles: Vec<ArticleSummary>) -> impl IntoView {
                 {articles
                     .into_iter()
                     .map(|article| {
-                        let link = format!("/articles/{}", article.slug);
+                        let link = format!("/{}/{}", article.category, article.slug);
                         let link_style = if slug() == article.slug {
                             sidebar_style::article_link_active
                         } else {

--- a/crates/site/web/src/lib.rs
+++ b/crates/site/web/src/lib.rs
@@ -66,12 +66,12 @@ mod tests {
     #[test]
     fn test_join_site_url_normalizes_slashes() {
         assert_eq!(
-            join_site_url("https://example.com/", "/articles/intro"),
-            "https://example.com/articles/intro"
+            join_site_url("https://example.com/", "/tech/intro"),
+            "https://example.com/tech/intro"
         );
         assert_eq!(
-            join_site_url("https://example.com", "categories/tech"),
-            "https://example.com/categories/tech"
+            join_site_url("https://example.com", "tech"),
+            "https://example.com/tech"
         );
         assert_eq!(
             join_site_url("https://example.com/", "/"),

--- a/crates/site/web/src/routes/article.rs
+++ b/crates/site/web/src/routes/article.rs
@@ -5,7 +5,7 @@ use crate::{SITE_NAME, build_site_url};
 use axum::http::StatusCode;
 use domain::ArticlePageDocument;
 #[cfg(feature = "ssr")]
-use domain::{Slug, build_article_page_document, find_article_summary};
+use domain::{Category, Slug, build_article_page_document, find_article_summary};
 use domain::{
     build_article_page_canonical_path, build_article_page_description, build_article_page_title,
 };
@@ -15,27 +15,34 @@ use leptos::prelude::*;
 #[cfg(feature = "ssr")]
 use leptos_axum::ResponseOptions;
 use leptos_router::{hooks::use_params_map, params::ParamsMap};
+#[cfg(feature = "ssr")]
+use std::str::FromStr;
 use stylance::import_style;
 
 import_style!(article_style, "article.module.scss");
 
 #[server]
 pub async fn get_article_page_document(
+    category: String,
     slug: String,
 ) -> Result<Option<ArticlePageDocument>, ServerFnError> {
     #[cfg(feature = "ssr")]
     {
         let artifact_reader = use_context::<DynArtifactReader>()
             .ok_or_else(|| ServerFnError::new("artifact reader context is missing"))?;
+        let category = match Category::from_str(&category) {
+            Ok(category) => category,
+            Err(_) => return Ok(None),
+        };
         let slug = match Slug::new(normalize_article_slug_param(&slug).to_string()) {
             Ok(slug) => slug,
             Err(_) => return Ok(None),
         };
         let article_index = artifact_reader.read_article_index().await?;
-        let Some(summary) = find_article_summary(&article_index, &slug) else {
+        let Some(summary) = find_article_summary(&article_index, &category, &slug) else {
             return Ok(None);
         };
-        let html = match artifact_reader.read_article_html(&slug).await {
+        let html = match artifact_reader.read_article_html(&category, &slug).await {
             Ok(html) => html,
             Err(error) if error.is_not_found() => return Ok(None),
             Err(error) => return Err(error.into()),
@@ -46,6 +53,7 @@ pub async fn get_article_page_document(
 
     #[cfg(not(feature = "ssr"))]
     {
+        let _ = category;
         let _ = slug;
         Err(ServerFnError::new(
             "get_article_page_document is only available during SSR",
@@ -108,15 +116,22 @@ fn ArticlePageContent(document: ArticlePageDocument) -> impl IntoView {
 #[component]
 pub fn ArticlePage() -> impl IntoView {
     let params = use_params_map();
-    let slug = move || params.with(|params: &ParamsMap| params.get("slug").unwrap_or_default());
+    let article_params = move || {
+        params.with(|params: &ParamsMap| {
+            (
+                params.get("category").unwrap_or_default(),
+                params.get("slug").unwrap_or_default(),
+            )
+        })
+    };
     let article_page = Resource::<Result<Option<ArticlePageDocument>, String>>::new(
-        slug,
-        move |slug| async move {
-            if slug.is_empty() {
+        article_params,
+        move |(category, slug)| async move {
+            if category.is_empty() || slug.is_empty() {
                 return Ok(None);
             }
 
-            get_article_page_document(slug)
+            get_article_page_document(category, slug)
                 .await
                 .map_err(|error| error.to_string())
         },

--- a/crates/site/web/src/routes/category.rs
+++ b/crates/site/web/src/routes/category.rs
@@ -7,7 +7,8 @@ use domain::CategoryPageDocument;
 #[cfg(feature = "ssr")]
 use domain::{Category, build_category_page_document};
 use domain::{
-    build_category_page_canonical_path, build_category_page_description, build_category_page_title,
+    build_article_path, build_category_page_canonical_path, build_category_page_description,
+    build_category_page_title,
 };
 #[cfg(feature = "ssr")]
 use infra::DynArtifactReader;
@@ -78,7 +79,7 @@ fn CategoryPageContent(document: CategoryPageDocument) -> impl IntoView {
                 .articles
                 .into_iter()
                 .map(|article| {
-                    let href = format!("/articles/{}", article.slug.as_str());
+                    let href = build_article_path(&article.category, &article.slug);
                     let title = article.title.as_str().to_string();
                     let description = article
                         .description

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -3,8 +3,8 @@ use crate::{SITE_NAME, build_site_url};
 #[cfg(feature = "ssr")]
 use domain::build_home_page_document;
 use domain::{
-    HomePageDocument, SiteArticleCard, build_home_page_canonical_path, build_home_page_description,
-    build_home_page_title,
+    HomePageDocument, SiteArticleCard, build_article_path, build_category_path,
+    build_home_page_canonical_path, build_home_page_description, build_home_page_title,
 };
 use leptos::prelude::*;
 use leptos_router::components::A;
@@ -45,7 +45,7 @@ fn HomePageContent(document: HomePageDocument) -> impl IntoView {
         .categories
         .into_iter()
         .map(|category| {
-            let href = format!("/categories/{}", category.category.as_str());
+            let href = build_category_path(&category.category);
             view! {
                 <li class=home_style::category_chip>
                     <A href={href} {..} class=home_style::category_link>
@@ -85,7 +85,7 @@ fn HomePageContent(document: HomePageDocument) -> impl IntoView {
 
 #[component]
 fn ArticleCard(article: SiteArticleCard) -> impl IntoView {
-    let slug = article.slug.as_str().to_string();
+    let article_href = build_article_path(&article.category, &article.slug);
     let title = article.title.as_str().to_string();
     let category = article.category_display_name;
     let description = article
@@ -95,7 +95,6 @@ fn ArticleCard(article: SiteArticleCard) -> impl IntoView {
     let has_tags = !tags.is_empty();
     let created_at = article.created_at;
     let updated_at = article.updated_at;
-    let article_href = format!("/articles/{slug}");
 
     view! {
         <A href={article_href} {..} class=home_style::article_card_link>


### PR DESCRIPTION
## Summary
- migrate public article/category routes to `/:category/:slug` and `/:category`
- align publisher internal links and article artifact paths to `site/articles/<category>/<slug>.html`
- update site infra/server/web fixtures and tests to the new category+slug contract

## Scope
- included: route/path migration for article/category pages
- not included: `home.md` fragment support

## Verification
- `cargo test -p domain -p artifacts -p infra -p publisher -p server`
- `cargo check -p web --features ssr`
- `cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate`
- `cargo clippy -p domain -p artifacts -p infra -p publisher -p server -p web --all-targets -- -D warnings`
- `cargo check --workspace`

## Notes
- local working tree still has an unrelated submodule drift at `crates/publish/publisher/obsidian`
- `.codex` remains untracked and is not part of this PR