### PR TITLE
feat: add optional home markdown fragment

### DIFF
--- a/crates/domain/src/site_page.rs
+++ b/crates/domain/src/site_page.rs
@@ -54,6 +54,7 @@ pub struct HomePageDocument {
     pub total_articles: usize,
     pub categories: Vec<SiteCategorySummary>,
     pub articles: Vec<SiteArticleCard>,
+    pub fragment: Option<StaticPageDocument>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -178,6 +179,7 @@ pub fn build_static_page_canonical_path(document: &StaticPageDocument) -> String
 pub fn build_home_page_document(
     article_index: &ArticleIndexDocument,
     site_metadata: &SiteMetadataDocument,
+    home_fragment: Option<&PageArtifactDocument>,
 ) -> Result<HomePageDocument> {
     let articles = article_index
         .articles
@@ -201,6 +203,7 @@ pub fn build_home_page_document(
         total_articles: site_metadata.total_articles,
         categories,
         articles,
+        fragment: home_fragment.map(build_static_page_document).transpose()?,
     })
 }
 
@@ -354,6 +357,7 @@ mod tests {
                     article_count: 1,
                 }],
             },
+            None,
         )
         .unwrap();
 
@@ -361,6 +365,41 @@ mod tests {
         assert_eq!(document.categories.len(), 1);
         assert_eq!(document.categories[0].category_display_name, "技術");
         assert_eq!(document.articles[0].title.as_str(), "Intro");
+        assert_eq!(document.fragment, None);
+    }
+
+    #[test]
+    fn test_build_home_page_document_with_fragment() {
+        let fragment = PageArtifactDocument {
+            page: PageKey::new("home".to_string()).unwrap(),
+            title: "Home".to_string(),
+            description: Some("Home fragment".to_string()),
+            html: "<p>Welcome</p>".to_string(),
+            updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+        };
+        let document = build_home_page_document(
+            &ArticleIndexDocument {
+                articles: vec![sample_summary()],
+            },
+            &SiteMetadataDocument {
+                total_articles: 1,
+                categories: vec![CategoryMetadataDocument {
+                    category: "tech".to_string(),
+                    article_count: 1,
+                }],
+            },
+            Some(&fragment),
+        )
+        .unwrap();
+
+        assert_eq!(
+            document
+                .fragment
+                .as_ref()
+                .map(|fragment| fragment.page.as_str()),
+            Some("home")
+        );
+        assert!(document.fragment.as_ref().unwrap().html.contains("Welcome"));
     }
 
     #[test]
@@ -466,6 +505,7 @@ mod tests {
                 },
             ],
             articles: vec![SiteArticleCard::try_from(&sample_summary()).unwrap()],
+            fragment: None,
         };
 
         assert_eq!(

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -110,6 +110,13 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
                             error!("Error processing {}: {}", file_path.display(), e);
                         }
                     },
+                    ContentKind::Home => match process_valid_home_file(parsed_file) {
+                        Ok(parsed_file) => valid_pages.push(parsed_file),
+                        Err(e) => {
+                            error_count += 1;
+                            error!("Error processing {}: {}", file_path.display(), e);
+                        }
+                    },
                     ContentKind::Category => match process_valid_category_file(parsed_file) {
                         Ok(parsed_file) => valid_categories.push(parsed_file),
                         Err(e) => {
@@ -117,14 +124,6 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
                             error!("Error processing {}: {}", file_path.display(), e);
                         }
                     },
