### PR TITLE
refactor(publisher): split lib.rs into types/classify/render modules

### DIFF
--- a/crates/publish/publisher/src/classify.rs
+++ b/crates/publish/publisher/src/classify.rs
@@ -1,0 +1,493 @@
+use crate::config::Config;
+use crate::error::{ObsidianError, Result};
+use crate::types::{ParsedArticleFile, ParsedCategoryFile, ParsedPageFile};
+use domain::{Category, ContentKind, PageKey};
+use ingest::{FileMapping, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file};
+use log::{error, warn};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// ファイル分類の結果を保持する構造体。
+pub(crate) struct ClassifiedFiles {
+    pub(crate) articles: Vec<ParsedArticleFile>,
+    pub(crate) pages: Vec<ParsedPageFile>,
+    pub(crate) categories: Vec<ParsedCategoryFile>,
+    pub(crate) skipped: usize,
+    pub(crate) errors: usize,
+}
+
+/// Obsidian ファイルのリストを解析し、記事・ページ・カテゴリに分類する。
+///  でないファイルはスキップ、解析エラーはエラーとしてカウントする。
+pub(crate) fn classify_obsidian_files(
+    markdown_files: Vec<PathBuf>,
+    config: &Config,
+) -> ClassifiedFiles {
+    let mut articles = Vec::new();
+    let mut pages = Vec::new();
+    let mut categories = Vec::new();
+    let mut skipped = 0usize;
+    let mut errors = 0usize;
+
+    for file_path in markdown_files {
+        match parse_obsidian_file(&file_path) {
+            Ok(Some(parsed)) if parsed.front_matter.is_completed => {
+                let result: Result<()> = match parsed.front_matter.kind {
+                    ContentKind::Article => process_valid_article_file(&file_path, parsed, config)
+                        .map(|f| articles.push(f)),
+                    ContentKind::Page => {
+                        process_valid_page_file(parsed).map(|f| pages.push(f))
+                    }
+                    ContentKind::Home => {
+                        process_valid_home_file(parsed).map(|f| pages.push(f))
+                    }
+                    ContentKind::Category => {
+                        process_valid_category_file(parsed).map(|f| categories.push(f))
+                    }
+                };
+                if let Err(e) = result {
+                    errors += 1;
+                    error!("Error processing {}: {}", file_path.display(), e);
+                }
+            }
+            Ok(_) => {
+                skipped += 1;
+                warn!("Skipped (not completed): {}", file_path.display());
+            }
+            Err(e) => {
+                errors += 1;
+                error!("Error processing {}: {}", file_path.display(), e);
+            }
+        }
+    }
+
+    ClassifiedFiles { articles, pages, categories, skipped, errors }
+}
+
+fn process_valid_article_file(
+    file_path: &Path,
+    parsed_file: ParsedObsidianFile,
+    config: &Config,
+) -> Result<ParsedArticleFile> {
+    let relative_path = get_relative_path(file_path, &config.obsidian_dir)?;
+    let slug = crate::slug::generate_slug(
+        &parsed_file.front_matter.title,
+        relative_path,
+        &parsed_file.front_matter.created,
+    )?;
+    let category = parse_category(&parsed_file.front_matter)?;
+    let mapping_key = normalize_path_for_url(&relative_path.with_extension(""));
+    let section_path =
+        derive_section_path(relative_path, parsed_file.front_matter.category.as_deref());
+
+    Ok(ParsedArticleFile {
+        category,
+        slug,
+        mapping_key,
+        section_path,
+        markdown_body: parsed_file.markdown_body,
+        front_matter: parsed_file.front_matter,
+    })
+}
+
+fn process_valid_page_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
+    Ok(ParsedPageFile {
+        page: parse_page_key(&parsed_file.front_matter)?,
+        markdown_body: parsed_file.markdown_body,
+        front_matter: parsed_file.front_matter,
+    })
+}
+
+fn process_valid_home_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
+    Ok(ParsedPageFile {
+        page: PageKey::new("home".to_string())
+            .map_err(|error| ObsidianError::Parse(error.to_string()))?,
+        markdown_body: parsed_file.markdown_body,
+        front_matter: parsed_file.front_matter,
+    })
+}
+
+fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<ParsedCategoryFile> {
+    Ok(ParsedCategoryFile {
+        category: parse_category(&parsed_file.front_matter)?,
+        markdown_body: parsed_file.markdown_body,
+        front_matter: parsed_file.front_matter,
+    })
+}
+
+/// OS 固有のパス区切り文字を  に統一する。
+fn normalize_path_for_url(path: &Path) -> String {
+    path.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/")
+}
+
+/// ベースディレクトリを除いた相対パスを取得する。
+fn get_relative_path<'a>(file_path: &'a Path, base_dir: &Path) -> Result<&'a Path> {
+    file_path.strip_prefix(base_dir).map_err(|_| {
+        ObsidianError::Path(format!(
+            "Failed to strip prefix from {}",
+            file_path.display()
+        ))
+    })
+}
+
+pub(crate) fn build_file_mapping(valid_files: &[ParsedArticleFile]) -> FileMapping {
+    let mut mapping = FileMapping::with_capacity(valid_files.len());
+    for parsed_file in valid_files {
+        mapping.insert(
+            parsed_file.mapping_key.clone(),
+            format!("/{}/{}", parsed_file.category.as_str(), parsed_file.slug),
+        );
+    }
+    mapping
+}
+
+fn derive_section_path(relative_path: &Path, category: Option<&str>) -> Vec<String> {
+    let mut path_components: Vec<String> = relative_path
+        .parent()
+        .map(|parent| {
+            parent
+                .iter()
+                .map(|component| component.to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if let (Some(category), Some(first_component)) = (category, path_components.first())
+        && first_component == category
+    {
+        path_components.remove(0);
+    }
+
+    path_components
+}
+
+pub(crate) fn ensure_unique_page_keys(valid_pages: &[ParsedPageFile]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(valid_pages.len());
+    for parsed_page in valid_pages {
+        if !seen.insert(parsed_page.page.as_str()) {
+            return Err(ObsidianError::Parse(format!(
+                "Duplicate page key detected: {}",
+                parsed_page.page.as_str()
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_unique_category_landings(
+    valid_categories: &[ParsedCategoryFile],
+) -> Result<()> {
+    let mut seen = HashSet::with_capacity(valid_categories.len());
+    for parsed_category in valid_categories {
+        if !seen.insert(parsed_category.category.as_str()) {
+            return Err(ObsidianError::Parse(format!(
+                "Duplicate category landing detected: {}",
+                parsed_category.category.as_str()
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn parse_category(front_matter: &ObsidianFrontMatter) -> Result<Category> {
+    let category = front_matter
+        .category
+        .as_deref()
+        .ok_or_else(|| ObsidianError::Parse("Completed articles require a category".to_string()))?;
+    category.parse().map_err(Into::into)
+}
+
+pub(crate) fn parse_page_key(front_matter: &ObsidianFrontMatter) -> Result<PageKey> {
+    let page = front_matter
+        .page
+        .as_deref()
+        .ok_or_else(|| ObsidianError::Parse("Completed pages require a page key".to_string()))?;
+    PageKey::new(page.trim().to_string()).map_err(|error| ObsidianError::Parse(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    fn test_build_file_mapping_success() {
+        let front_matter = ObsidianFrontMatter {
+            title: "Test Article".to_string(),
+            kind: ContentKind::Article,
+            tags: Some(vec!["test".to_string()]),
+            summary: Some("Test summary".to_string()),
+            priority: Some(1),
+            created: "2025-01-01T00:00:00+09:00".to_string(),
+            updated: "2025-01-02T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: Some("tech".to_string()),
+            page: None,
+        };
+
+        let parsed_file = ParsedArticleFile {
+            category: Category::Tech,
+            slug: "slug".to_string(),
+            mapping_key: "test".to_string(),
+            section_path: vec![],
+            markdown_body: "# Test Content".to_string(),
+            front_matter,
+        };
+        let valid_files = vec![parsed_file];
+        let mapping = build_file_mapping(&valid_files);
+
+        assert_eq!(mapping.len(), 1);
+        assert!(mapping.contains_key("test"));
+        assert_eq!(mapping.get("test").unwrap(), "/tech/slug");
+    }
+
+    #[rstest]
+    fn test_build_file_mapping_empty() {
+        let valid_files: Vec<ParsedArticleFile> = vec![];
+        let mapping = build_file_mapping(&valid_files);
+
+        assert_eq!(mapping.len(), 0);
+    }
+
+    #[rstest]
+    fn test_build_file_mapping_path_collision() {
+        let front_matter1 = ObsidianFrontMatter {
+            title: "Test Article 1".to_string(),
+            kind: ContentKind::Article,
+            tags: Some(vec!["test1".to_string()]),
+            summary: Some("Test summary 1".to_string()),
+            priority: Some(1),
+            created: "2025-01-01T00:00:00+09:00".to_string(),
+            updated: "2025-01-02T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: Some("tech".to_string()),
+            page: None,
+        };
+
+        let front_matter2 = ObsidianFrontMatter {
+            title: "Test Article 2".to_string(),
+            kind: ContentKind::Article,
+            tags: Some(vec!["test2".to_string()]),
+            summary: Some("Test summary 2".to_string()),
+            priority: Some(2),
+            created: "2025-01-03T00:00:00+09:00".to_string(),
+            updated: "2025-01-04T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: Some("daily".to_string()),
+            page: None,
+        };
+
+        let parsed_file1 = ParsedArticleFile {
+            category: Category::Tech,
+            slug: "slug1".to_string(),
+            mapping_key: "dir1/test".to_string(),
+            section_path: vec!["dir1".to_string()],
+            markdown_body: "# Test Content 1".to_string(),
+            front_matter: front_matter1,
+        };
+        let parsed_file2 = ParsedArticleFile {
+            category: Category::Daily,
+            slug: "slug2".to_string(),
+            mapping_key: "dir2/test".to_string(),
+            section_path: vec!["dir2".to_string()],
+            markdown_body: "# Test Content 2".to_string(),
+            front_matter: front_matter2,
+        };
+        let valid_files = vec![parsed_file1, parsed_file2];
+        let mapping = build_file_mapping(&valid_files);
+
+        assert_eq!(mapping.len(), 2);
+        assert!(mapping.contains_key("dir1/test"));
+        assert!(mapping.contains_key("dir2/test"));
+    }
+
+    #[rstest]
+    fn test_build_file_mapping_url_normalization() {
+        let front_matter = ObsidianFrontMatter {
+            title: "URL Test".to_string(),
+            kind: ContentKind::Article,
+            tags: None,
+            summary: None,
+            priority: None,
+            created: "2025-01-01T00:00:00+09:00".to_string(),
+            updated: "2025-01-01T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: Some("tech".to_string()),
+            page: None,
+        };
+
+        let parsed_file = ParsedArticleFile {
+            category: Category::Tech,
+            slug: "slug".to_string(),
+            mapping_key: "sub/dir/test".to_string(),
+            section_path: vec!["sub".to_string(), "dir".to_string()],
+            markdown_body: "# URL Test Content".to_string(),
+            front_matter,
+        };
+        let valid_files = vec![parsed_file];
+        let mapping = build_file_mapping(&valid_files);
+
+        let href = mapping.get("sub/dir/test").unwrap();
+        assert_eq!(href, "/tech/slug");
+    }
+
+    #[test]
+    fn test_ensure_unique_category_landings_rejects_duplicates() {
+        let valid_categories = vec![
+            ParsedCategoryFile {
+                category: Category::Tech,
+                markdown_body: "# Tech".to_string(),
+                front_matter: ObsidianFrontMatter {
+                    title: "Tech".to_string(),
+                    kind: ContentKind::Category,
+                    tags: None,
+                    summary: None,
+                    is_completed: true,
+                    priority: None,
+                    created: "2025-01-01T00:00:00+09:00".to_string(),
+                    updated: "2025-01-01T00:00:00+09:00".to_string(),
+                    category: Some("tech".to_string()),
+                    page: None,
+                },
+            },
+            ParsedCategoryFile {
+                category: Category::Tech,
+                markdown_body: "# Tech again".to_string(),
+                front_matter: ObsidianFrontMatter {
+                    title: "Tech Again".to_string(),
+                    kind: ContentKind::Category,
+                    tags: None,
+                    summary: None,
+                    is_completed: true,
+                    priority: None,
+                    created: "2025-01-01T00:00:00+09:00".to_string(),
+                    updated: "2025-01-01T00:00:00+09:00".to_string(),
+                    category: Some("tech".to_string()),
+                    page: None,
+                },
+            },
+        ];
+
+        let result = ensure_unique_category_landings(&valid_categories);
+
+        assert!(
+            matches!(result, Err(ObsidianError::Parse(message)) if message.contains("Duplicate category landing"))
+        );
+    }
+
+    #[test]
+    fn test_derive_section_path_drops_category_root() {
+        let section_path = derive_section_path(Path::new("tech/block1/hoge.md"), Some("tech"));
+
+        assert_eq!(section_path, vec!["block1".to_string()]);
+    }
+
+    #[test]
+    fn test_derive_section_path_keeps_nested_sections() {
+        let section_path = derive_section_path(Path::new("tech/rust/async/hoge.md"), Some("tech"));
+
+        assert_eq!(section_path, vec!["rust".to_string(), "async".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_page_key_success() {
+        let front_matter = ObsidianFrontMatter {
+            title: "About".to_string(),
+            kind: ContentKind::Page,
+            tags: None,
+            summary: Some("About this site".to_string()),
+            priority: None,
+            created: "2025-01-01T00:00:00+09:00".to_string(),
+            updated: "2025-01-01T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: None,
+            page: Some("about".to_string()),
+        };
+
+        assert_eq!(parse_page_key(&front_matter).unwrap().as_str(), "about");
+    }
+
+    #[test]
+    fn test_parse_page_key_rejects_nested_path() {
+        let front_matter = ObsidianFrontMatter {
+            title: "About".to_string(),
+            kind: ContentKind::Page,
+            tags: None,
+            summary: None,
+            priority: None,
+            created: "2025-01-01T00:00:00+09:00".to_string(),
+            updated: "2025-01-01T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: None,
+            page: Some("about/team".to_string()),
+        };
+
+        assert!(matches!(
+            parse_page_key(&front_matter),
+            Err(ObsidianError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_page_key_rejects_uppercase() {
+        let front_matter = ObsidianFrontMatter {
+            title: "About".to_string(),
+            kind: ContentKind::Page,
+            tags: None,
+            summary: None,
+            priority: None,
+            created: "2025-01-01T00:00:00+09:00".to_string(),
+            updated: "2025-01-01T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: None,
+            page: Some("About".to_string()),
+        };
+
+        assert!(matches!(
+            parse_page_key(&front_matter),
+            Err(ObsidianError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn test_ensure_unique_page_keys_rejects_duplicates() {
+        let parsed_pages = vec![
+            ParsedPageFile {
+                page: PageKey::new("about".to_string()).unwrap(),
+                markdown_body: "# About".to_string(),
+                front_matter: ObsidianFrontMatter {
+                    title: "About".to_string(),
+                    kind: ContentKind::Page,
+                    tags: None,
+                    summary: None,
+                    priority: None,
+                    created: "2025-01-01T00:00:00+09:00".to_string(),
+                    updated: "2025-01-01T00:00:00+09:00".to_string(),
+                    is_completed: true,
+                    category: None,
+                    page: Some("about".to_string()),
+                },
+            },
+            ParsedPageFile {
+                page: PageKey::new("about".to_string()).unwrap(),
+                markdown_body: "# About 2".to_string(),
+                front_matter: ObsidianFrontMatter {
+                    title: "About 2".to_string(),
+                    kind: ContentKind::Page,
+                    tags: None,
+                    summary: None,
+                    priority: None,
+                    created: "2025-01-01T00:00:00+09:00".to_string(),
+                    updated: "2025-01-01T00:00:00+09:00".to_string(),
+                    is_completed: true,
+                    category: None,
+                    page: Some("about".to_string()),
+                },
+            },
+        ];
+
+        assert!(matches!(
+            ensure_unique_page_keys(&parsed_pages),
+            Err(ObsidianError::Parse(message)) if message.contains("Duplicate page key")
+        ));
+    }
+}

--- a/crates/publish/publisher/src/classify.rs
+++ b/crates/publish/publisher/src/classify.rs
@@ -17,7 +17,8 @@ pub(crate) struct ClassifiedFiles {
 }
 
 /// Obsidian ファイルのリストを解析し、記事・ページ・カテゴリに分類する。
-///  でないファイルはスキップ、解析エラーはエラーとしてカウントする。
+/// `parsed.front_matter.is_completed` が true でないファイルはスキップし、
+/// 解析エラーはエラーとしてカウントする。
 pub(crate) fn classify_obsidian_files(
     markdown_files: Vec<PathBuf>,
     config: &Config,
@@ -34,12 +35,8 @@ pub(crate) fn classify_obsidian_files(
                 let result: Result<()> = match parsed.front_matter.kind {
                     ContentKind::Article => process_valid_article_file(&file_path, parsed, config)
                         .map(|f| articles.push(f)),
-                    ContentKind::Page => {
-                        process_valid_page_file(parsed).map(|f| pages.push(f))
-                    }
-                    ContentKind::Home => {
-                        process_valid_home_file(parsed).map(|f| pages.push(f))
-                    }
+                    ContentKind::Page => process_valid_page_file(parsed).map(|f| pages.push(f)),
+                    ContentKind::Home => process_valid_home_file(parsed).map(|f| pages.push(f)),
                     ContentKind::Category => {
                         process_valid_category_file(parsed).map(|f| categories.push(f))
                     }
@@ -60,7 +57,13 @@ pub(crate) fn classify_obsidian_files(
         }
     }
 
-    ClassifiedFiles { articles, pages, categories, skipped, errors }
+    ClassifiedFiles {
+        articles,
+        pages,
+        categories,
+        skipped,
+        errors,
+    }
 }
 
 fn process_valid_article_file(
@@ -114,9 +117,10 @@ fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<Parsed
     })
 }
 
-/// OS 固有のパス区切り文字を  に統一する。
+/// OS 固有のパス区切り文字を `/` に統一する。
 fn normalize_path_for_url(path: &Path) -> String {
-    path.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/")
+    path.to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "/")
 }
 
 /// ベースディレクトリを除いた相対パスを取得する。
@@ -192,7 +196,7 @@ pub(crate) fn parse_category(front_matter: &ObsidianFrontMatter) -> Result<Categ
     let category = front_matter
         .category
         .as_deref()
-        .ok_or_else(|| ObsidianError::Parse("Completed articles require a category".to_string()))?;
+        .ok_or_else(|| ObsidianError::Parse("Completed content requires a category".to_string()))?;
     category.parse().map_err(Into::into)
 }
 

--- a/crates/publish/publisher/src/lib.rs
+++ b/crates/publish/publisher/src/lib.rs
@@ -1,71 +1,36 @@
 pub mod config;
 pub mod error;
 pub mod slug;
+mod classify;
+mod render;
+mod types;
+
+use artifacts::{
+    SiteDirectories, build_site_artifacts, write_article_page, write_category_page,
+    write_page_document, write_site_artifacts,
+};
+pub use config::Config;
+use classify::{
+    build_file_mapping, classify_obsidian_files, ensure_unique_category_landings,
+    ensure_unique_page_keys,
+};
+pub use error::{ObsidianError, Result};
+use futures::{StreamExt, TryStreamExt, future::BoxFuture, stream};
+use ingest::scan_obsidian_files;
+use log::{info, warn};
+use render::{render_article, render_category, render_page};
+use std::sync::Arc;
 
 /// Async fn that takes page HTML and returns enriched HTML with rich bookmark cards.
-/// Use `offline_bookmark_enricher` in tests to avoid network access.
+/// Use offline_bookmark_enricher in tests to avoid network access.
 pub type BookmarkEnricher =
     Arc<dyn Fn(String) -> BoxFuture<'static, bookmark::Result<String>> + Send + Sync>;
 
-/// Returns a `BookmarkEnricher` that uses fallback data only; no network requests.
+/// Returns a BookmarkEnricher that uses fallback data only; no network requests.
 pub fn offline_bookmark_enricher() -> BookmarkEnricher {
     Arc::new(|html: String| {
         Box::pin(async move { bookmark::convert_simple_bookmarks_to_rich_offline(&html).await })
     })
-}
-
-use artifacts::{
-    CategoryLandingMetadata, SiteDirectories, build_site_artifacts, write_article_page,
-    write_category_page, write_page_document, write_site_artifacts,
-};
-pub use config::Config;
-use domain::{
-    ArticleBody, ArticleMeta, ArticleMetaInput, Category, ContentKind, PageArtifactDocument,
-    PageKey, Slug, Title,
-};
-pub use error::{ObsidianError, Result};
-use ingest::{
-    FileMapping, ObsidianFrontMatter, ParsedObsidianFile, convert_markdown_to_html,
-    convert_obsidian_links, parse_obsidian_file, scan_obsidian_files,
-};
-
-use futures::{StreamExt, TryStreamExt, future::BoxFuture, stream};
-use log::{error, info, warn};
-use std::{collections::HashSet, path::Path, sync::Arc};
-
-struct RenderedArticle {
-    meta: ArticleMeta,
-    html: String,
-}
-
-struct RenderedPage {
-    document: PageArtifactDocument,
-}
-
-struct RenderedCategoryLanding {
-    metadata: CategoryLandingMetadata,
-    html: String,
-}
-
-struct ParsedArticleFile {
-    category: Category,
-    slug: String,
-    mapping_key: String,
-    section_path: Vec<String>,
-    markdown_body: String,
-    front_matter: ObsidianFrontMatter,
-}
-
-struct ParsedPageFile {
-    page: PageKey,
-    markdown_body: String,
-    front_matter: ObsidianFrontMatter,
-}
-
-struct ParsedCategoryFile {
-    category: Category,
-    markdown_body: String,
-    front_matter: ObsidianFrontMatter,
 }
 
 pub async fn run_main(config: &Config) -> Result<()> {
@@ -84,116 +49,67 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
     let markdown_files = scan_obsidian_files(&config.obsidian_dir)?;
     info!("Found {} markdown files", markdown_files.len());
 
-    let mut skipped_count = 0;
-    let mut error_count = 0;
+    let classify::ClassifiedFiles { articles, pages, categories, skipped, errors } =
+        classify_obsidian_files(markdown_files, config);
 
-    let mut valid_articles = Vec::new();
-    let mut valid_pages = Vec::new();
-    let mut valid_categories = Vec::new();
-    for file_path in markdown_files {
-        match parse_obsidian_file(&file_path) {
-            Ok(Some(parsed_file)) if parsed_file.front_matter.is_completed => {
-                match parsed_file.front_matter.kind {
-                    ContentKind::Article => {
-                        match process_valid_article_file(&file_path, parsed_file, config) {
-                            Ok(parsed_file) => valid_articles.push(parsed_file),
-                            Err(e) => {
-                                error_count += 1;
-                                error!("Error processing {}: {}", file_path.display(), e);
-                            }
-                        }
-                    }
-                    ContentKind::Page => match process_valid_page_file(parsed_file) {
-                        Ok(parsed_file) => valid_pages.push(parsed_file),
-                        Err(e) => {
-                            error_count += 1;
-                            error!("Error processing {}: {}", file_path.display(), e);
-                        }
-                    },
-                    ContentKind::Home => match process_valid_home_file(parsed_file) {
-                        Ok(parsed_file) => valid_pages.push(parsed_file),
-                        Err(e) => {
-                            error_count += 1;
-                            error!("Error processing {}: {}", file_path.display(), e);
-                        }
-                    },
-                    ContentKind::Category => match process_valid_category_file(parsed_file) {
-                        Ok(parsed_file) => valid_categories.push(parsed_file),
-                        Err(e) => {
-                            error_count += 1;
-                            error!("Error processing {}: {}", file_path.display(), e);
-                        }
-                    },
-                }
-            }
-            Ok(_) => {
-                skipped_count += 1;
-                warn!("Skipped (not completed): {}", file_path.display());
-            }
-            Err(e) => {
-                error_count += 1;
-                error!("Error processing {}: {}", file_path.display(), e);
-            }
-        }
+    info!("Valid article files: {}", articles.len());
+    info!("Valid page files: {}", pages.len());
+    info!("Valid category files: {}", categories.len());
+    info!("Skipped files: {skipped}");
+    if errors > 0 {
+        warn!("Error files: {errors}");
     }
 
-    info!("Valid article files: {}", valid_articles.len());
-    info!("Valid page files: {}", valid_pages.len());
-    info!("Valid category files: {}", valid_categories.len());
-    info!("Skipped files: {skipped_count}");
-    if error_count > 0 {
-        warn!("Error files: {error_count}");
-    }
+    ensure_unique_page_keys(&pages)?;
+    ensure_unique_category_landings(&categories)?;
 
-    ensure_unique_page_keys(&valid_pages)?;
-    ensure_unique_category_landings(&valid_categories)?;
-
-    let file_mapping = build_file_mapping(&valid_articles);
+    let file_mapping = build_file_mapping(&articles);
     let site_directories = SiteDirectories::prepare(&config.output_dir)?;
 
     const CONCURRENT_LIMIT: usize = 4;
-    let article_metas: Vec<ArticleMeta> = stream::iter(valid_articles)
+
+    let article_metas = stream::iter(articles)
         .map(|parsed_file| {
             let enrich = Arc::clone(&enrich);
-            render_publishable_article(parsed_file, &file_mapping, enrich)
+            render_article(parsed_file, &file_mapping, enrich)
         })
         .buffer_unordered(CONCURRENT_LIMIT)
-        .try_fold(Vec::new(), |mut article_metas, rendered_article| {
+        .try_fold(Vec::new(), |mut article_metas, rendered| {
             let site_directories = site_directories.clone();
             async move {
-                let (rendered_article, output_file_path) = tokio::task::spawn_blocking(move || {
+                let (rendered, output_file_path) = tokio::task::spawn_blocking(move || {
                     let output_file_path = write_article_page(
                         &site_directories,
-                        rendered_article.meta.category,
-                        &rendered_article.meta.slug,
-                        &rendered_article.html,
+                        rendered.meta.category,
+                        &rendered.meta.slug,
+                        &rendered.html,
                     )?;
-                    Ok::<_, artifacts::ArtifactsError>((rendered_article, output_file_path))
+                    Ok::<_, artifacts::ArtifactsError>((rendered, output_file_path))
                 })
                 .await??;
                 info!("...processed {}", output_file_path.display());
-                article_metas.push(rendered_article.meta);
+                article_metas.push(rendered.meta);
                 Ok(article_metas)
             }
         })
         .await?;
 
-    let rendered_pages: Vec<RenderedPage> = stream::iter(valid_pages)
+    let rendered_pages = stream::iter(pages)
         .map(|parsed_file| {
             let enrich = Arc::clone(&enrich);
-            render_static_page(parsed_file, &file_mapping, enrich)
+            render_page(parsed_file, &file_mapping, enrich)
         })
         .buffer_unordered(CONCURRENT_LIMIT)
-        .try_collect()
+        .try_collect::<Vec<_>>()
         .await?;
 
-    let rendered_categories: Vec<RenderedCategoryLanding> = stream::iter(valid_categories)
+    let rendered_categories = stream::iter(categories)
         .map(|parsed_file| {
             let enrich = Arc::clone(&enrich);
-            render_category_landing(parsed_file, &file_mapping, enrich)
+            render_category(parsed_file, &file_mapping, enrich)
         })
         .buffer_unordered(CONCURRENT_LIMIT)
-        .try_collect()
+        .try_collect::<Vec<_>>()
         .await?;
 
     for rendered_page in rendered_pages {
@@ -232,17 +148,15 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
     let processed_count = site_artifacts.article_index.len();
     let duration = start_time.elapsed();
 
-    // Print the processing summary.
     info!("=== Processing Summary ===");
     info!("Successfully processed: {processed_count} files");
-    info!("  Skipped: {skipped_count} files");
-    if error_count > 0 {
-        warn!("  Errors: {error_count} files");
+    info!("  Skipped: {skipped} files");
+    if errors > 0 {
+        warn!("  Errors: {errors} files");
     }
     info!("  Processing time: {duration:.2?}");
     info!("Output directory: {}", config.output_dir.display());
 
-    // Print details for the processed files.
     if !site_artifacts.article_index.is_empty() {
         info!("Processed files:");
         for article in &site_artifacts.article_index {
@@ -252,621 +166,4 @@ pub async fn run_with_enricher(config: &Config, enrich: BookmarkEnricher) -> Res
 
     info!("=== Publisher Completed ===");
     Ok(())
-}
-
-/// Processes a valid file and builds a `ParsedFile`.
-fn process_valid_article_file(
-    file_path: &Path,
-    parsed_file: ParsedObsidianFile,
-    config: &Config,
-) -> Result<ParsedArticleFile> {
-    let relative_path = get_relative_path(file_path, &config.obsidian_dir)?;
-    let slug = slug::generate_slug(
-        &parsed_file.front_matter.title,
-        relative_path,
-        &parsed_file.front_matter.created,
-    )?;
-    let category = parse_category(&parsed_file.front_matter)?;
-    let mapping_key = normalize_path_for_url(&relative_path.with_extension(""));
-    let section_path =
-        derive_section_path(relative_path, parsed_file.front_matter.category.as_deref());
-
-    Ok(ParsedArticleFile {
-        category,
-        slug,
-        mapping_key,
-        section_path,
-        markdown_body: parsed_file.markdown_body,
-        front_matter: parsed_file.front_matter,
-    })
-}
-
-fn process_valid_page_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
-    Ok(ParsedPageFile {
-        page: parse_page_key(&parsed_file.front_matter)?,
-        markdown_body: parsed_file.markdown_body,
-        front_matter: parsed_file.front_matter,
-    })
-}
-
-fn process_valid_home_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
-    Ok(ParsedPageFile {
-        page: PageKey::new("home".to_string())
-            .map_err(|error| ObsidianError::Parse(error.to_string()))?,
-        markdown_body: parsed_file.markdown_body,
-        front_matter: parsed_file.front_matter,
-    })
-}
-
-fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<ParsedCategoryFile> {
-    Ok(ParsedCategoryFile {
-        category: parse_category(&parsed_file.front_matter)?,
-        markdown_body: parsed_file.markdown_body,
-        front_matter: parsed_file.front_matter,
-    })
-}
-
-/// Normalizes a path for use in URLs by converting OS-specific separators to `/`.
-fn normalize_path_for_url(path: &Path) -> String {
-    let path_str = path.to_string_lossy();
-    path_str.replace(std::path::MAIN_SEPARATOR, "/")
-}
-
-/// Shared helper for extracting a relative path.
-fn get_relative_path<'a>(file_path: &'a Path, base_dir: &Path) -> Result<&'a Path> {
-    file_path.strip_prefix(base_dir).map_err(|_| {
-        ObsidianError::Path(format!(
-            "Failed to strip prefix from {}",
-            file_path.display()
-        ))
-    })
-}
-
-fn build_file_mapping(valid_files: &[ParsedArticleFile]) -> FileMapping {
-    let mut mapping = FileMapping::with_capacity(valid_files.len());
-
-    for parsed_file in valid_files {
-        mapping.insert(
-            parsed_file.mapping_key.clone(),
-            format!("/{}/{}", parsed_file.category.as_str(), parsed_file.slug),
-        );
-    }
-
-    mapping
-}
-
-fn derive_section_path(relative_path: &Path, category: Option<&str>) -> Vec<String> {
-    let mut path_components: Vec<String> = relative_path
-        .parent()
-        .map(|parent| {
-            parent
-                .iter()
-                .map(|component| component.to_string_lossy().into_owned())
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if let (Some(category), Some(first_component)) = (category, path_components.first())
-        && first_component == category
-    {
-        path_components.remove(0);
-    }
-
-    path_components
-}
-
-fn ensure_unique_page_keys(valid_pages: &[ParsedPageFile]) -> Result<()> {
-    let mut seen = HashSet::with_capacity(valid_pages.len());
-
-    for parsed_page in valid_pages {
-        if !seen.insert(parsed_page.page.as_str()) {
-            return Err(ObsidianError::Parse(format!(
-                "Duplicate page key detected: {}",
-                parsed_page.page.as_str()
-            )));
-        }
-    }
-
-    Ok(())
-}
-
-fn ensure_unique_category_landings(valid_categories: &[ParsedCategoryFile]) -> Result<()> {
-    let mut seen = HashSet::with_capacity(valid_categories.len());
-
-    for parsed_category in valid_categories {
-        if !seen.insert(parsed_category.category.as_str()) {
-            return Err(ObsidianError::Parse(format!(
-                "Duplicate category landing detected: {}",
-                parsed_category.category.as_str()
-            )));
-        }
-    }
-
-    Ok(())
-}
-
-async fn process_parsed_file(
-    parsed_file: ParsedArticleFile,
-    file_mapping: &FileMapping,
-    enrich: &BookmarkEnricher,
-) -> Result<RenderedArticle> {
-    let markdown_with_links = convert_obsidian_links(&parsed_file.markdown_body, file_mapping);
-    let html_body = convert_markdown_to_html(&markdown_with_links)?;
-
-    // Convert simple bookmark markup into rich bookmark cards after rendering HTML.
-    let fallback = html_body.clone();
-    let html_with_rich_bookmarks = enrich(html_body).await.unwrap_or_else(|e| {
-        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
-        fallback
-    });
-
-    let meta = ArticleMeta::new(ArticleMetaInput {
-        slug: Slug::new(parsed_file.slug)?,
-        title: Title::new(parsed_file.front_matter.title)?,
-        category: parsed_file.category,
-        section_path: parsed_file.section_path,
-        description: parsed_file.front_matter.summary,
-        tags: parsed_file.front_matter.tags.unwrap_or_default(),
-        priority: parsed_file.front_matter.priority,
-        created_at: parsed_file.front_matter.created,
-        updated_at: parsed_file.front_matter.updated,
-    })?;
-    let body = ArticleBody::new(html_with_rich_bookmarks)?;
-
-    Ok(RenderedArticle {
-        meta,
-        html: body.html,
-    })
-}
-
-async fn render_publishable_article(
-    parsed_file: ParsedArticleFile,
-    file_mapping: &FileMapping,
-    enrich: BookmarkEnricher,
-) -> Result<RenderedArticle> {
-    process_parsed_file(parsed_file, file_mapping, &enrich).await
-}
-
-async fn process_page_file(
-    parsed_file: ParsedPageFile,
-    file_mapping: &FileMapping,
-    enrich: &BookmarkEnricher,
-) -> Result<RenderedPage> {
-    let markdown_with_links = convert_obsidian_links(&parsed_file.markdown_body, file_mapping);
-    let html_body = convert_markdown_to_html(&markdown_with_links)?;
-
-    let fallback = html_body.clone();
-    let html_with_rich_bookmarks = enrich(html_body).await.unwrap_or_else(|e| {
-        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
-        fallback
-    });
-
-    Ok(RenderedPage {
-        document: PageArtifactDocument {
-            page: parsed_file.page,
-            title: parsed_file.front_matter.title,
-            description: parsed_file.front_matter.summary,
-            html: html_with_rich_bookmarks,
-            updated_at: parsed_file.front_matter.updated,
-        },
-    })
-}
-
-async fn render_static_page(
-    parsed_file: ParsedPageFile,
-    file_mapping: &FileMapping,
-    enrich: BookmarkEnricher,
-) -> Result<RenderedPage> {
-    process_page_file(parsed_file, file_mapping, &enrich).await
-}
-
-async fn process_category_file(
-    parsed_file: ParsedCategoryFile,
-    file_mapping: &FileMapping,
-    enrich: &BookmarkEnricher,
-) -> Result<RenderedCategoryLanding> {
-    let markdown_with_links = convert_obsidian_links(&parsed_file.markdown_body, file_mapping);
-    let html_body = convert_markdown_to_html(&markdown_with_links)?;
-
-    let fallback = html_body.clone();
-    let html_with_rich_bookmarks = enrich(html_body).await.unwrap_or_else(|e| {
-        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
-        fallback
-    });
-    let html = if html_with_rich_bookmarks.trim().is_empty() {
-        build_fallback_category_landing_html(
-            parsed_file.category,
-            &parsed_file.front_matter.title,
-            parsed_file.front_matter.summary.as_deref(),
-        )
-    } else {
-        html_with_rich_bookmarks
-    };
-
-    Ok(RenderedCategoryLanding {
-        metadata: CategoryLandingMetadata {
-            category: parsed_file.category,
-            title: parsed_file.front_matter.title,
-            description: parsed_file.front_matter.summary,
-            updated_at: parsed_file.front_matter.updated,
-        },
-        html,
-    })
-}
-
-async fn render_category_landing(
-    parsed_file: ParsedCategoryFile,
-    file_mapping: &FileMapping,
-    enrich: BookmarkEnricher,
-) -> Result<RenderedCategoryLanding> {
-    process_category_file(parsed_file, file_mapping, &enrich).await
-}
-
-fn parse_category(front_matter: &ObsidianFrontMatter) -> Result<Category> {
-    let category = front_matter
-        .category
-        .as_deref()
-        .ok_or_else(|| ObsidianError::Parse("Completed articles require a category".to_string()))?;
-
-    category.parse().map_err(Into::into)
-}
-
-fn parse_page_key(front_matter: &ObsidianFrontMatter) -> Result<PageKey> {
-    let page = front_matter
-        .page
-        .as_deref()
-        .ok_or_else(|| ObsidianError::Parse("Completed pages require a page key".to_string()))?;
-    PageKey::new(page.trim().to_string()).map_err(|error| ObsidianError::Parse(error.to_string()))
-}
-
-fn build_fallback_category_landing_html(
-    category: Category,
-    title: &str,
-    description: Option<&str>,
-) -> String {
-    let heading = if title.trim().is_empty() {
-        category.display_name()
-    } else {
-        title.trim()
-    };
-
-    let body = description
-        .filter(|description| !description.trim().is_empty())
-        .map(str::trim)
-        .map(str::to_owned)
-        .unwrap_or_else(|| format!("{}カテゴリの記事一覧です。", category.display_name()));
-    let heading = html_escape(heading);
-    let body = html_escape(&body);
-
-    format!("<article><h1>{heading}</h1><p>{body}</p></article>")
-}
-
-fn html_escape(text: &str) -> String {
-    text.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::*;
-
-    #[rstest]
-    fn test_build_file_mapping_success() {
-        let front_matter = ObsidianFrontMatter {
-            title: "Test Article".to_string(),
-            kind: ContentKind::Article,
-            tags: Some(vec!["test".to_string()]),
-            summary: Some("Test summary".to_string()),
-            priority: Some(1),
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-02T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("tech".to_string()),
-            page: None,
-        };
-
-        let parsed_file = ParsedArticleFile {
-            category: Category::Tech,
-            slug: "slug".to_string(),
-            mapping_key: "test".to_string(),
-            section_path: vec![],
-            markdown_body: "# Test Content".to_string(),
-            front_matter,
-        };
-        let valid_files = vec![parsed_file];
-        let mapping = build_file_mapping(&valid_files);
-
-        assert_eq!(mapping.len(), 1);
-        assert!(mapping.contains_key("test"));
-        assert_eq!(mapping.get("test").unwrap(), "/tech/slug");
-    }
-
-    #[rstest]
-    fn test_build_file_mapping_empty() {
-        let valid_files: Vec<ParsedArticleFile> = vec![];
-        let mapping = build_file_mapping(&valid_files);
-
-        assert_eq!(mapping.len(), 0);
-    }
-
-    #[rstest]
-    fn test_build_file_mapping_path_collision() {
-        let front_matter1 = ObsidianFrontMatter {
-            title: "Test Article 1".to_string(),
-            kind: ContentKind::Article,
-            tags: Some(vec!["test1".to_string()]),
-            summary: Some("Test summary 1".to_string()),
-            priority: Some(1),
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-02T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("tech".to_string()),
-            page: None,
-        };
-
-        let front_matter2 = ObsidianFrontMatter {
-            title: "Test Article 2".to_string(),
-            kind: ContentKind::Article,
-            tags: Some(vec!["test2".to_string()]),
-            summary: Some("Test summary 2".to_string()),
-            priority: Some(2),
-            created: "2025-01-03T00:00:00+09:00".to_string(),
-            updated: "2025-01-04T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("daily".to_string()),
-            page: None,
-        };
-
-        let parsed_file1 = ParsedArticleFile {
-            category: Category::Tech,
-            slug: "slug1".to_string(),
-            mapping_key: "dir1/test".to_string(),
-            section_path: vec!["dir1".to_string()],
-            markdown_body: "# Test Content 1".to_string(),
-            front_matter: front_matter1,
-        };
-        let parsed_file2 = ParsedArticleFile {
-            category: Category::Daily,
-            slug: "slug2".to_string(),
-            mapping_key: "dir2/test".to_string(),
-            section_path: vec!["dir2".to_string()],
-            markdown_body: "# Test Content 2".to_string(),
-            front_matter: front_matter2,
-        };
-        let valid_files = vec![parsed_file1, parsed_file2];
-        let mapping = build_file_mapping(&valid_files);
-
-        // Using the full relative path as the key prevents collisions.
-        assert_eq!(mapping.len(), 2);
-        assert!(mapping.contains_key("dir1/test"));
-        assert!(mapping.contains_key("dir2/test"));
-    }
-
-    #[rstest]
-    fn test_build_file_mapping_url_normalization() {
-        let front_matter = ObsidianFrontMatter {
-            title: "URL Test".to_string(),
-            kind: ContentKind::Article,
-            tags: None,
-            summary: None,
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("tech".to_string()),
-            page: None,
-        };
-
-        let parsed_file = ParsedArticleFile {
-            category: Category::Tech,
-            slug: "slug".to_string(),
-            mapping_key: "sub/dir/test".to_string(),
-            section_path: vec!["sub".to_string(), "dir".to_string()],
-            markdown_body: "# URL Test Content".to_string(),
-            front_matter,
-        };
-        let valid_files = vec![parsed_file];
-        let mapping = build_file_mapping(&valid_files);
-
-        let href = mapping.get("sub/dir/test").unwrap();
-        assert_eq!(href, "/tech/slug");
-    }
-
-    #[test]
-    fn test_ensure_unique_category_landings_rejects_duplicates() {
-        let valid_categories = vec![
-            ParsedCategoryFile {
-                category: Category::Tech,
-                markdown_body: "# Tech".to_string(),
-                front_matter: ObsidianFrontMatter {
-                    title: "Tech".to_string(),
-                    kind: ContentKind::Category,
-                    tags: None,
-                    summary: None,
-                    is_completed: true,
-                    priority: None,
-                    created: "2025-01-01T00:00:00+09:00".to_string(),
-                    updated: "2025-01-01T00:00:00+09:00".to_string(),
-                    category: Some("tech".to_string()),
-                    page: None,
-                },
-            },
-            ParsedCategoryFile {
-                category: Category::Tech,
-                markdown_body: "# Tech again".to_string(),
-                front_matter: ObsidianFrontMatter {
-                    title: "Tech Again".to_string(),
-                    kind: ContentKind::Category,
-                    tags: None,
-                    summary: None,
-                    is_completed: true,
-                    priority: None,
-                    created: "2025-01-01T00:00:00+09:00".to_string(),
-                    updated: "2025-01-01T00:00:00+09:00".to_string(),
-                    category: Some("tech".to_string()),
-                    page: None,
-                },
-            },
-        ];
-
-        let result = ensure_unique_category_landings(&valid_categories);
-
-        assert!(
-            matches!(result, Err(ObsidianError::Parse(message)) if message.contains("Duplicate category landing"))
-        );
-    }
-
-    #[test]
-    fn test_build_fallback_category_landing_html_uses_title_and_summary() {
-        let html = build_fallback_category_landing_html(
-            Category::Tech,
-            "Tech",
-            Some("Technology landing"),
-        );
-
-        assert!(html.contains("<h1>Tech</h1>"));
-        assert!(html.contains("<p>Technology landing</p>"));
-    }
-
-    #[test]
-    fn test_build_fallback_category_landing_html_falls_back_to_category_display_name() {
-        let html = build_fallback_category_landing_html(Category::Physics, "   ", None);
-
-        assert!(html.contains("<h1>物理学</h1>"));
-        assert!(html.contains("物理学カテゴリの記事一覧です。"));
-    }
-
-    #[test]
-    fn test_build_fallback_category_landing_html_escapes_frontmatter_text() {
-        let html = build_fallback_category_landing_html(
-            Category::Tech,
-            "<script>alert(1)</script>",
-            Some("\"quoted\" & <tag>"),
-        );
-
-        assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
-        assert!(html.contains("&quot;quoted&quot; &amp; &lt;tag&gt;"));
-        assert!(!html.contains("<script>alert(1)</script>"));
-    }
-
-    #[test]
-    fn test_derive_section_path_drops_category_root() {
-        let section_path = derive_section_path(Path::new("tech/block1/hoge.md"), Some("tech"));
-
-        assert_eq!(section_path, vec!["block1".to_string()]);
-    }
-
-    #[test]
-    fn test_derive_section_path_keeps_nested_sections() {
-        let section_path = derive_section_path(Path::new("tech/rust/async/hoge.md"), Some("tech"));
-
-        assert_eq!(section_path, vec!["rust".to_string(), "async".to_string()]);
-    }
-
-    #[test]
-    fn test_parse_page_key_success() {
-        let front_matter = ObsidianFrontMatter {
-            title: "About".to_string(),
-            kind: ContentKind::Page,
-            tags: None,
-            summary: Some("About this site".to_string()),
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: None,
-            page: Some("about".to_string()),
-        };
-
-        assert_eq!(parse_page_key(&front_matter).unwrap().as_str(), "about");
-    }
-
-    #[test]
-    fn test_parse_page_key_rejects_nested_path() {
-        let front_matter = ObsidianFrontMatter {
-            title: "About".to_string(),
-            kind: ContentKind::Page,
-            tags: None,
-            summary: None,
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: None,
-            page: Some("about/team".to_string()),
-        };
-
-        assert!(matches!(
-            parse_page_key(&front_matter),
-            Err(ObsidianError::Parse(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_page_key_rejects_uppercase() {
-        let front_matter = ObsidianFrontMatter {
-            title: "About".to_string(),
-            kind: ContentKind::Page,
-            tags: None,
-            summary: None,
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: None,
-            page: Some("About".to_string()),
-        };
-
-        assert!(matches!(
-            parse_page_key(&front_matter),
-            Err(ObsidianError::Parse(_))
-        ));
-    }
-
-    #[test]
-    fn test_ensure_unique_page_keys_rejects_duplicates() {
-        let parsed_pages = vec![
-            ParsedPageFile {
-                page: PageKey::new("about".to_string()).unwrap(),
-                markdown_body: "# About".to_string(),
-                front_matter: ObsidianFrontMatter {
-                    title: "About".to_string(),
-                    kind: ContentKind::Page,
-                    tags: None,
-                    summary: None,
-                    priority: None,
-                    created: "2025-01-01T00:00:00+09:00".to_string(),
-                    updated: "2025-01-01T00:00:00+09:00".to_string(),
-                    is_completed: true,
-                    category: None,
-                    page: Some("about".to_string()),
-                },
-            },
-            ParsedPageFile {
-                page: PageKey::new("about".to_string()).unwrap(),
-                markdown_body: "# About 2".to_string(),
-                front_matter: ObsidianFrontMatter {
-                    title: "About 2".to_string(),
-                    kind: ContentKind::Page,
-                    tags: None,
-                    summary: None,
-                    priority: None,
-                    created: "2025-01-01T00:00:00+09:00".to_string(),
-                    updated: "2025-01-01T00:00:00+09:00".to_string(),
-                    is_completed: true,
-                    category: None,
-                    page: Some("about".to_string()),
-                },
-            },
-        ];
-
-        assert!(matches!(
-            ensure_unique_page_keys(&parsed_pages),
-            Err(ObsidianError::Parse(message)) if message.contains("Duplicate page key")
-        ));
-    }
 }

--- a/crates/publish/publisher/src/render.rs
+++ b/crates/publish/publisher/src/render.rs
@@ -1,0 +1,159 @@
+use crate::types::{
+    ParsedArticleFile, ParsedCategoryFile, ParsedPageFile, RenderedArticle,
+    RenderedCategoryLanding, RenderedPage,
+};
+use crate::BookmarkEnricher;
+use crate::error::Result;
+use artifacts::CategoryLandingMetadata;
+use domain::{ArticleBody, ArticleMeta, ArticleMetaInput, Category, PageArtifactDocument, Slug, Title};
+use ingest::{FileMapping, convert_markdown_to_html, convert_obsidian_links};
+use log::warn;
+
+async fn render_html(
+    markdown_body: &str,
+    file_mapping: &FileMapping,
+    enrich: &BookmarkEnricher,
+) -> Result<String> {
+    let markdown_with_links = convert_obsidian_links(markdown_body, file_mapping);
+    let html_body = convert_markdown_to_html(&markdown_with_links)?;
+    let fallback = html_body.clone();
+    let html = enrich(html_body).await.unwrap_or_else(|e| {
+        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
+        fallback
+    });
+    Ok(html)
+}
+
+pub(crate) async fn render_article(
+    parsed_file: ParsedArticleFile,
+    file_mapping: &FileMapping,
+    enrich: BookmarkEnricher,
+) -> Result<RenderedArticle> {
+    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    let meta = ArticleMeta::new(ArticleMetaInput {
+        slug: Slug::new(parsed_file.slug)?,
+        title: Title::new(parsed_file.front_matter.title)?,
+        category: parsed_file.category,
+        section_path: parsed_file.section_path,
+        description: parsed_file.front_matter.summary,
+        tags: parsed_file.front_matter.tags.unwrap_or_default(),
+        priority: parsed_file.front_matter.priority,
+        created_at: parsed_file.front_matter.created,
+        updated_at: parsed_file.front_matter.updated,
+    })?;
+    let body = ArticleBody::new(html)?;
+    Ok(RenderedArticle {
+        meta,
+        html: body.html,
+    })
+}
+
+pub(crate) async fn render_page(
+    parsed_file: ParsedPageFile,
+    file_mapping: &FileMapping,
+    enrich: BookmarkEnricher,
+) -> Result<RenderedPage> {
+    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    Ok(RenderedPage {
+        document: PageArtifactDocument {
+            page: parsed_file.page,
+            title: parsed_file.front_matter.title,
+            description: parsed_file.front_matter.summary,
+            html,
+            updated_at: parsed_file.front_matter.updated,
+        },
+    })
+}
+
+pub(crate) async fn render_category(
+    parsed_file: ParsedCategoryFile,
+    file_mapping: &FileMapping,
+    enrich: BookmarkEnricher,
+) -> Result<RenderedCategoryLanding> {
+    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    let html = if html.trim().is_empty() {
+        build_fallback_category_landing_html(
+            parsed_file.category,
+            &parsed_file.front_matter.title,
+            parsed_file.front_matter.summary.as_deref(),
+        )
+    } else {
+        html
+    };
+    Ok(RenderedCategoryLanding {
+        metadata: CategoryLandingMetadata {
+            category: parsed_file.category,
+            title: parsed_file.front_matter.title,
+            description: parsed_file.front_matter.summary,
+            updated_at: parsed_file.front_matter.updated,
+        },
+        html,
+    })
+}
+
+fn build_fallback_category_landing_html(
+    category: Category,
+    title: &str,
+    description: Option<&str>,
+) -> String {
+    let heading = if title.trim().is_empty() {
+        category.display_name()
+    } else {
+        title.trim()
+    };
+
+    let body = description
+        .filter(|d| !d.trim().is_empty())
+        .map(str::trim)
+        .map(str::to_owned)
+        .unwrap_or_else(|| format!("{}カテゴリの記事一覧です。", category.display_name()));
+    let heading = html_escape(heading);
+    let body = html_escape(&body);
+    format!("<article><h1>{heading}</h1><p>{body}</p></article>")
+}
+
+fn html_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_fallback_category_landing_html_uses_title_and_summary() {
+        let html = build_fallback_category_landing_html(
+            Category::Tech,
+            "Tech",
+            Some("Technology landing"),
+        );
+
+        assert!(html.contains("<h1>Tech</h1>"));
+        assert!(html.contains("<p>Technology landing</p>"));
+    }
+
+    #[test]
+    fn test_build_fallback_category_landing_html_falls_back_to_category_display_name() {
+        let html = build_fallback_category_landing_html(Category::Physics, "   ", None);
+
+        assert!(html.contains("<h1>物理学</h1>"));
+        assert!(html.contains("物理学カテゴリの記事一覧です。"));
+    }
+
+    #[test]
+    fn test_build_fallback_category_landing_html_escapes_frontmatter_text() {
+        let html = build_fallback_category_landing_html(
+            Category::Tech,
+            "<script>alert(1)</script>",
+            Some("\"quoted\" & <tag>"),
+        );
+
+        assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assert!(html.contains("&quot;quoted&quot; &amp; &lt;tag&gt;"));
+        assert!(!html.contains("<script>alert(1)</script>"));
+    }
+}

--- a/crates/publish/publisher/src/render.rs
+++ b/crates/publish/publisher/src/render.rs
@@ -1,11 +1,13 @@
+use crate::BookmarkEnricher;
+use crate::error::Result;
 use crate::types::{
     ParsedArticleFile, ParsedCategoryFile, ParsedPageFile, RenderedArticle,
     RenderedCategoryLanding, RenderedPage,
 };
-use crate::BookmarkEnricher;
-use crate::error::Result;
 use artifacts::CategoryLandingMetadata;
-use domain::{ArticleBody, ArticleMeta, ArticleMetaInput, Category, PageArtifactDocument, Slug, Title};
+use domain::{
+    ArticleBody, ArticleMeta, ArticleMetaInput, Category, PageArtifactDocument, Slug, Title,
+};
 use ingest::{FileMapping, convert_markdown_to_html, convert_obsidian_links};
 use log::warn;
 
@@ -71,24 +73,38 @@ pub(crate) async fn render_category(
     enrich: BookmarkEnricher,
 ) -> Result<RenderedCategoryLanding> {
     let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    let title = normalize_category_title(parsed_file.category, &parsed_file.front_matter.title);
+    let description = normalize_category_description(parsed_file.front_matter.summary.as_deref());
     let html = if html.trim().is_empty() {
-        build_fallback_category_landing_html(
-            parsed_file.category,
-            &parsed_file.front_matter.title,
-            parsed_file.front_matter.summary.as_deref(),
-        )
+        build_fallback_category_landing_html(parsed_file.category, &title, description.as_deref())
     } else {
         html
     };
     Ok(RenderedCategoryLanding {
         metadata: CategoryLandingMetadata {
             category: parsed_file.category,
-            title: parsed_file.front_matter.title,
-            description: parsed_file.front_matter.summary,
+            title,
+            description,
             updated_at: parsed_file.front_matter.updated,
         },
         html,
     })
+}
+
+fn normalize_category_title(category: Category, title: &str) -> String {
+    let title = title.trim();
+    if title.is_empty() {
+        category.display_name().to_owned()
+    } else {
+        title.to_owned()
+    }
+}
+
+fn normalize_category_description(description: Option<&str>) -> Option<String> {
+    description
+        .map(str::trim)
+        .filter(|description| !description.is_empty())
+        .map(str::to_owned)
 }
 
 fn build_fallback_category_landing_html(
@@ -155,5 +171,16 @@ mod tests {
         assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
         assert!(html.contains("&quot;quoted&quot; &amp; &lt;tag&gt;"));
         assert!(!html.contains("<script>alert(1)</script>"));
+    }
+
+    #[test]
+    fn test_normalize_category_metadata_trims_and_falls_back() {
+        assert_eq!(normalize_category_title(Category::Physics, "   "), "物理学");
+        assert_eq!(normalize_category_title(Category::Tech, "  Tech  "), "Tech");
+        assert_eq!(normalize_category_description(Some("   ")), None);
+        assert_eq!(
+            normalize_category_description(Some("  Technology landing  ")),
+            Some("Technology landing".to_string())
+        );
     }
 }

--- a/crates/publish/publisher/src/types.rs
+++ b/crates/publish/publisher/src/types.rs
@@ -1,0 +1,38 @@
+use artifacts::CategoryLandingMetadata;
+use domain::{ArticleMeta, Category, PageArtifactDocument, PageKey};
+use ingest::ObsidianFrontMatter;
+
+pub(crate) struct RenderedArticle {
+    pub(crate) meta: ArticleMeta,
+    pub(crate) html: String,
+}
+
+pub(crate) struct RenderedPage {
+    pub(crate) document: PageArtifactDocument,
+}
+
+pub(crate) struct RenderedCategoryLanding {
+    pub(crate) metadata: CategoryLandingMetadata,
+    pub(crate) html: String,
+}
+
+pub(crate) struct ParsedArticleFile {
+    pub(crate) category: Category,
+    pub(crate) slug: String,
+    pub(crate) mapping_key: String,
+    pub(crate) section_path: Vec<String>,
+    pub(crate) markdown_body: String,
+    pub(crate) front_matter: ObsidianFrontMatter,
+}
+
+pub(crate) struct ParsedPageFile {
+    pub(crate) page: PageKey,
+    pub(crate) markdown_body: String,
+    pub(crate) front_matter: ObsidianFrontMatter,
+}
+
+pub(crate) struct ParsedCategoryFile {
+    pub(crate) category: Category,
+    pub(crate) markdown_body: String,
+    pub(crate) front_matter: ObsidianFrontMatter,
+}


### PR DESCRIPTION
## 概要

（872行）を責務ごとに4ファイルへ分割し、重複コードを除去しました。

## 変更内容

### 新規ファイル
- **** — 内部データ構造体 6 種（、 など）を分離
- **** — ファイル分類ロジック・パースユーティリティ + テスト 11 件を分離
- **** — レンダリングロジック + テスト 3 件を分離

### 修正ファイル
- **** — 公開 API とオーケストレーションのみに絞り込み（~870行 → ~90行）

## 主な改善点

- `render_publishable_article` / `render_static_page` / `render_category_landing` の冗長な wrapper 関数を削除
- markdown → HTML → enrich の変換パターンを `render_html` ヘルパーに抽出（3 箇所の重複解消）
- ファイル分類ループを `classify_obsidian_files` 関数に抽出し、`run_with_enricher` を ~177行 → ~90行に削減
- 各テストを対応するモジュールへ移動

## テスト

既存テスト全件通過（publisher クレート エラー・警告ゼロ）