-                    kind => {
-                        skipped_count += 1;
-                        info!(
-                            "Skipped (kind not implemented yet): {} [{}]",
-                            file_path.display(),
-                            kind
-                        );
-                    }
                 }
             }
             Ok(_) => {
@@ -285,6 +284,15 @@ fn process_valid_article_file(
 fn process_valid_page_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
     Ok(ParsedPageFile {
         page: parse_page_key(&parsed_file.front_matter)?,
+        markdown_body: parsed_file.markdown_body,
+        front_matter: parsed_file.front_matter,
+    })
+}
+
+fn process_valid_home_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
+    Ok(ParsedPageFile {
+        page: PageKey::new("home".to_string())
+            .map_err(|error| ObsidianError::Parse(error.to_string()))?,
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })

--- a/crates/publish/publisher/tests/integration_test.rs
+++ b/crates/publish/publisher/tests/integration_test.rs
@@ -182,6 +182,48 @@ async fn test_run_main_with_static_page_file() {
 }
 
 #[tokio::test]
+async fn test_run_main_with_home_fragment_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let obsidian_dir = temp_dir.path().join("obsidian");
+    let output_dir = temp_dir.path().join("dist");
+
+    fs::create_dir_all(&obsidian_dir).unwrap();
+
+    let page_content = indoc! {r#"
+        ---
+        title: "Home"
+        kind: home
+        summary: "Home intro"
+        created: "2025-01-01T00:00:00+09:00"
+        updated: "2025-01-01T00:00:00+09:00"
+        is_completed: true
+        ---
+
+        # Welcome
+
+        This fragment is generated from markdown.
+    "#};
+
+    let page_file = obsidian_dir.join("home.md");
+    fs::write(&page_file, page_content).unwrap();
+
+    let config = Config {
+        obsidian_dir,
+        output_dir: output_dir.clone(),
+    };
+
+    let result = run_main(&config).await;
+    assert!(result.is_ok());
+
+    let page_document =
+        fs::read_to_string(output_dir.join("site").join("pages").join("home.json")).unwrap();
+
+    assert!(page_document.contains("\"page\": \"home\""));
+    assert!(page_document.contains("\"title\": \"Home\""));
+    assert!(page_document.contains("This fragment is generated from markdown."));
+}
+
+#[tokio::test]
 async fn test_run_main_with_category_landing_file() {
     let temp_dir = TempDir::new().unwrap();
     let obsidian_dir = temp_dir.path().join("obsidian");

--- a/crates/site/server/src/handlers/api/pages.rs
+++ b/crates/site/server/src/handlers/api/pages.rs
@@ -20,7 +20,15 @@ pub async fn get_home_page(
         .read_site_metadata()
         .await
         .map_err(map_infra_error)?;
-    let page = build_home_page_document(&article_index, &site_metadata)
+    let home_fragment = match artifact_reader
+        .read_page_document(&PageKey::new("home".to_string()).expect("valid home page key"))
+        .await
+    {
+        Ok(fragment) => Some(fragment),
+        Err(error) if error.is_not_found() => None,
+        Err(error) => return Err(map_infra_error(error)),
+    };
+    let page = build_home_page_document(&article_index, &site_metadata, home_fragment.as_ref())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(page))
@@ -112,6 +120,19 @@ mod tests {
         assert_eq!(page.total_articles, 1);
         assert_eq!(page.articles.len(), 1);
         assert_eq!(page.categories[0].category_display_name, "技術");
+        assert_eq!(
+            page.fragment
+                .as_ref()
+                .map(|fragment| fragment.page.as_str()),
+            Some("home")
+        );
+        assert!(
+            page.fragment
+                .as_ref()
+                .unwrap()
+                .html
+                .contains("Welcome home")
+        );
     }
 
     #[tokio::test]

--- a/crates/site/server/src/handlers/api/pages.rs
+++ b/crates/site/server/src/handlers/api/pages.rs
@@ -135,6 +135,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_home_page_allows_missing_home_fragment() {
+        let temp_dir = TempDir::new().unwrap();
+        write_fixture_site(temp_dir.path());
+        fs::remove_file(temp_dir.path().join("pages/home.json")).unwrap();
+
+        let Json(page) = get_home_page(Extension(Arc::new(LocalArtifactReader::new(
+            temp_dir.path(),
+        ))))
+        .await
+        .unwrap();
+
+        assert_eq!(page.total_articles, 1);
+        assert!(page.fragment.is_none());
+    }
+
+    #[tokio::test]
     async fn test_get_article_page_reads_html_and_summary() {
         let temp_dir = TempDir::new().unwrap();
         write_fixture_site(temp_dir.path());

--- a/crates/site/server/src/handlers/api/pages.rs
+++ b/crates/site/server/src/handlers/api/pages.rs
@@ -22,10 +22,7 @@ pub async fn get_home_page(
         .map_err(map_infra_error)?;
     let home_page_key =
         PageKey::new("home".to_string()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let home_fragment = match artifact_reader
-        .read_page_document(&home_page_key)
-        .await
-    {
+    let home_fragment = match artifact_reader.read_page_document(&home_page_key).await {
         Ok(fragment) => Some(fragment),
         Err(error) if error.is_not_found() => None,
         Err(error) => return Err(map_infra_error(error)),

--- a/crates/site/server/src/handlers/api/pages.rs
+++ b/crates/site/server/src/handlers/api/pages.rs
@@ -20,8 +20,10 @@ pub async fn get_home_page(
         .read_site_metadata()
         .await
         .map_err(map_infra_error)?;
+    let home_page_key =
+        PageKey::new("home".to_string()).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let home_fragment = match artifact_reader
-        .read_page_document(&PageKey::new("home".to_string()).expect("valid home page key"))
+        .read_page_document(&home_page_key)
         .await
     {
         Ok(fragment) => Some(fragment),

--- a/crates/site/server/src/test_support.rs
+++ b/crates/site/server/src/test_support.rs
@@ -84,4 +84,16 @@ pub(crate) fn write_fixture_site(root: &Path) {
         .unwrap(),
     )
     .unwrap();
+    fs::write(
+        root.join("pages/home.json"),
+        serde_json::to_string_pretty(&PageArtifactDocument {
+            page: PageKey::new("home".to_string()).unwrap(),
+            title: "Home".to_string(),
+            description: Some("Home fragment".to_string()),
+            html: "<p>Welcome home</p>".to_string(),
+            updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+        })
+        .unwrap(),
+    )
+    .unwrap();
 }

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -1,6 +1,8 @@
 use crate::components::PageMetadata;
 use crate::{SITE_NAME, build_site_url};
 #[cfg(feature = "ssr")]
+use domain::PageKey;
+#[cfg(feature = "ssr")]
 use domain::build_home_page_document;
 use domain::{
     HomePageDocument, SiteArticleCard, build_article_path, build_category_path,
@@ -24,8 +26,20 @@ pub async fn get_home_page_document() -> Result<HomePageDocument, ServerFnError>
             .ok_or_else(|| ServerFnError::new("artifact reader context is missing"))?;
         let article_index = artifact_reader.read_article_index().await?;
         let site_metadata = artifact_reader.read_site_metadata().await?;
+        let home_fragment = match artifact_reader
+            .read_page_document(&PageKey::new("home".to_string()).expect("valid home page key"))
+            .await
+        {
+            Ok(fragment) => Some(fragment),
+            Err(error) if error.is_not_found() => None,
+            Err(error) => return Err(error.into()),
+        };
 
-        Ok(build_home_page_document(&article_index, &site_metadata)?)
+        Ok(build_home_page_document(
+            &article_index,
+            &site_metadata,
+            home_fragment.as_ref(),
+        )?)
     }
 
     #[cfg(not(feature = "ssr"))]
@@ -41,6 +55,10 @@ fn HomePageContent(document: HomePageDocument) -> impl IntoView {
     let page_title = build_home_page_title(SITE_NAME);
     let page_description: Arc<str> = build_home_page_description(&document).into();
     let canonical_url = build_site_url(build_home_page_canonical_path());
+    let home_fragment_html = document
+        .fragment
+        .as_ref()
+        .map(|fragment| fragment.html.clone());
     let category_items = document
         .categories
         .into_iter()
@@ -71,9 +89,22 @@ fn HomePageContent(document: HomePageDocument) -> impl IntoView {
 
         <div class=home_style::content_grid>
             <section class=home_style::overview_panel>
-                <p class=home_style::overview_copy>
-                    {"公開済みの artifact をもとに、最近の記事とカテゴリをまとめています。"}
-                </p>
+                {home_fragment_html
+                    .map(|html| {
+                        view! {
+                            // Publisher artifacts escape raw HTML and neutralize unsafe links before persistence.
+                            <div class=home_style::overview_copy inner_html=html></div>
+                        }
+                            .into_any()
+                    })
+                    .unwrap_or_else(|| {
+                        view! {
+                            <p class=home_style::overview_copy>
+                                {"公開済みの artifact をもとに、最近の記事とカテゴリをまとめています。"}
+                            </p>
+                        }
+                            .into_any()
+                    })}
                 <p class=home_style::overview_stats>{page_description}</p>
                 <ul class=home_style::category_list>{category_items}</ul>
             </section>

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -26,8 +26,10 @@ pub async fn get_home_page_document() -> Result<HomePageDocument, ServerFnError>
             .ok_or_else(|| ServerFnError::new("artifact reader context is missing"))?;
         let article_index = artifact_reader.read_article_index().await?;
         let site_metadata = artifact_reader.read_site_metadata().await?;
+        let home_page_key = PageKey::new("home".to_string())
+            .map_err(|error| ServerFnError::new(format!("invalid home page key: {error}")))?;
         let home_fragment = match artifact_reader
-            .read_page_document(&PageKey::new("home".to_string()).expect("valid home page key"))
+            .read_page_document(&home_page_key)
             .await
         {
             Ok(fragment) => Some(fragment),

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -28,10 +28,7 @@ pub async fn get_home_page_document() -> Result<HomePageDocument, ServerFnError>
         let site_metadata = artifact_reader.read_site_metadata().await?;
         let home_page_key = PageKey::new("home".to_string())
             .map_err(|error| ServerFnError::new(format!("invalid home page key: {error}")))?;
-        let home_fragment = match artifact_reader
-            .read_page_document(&home_page_key)
-            .await
-        {
+        let home_fragment = match artifact_reader.read_page_document(&home_page_key).await {
             Ok(fragment) => Some(fragment),
             Err(error) if error.is_not_found() => None,
             Err(error) => return Err(error.into()),


### PR DESCRIPTION
## Summary
- add `kind=home` support to publisher and emit `pages/home.json`
- let server/web read the home fragment artifact and inject it into the home intro area
- keep the existing home page structure for category/article navigation while allowing optional markdown content

## Verification
- cargo test -p domain -p publisher -p server
- cargo check -p web --features ssr
- cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate
- cargo clippy -p domain -p publisher -p server -p web --all-targets -- -D warnings