### PR TITLE
Harden runtime credentials and artifact readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           rustup component add clippy
           rustup target add wasm32-unknown-unknown
 
+      - name: Validate service scripts
+        run: bash -n service/update_aws_creds.sh
+
       - name: Cache Cargo dependencies
         uses: actions/cache@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
       - name: Validate service scripts
-        run: bash -n service/update_aws_creds.sh
+        run: |
+          bash -n service/update_aws_creds.sh
+          bash service/tests/update_aws_creds_test.sh
 
       - name: Cache Cargo dependencies
         uses: actions/cache@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,9 @@ okawak_blog/
 ### `service`
 
 - `systemd`、`nginx`、運用補助ファイルを置く
+- runtime用AWS credentialsは`/var/lib/okawak_blog/aws/credentials`へ置き、`AWS_SHARED_CREDENTIALS_FILE`で明示する
+- `ProtectHome=true`を維持し、serviceからhome directoryのcredentialsを読ませない
+- `/api/health`はliveness、`/api/ready`はartifact readerのreadinessとして扱う
 
 ### `terraform`
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ category: "tech"
 - `nginx` を前段に置いて HTTPS 終端とリバースプロキシを担当させる
 - アプリケーション本体は単一バイナリとして扱う
 - SSR サーバーは S3 上の成果物を読み、必要に応じて静的ファイルも配信する
+- `/api/health` はprocess liveness、`/api/ready` はartifact readerのreadinessとして分ける
+- runtime用AWS credentialsは`/var/lib/okawak_blog/aws/credentials`へ置き、home directoryには依存しない
+
+VPS上のservice設定とcredential更新手順は[service/README.md](./service/README.md)を参照してください。
 
 ## 開発原則
 

--- a/crates/site/server/src/handlers/api.rs
+++ b/crates/site/server/src/handlers/api.rs
@@ -1,6 +1,7 @@
 //! HTTP API handlers.
 
 pub mod articles;
+pub mod readiness;
 
 pub use articles::*;
 
@@ -13,6 +14,7 @@ use leptos::prelude::LeptosOptions;
 pub fn create_api_router(artifact_reader: DynArtifactReader) -> Router<LeptosOptions> {
     Router::new()
         .route("/articles", get(articles::list_articles))
+        .route("/ready", get(readiness::artifact_readiness))
         .layer(Extension(artifact_reader))
 }
 
@@ -24,7 +26,7 @@ mod tests {
         http::{Request, StatusCode},
     };
     use infra::LocalArtifactReader;
-    use std::sync::Arc;
+    use std::{fs, sync::Arc};
     use tempfile::TempDir;
     use tower::util::ServiceExt;
 
@@ -48,5 +50,45 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_readiness_returns_ok_when_site_metadata_is_readable() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::create_dir_all(temp_dir.path().join("metadata")).unwrap();
+        fs::write(
+            temp_dir.path().join("metadata/site.json"),
+            r#"{"total_articles":0,"categories":[]}"#,
+        )
+        .unwrap();
+
+        let response = create_test_router(temp_dir.path())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_readiness_returns_service_unavailable_when_site_metadata_is_missing() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let response = create_test_router(temp_dir.path())
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/crates/site/server/src/handlers/api/readiness.rs
+++ b/crates/site/server/src/handlers/api/readiness.rs
@@ -1,0 +1,17 @@
+//! Runtime readiness checks backed by the configured artifact reader.
+
+use axum::{Extension, http::StatusCode};
+use infra::DynArtifactReader;
+
+pub async fn artifact_readiness(
+    Extension(artifact_reader): Extension<DynArtifactReader>,
+) -> Result<&'static str, (StatusCode, &'static str)> {
+    artifact_reader
+        .read_site_metadata()
+        .await
+        .map(|_| "READY")
+        .map_err(|error| {
+            eprintln!("Artifact readiness check failed: {error}");
+            (StatusCode::SERVICE_UNAVAILABLE, "NOT READY")
+        })
+}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -85,7 +85,8 @@ okawak_blog/
 - `crates/site/server`
   - Axum + Leptos SSR のホスト
   - reader の生成と Leptos context への注入
-  - 互換用の記事一覧 API と health endpoint
+  - 互換用の記事一覧 API
+  - process liveness (`/api/health`) と artifact readiness (`/api/ready`)
 - `crates/site/web`
   - Leptos UI
   - route 定義
@@ -357,6 +358,15 @@ reader 側の設定は主に次の env で切り替える。
 - `OKAWAK_BLOG_ARTIFACT_PREFIX`
 
 `OKAWAK_BLOG_SITE_ORIGIN` は canonical / Open Graph 用の absolute URL 生成に使う。
+
+本番のAWS SDKは`AWS_SHARED_CREDENTIALS_FILE=/var/lib/okawak_blog/aws/credentials`を明示して使う。runtime credentialsはsystemdの`StateDirectory=okawak_blog`配下に置き、`ProtectHome=true`を維持したまま読み取れる構成とする。credential fileの生成・更新は`service/update_aws_creds.sh`が担い、`site/infra`にはcredential管理責務を持ち込まない。
+
+runtime probeは次のように分ける。
+
+- `/api/health`
+  - processがHTTP requestへ応答できることだけを確認するliveness
+- `/api/ready`
+  - configured `ArtifactReader`からsite metadataを読めることを確認するreadiness
 
 ## ローカル開発と本番運用
 

--- a/e2e/tests/artifact-routes.spec.ts
+++ b/e2e/tests/artifact-routes.spec.ts
@@ -41,6 +41,16 @@ async function expectNotFoundMetadata(page: Page, canonicalPath: string) {
   );
 }
 
+test("runtime probes distinguish liveness and artifact readiness", async ({ request }) => {
+  const healthResponse = await request.get("/api/health");
+  expect(healthResponse.status()).toBe(200);
+  expect(await healthResponse.text()).toBe("OK");
+
+  const readinessResponse = await request.get("/api/ready");
+  expect(readinessResponse.status()).toBe(200);
+  expect(await readinessResponse.text()).toBe("READY");
+});
+
 test("home renders artifacts and hydrates article navigation", async ({ page }) => {
   const response = await page.goto("/");
 

--- a/service/README.md
+++ b/service/README.md
@@ -37,9 +37,11 @@ curl --fail http://127.0.0.1:8008/api/ready
 別の検証用pathへ書く場合だけ、次のenvを指定できます。
 
 ```bash
-OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE=/tmp/okawak-blog-credentials \
+OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE=/tmp/okawak-blog-runtime/aws/credentials \
   ./service/update_aws_creds.sh
 ```
+
+override先にもruntime専用directoryを指定してください。スクリプトは既存directoryのmodeやownerを変更せず、既存directoryが実行userの所有で書き込み可能な場合だけ利用します。`/tmp/credentials`のように共有directoryを直接親にするpathは拒否します。
 
 ## Runtime probes
 

--- a/service/README.md
+++ b/service/README.md
@@ -16,12 +16,21 @@ credential更新スクリプトは、`okawak` userの通常環境にある`secre
 
 前提:
 
-- systemd unitを一度起動し、`/var/lib/okawak_blog`が作成されている
 - `okawak` userが`secret-get` profileを利用できる
 - AWS CLIと`jq`が導入済み
+- `okawak` userがruntime directory作成とservice再起動に必要な`sudo`権限を持つ
+
+home配下のcredentialsから移行する初回だけ、serviceのdeploy前にruntime credentialsを配置します。
 
 ```bash
-sudo systemctl start okawak_blog
+OKAWAK_BLOG_SKIP_RESTART=1 ./service/update_aws_creds.sh
+mise run production-deploy
+curl --fail http://127.0.0.1:8008/api/ready
+```
+
+以降のcredential rotationでは、スクリプトがfileを置き換えてserviceを再起動します。
+
+```bash
 ./service/update_aws_creds.sh
 ```
 

--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,43 @@
+# Runtime service
+
+本番のLeptos SSR serverは`okawak_blog.service`で起動し、S3 artifact readerを使います。
+
+## AWS credentials
+
+runtime専用の共有credentials fileは次の場所へ置きます。
+
+```text
+/var/lib/okawak_blog/aws/credentials
+```
+
+このdirectoryのrootはsystemdの`StateDirectory=okawak_blog`が作成し、unitは`AWS_SHARED_CREDENTIALS_FILE`でfileを明示します。`ProtectHome=true`を維持するため、serviceは`~/.aws/credentials`を読みません。
+
+credential更新スクリプトは、`okawak` userの通常環境にある`secret-get` profileでAWS Secrets Managerを読み、runtime専用fileを同一directory内でatomicに置き換えます。
+
+前提:
+
+- systemd unitを一度起動し、`/var/lib/okawak_blog`が作成されている
+- `okawak` userが`secret-get` profileを利用できる
+- AWS CLIと`jq`が導入済み
+
+```bash
+sudo systemctl start okawak_blog
+./service/update_aws_creds.sh
+```
+
+別の検証用pathへ書く場合だけ、次のenvを指定できます。
+
+```bash
+OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE=/tmp/okawak-blog-credentials \
+  ./service/update_aws_creds.sh
+```
+
+## Runtime probes
+
+```bash
+curl --fail http://127.0.0.1:8008/api/health
+curl --fail http://127.0.0.1:8008/api/ready
+```
+
+- `/api/health`: process liveness。artifactの状態は確認しません。
+- `/api/ready`: configured `ArtifactReader`からsite metadataを読めた場合だけ`200 OK`を返します。credentials、S3、local artifact、JSON decodeの問題がある場合は`503 Service Unavailable`です。

--- a/service/okawak_blog.service
+++ b/service/okawak_blog.service
@@ -16,11 +16,13 @@ TimeoutStopSec=30
 
 Environment=AWS_PROFILE=blog-s3
 Environment=AWS_REGION=ap-northeast-1
+Environment=AWS_SHARED_CREDENTIALS_FILE=/var/lib/okawak_blog/aws/credentials
 Environment=OKAWAK_BLOG_ARTIFACT_SOURCE=s3
 Environment=OKAWAK_BLOG_ARTIFACT_BUCKET=okawak-blog-resources-bucket
 Environment=OKAWAK_BLOG_SITE_ORIGIN=https://www.okawak.net
 
 StateDirectory=okawak_blog
+StateDirectoryMode=0700
 LogsDirectory=okawak_blog
 RuntimeDirectory=okawak_blog
 

--- a/service/tests/update_aws_creds_test.sh
+++ b/service/tests/update_aws_creds_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+script="$repo_root/service/update_aws_creds.sh"
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+mode_of() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+mock_bin="$work_dir/bin"
+mkdir -p "$mock_bin"
+
+cat >"$mock_bin/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' '{"aws_access_key_id":"AKIATEST","aws_secret_access_key":"test-secret"}'
+EOF
+
+cat >"$mock_bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "systemctl" ] && [ "$2" = "restart" ] && [ "$3" = "okawak_blog" ]; then
+  exit 0
+fi
+echo "unexpected sudo command: $*" >&2
+exit 1
+EOF
+
+chmod +x "$mock_bin/aws" "$mock_bin/sudo"
+
+runtime_dir="$work_dir/existing-runtime"
+mkdir -m 755 "$runtime_dir"
+mode_before=$(mode_of "$runtime_dir")
+
+PATH="$mock_bin:$PATH" \
+  OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE="$runtime_dir/credentials" \
+  OKAWAK_BLOG_SKIP_RESTART=1 \
+  "$script"
+
+test "$(mode_of "$runtime_dir")" = "$mode_before"
+test "$(mode_of "$runtime_dir/credentials")" = "600"
+grep -qx '\[blog-s3\]' "$runtime_dir/credentials"
+grep -qx 'aws_access_key_id     = AKIATEST' "$runtime_dir/credentials"
+grep -qx 'aws_secret_access_key = test-secret' "$runtime_dir/credentials"
+
+shared_dir_mode=$(mode_of /tmp)
+if PATH="$mock_bin:$PATH" \
+  OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE="/tmp/okawak-blog-unsafe-credentials" \
+  OKAWAK_BLOG_SKIP_RESTART=1 \
+  "$script"; then
+  echo "shared parent directory should have been rejected" >&2
+  exit 1
+fi
+test "$(mode_of /tmp)" = "$shared_dir_mode"
+
+new_runtime_file="$work_dir/new-runtime/aws/credentials"
+PATH="$mock_bin:$PATH" \
+  OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE="$new_runtime_file" \
+  OKAWAK_BLOG_SKIP_RESTART=1 \
+  "$script"
+
+test "$(mode_of "$work_dir/new-runtime/aws")" = "700"
+test "$(mode_of "$new_runtime_file")" = "600"

--- a/service/update_aws_creds.sh
+++ b/service/update_aws_creds.sh
@@ -4,41 +4,34 @@ set -euo pipefail
 SECRET_NAME="blog/iam_access_key" # Terraform で作成した Secret 名
 SRC_PROFILE="secret-get"
 DST_PROFILE="blog-s3" # Leptos が使うプロファイル
-if [ -n "$XDG_CONFIG_HOME" ]; then
-  AWS_CONFIG_DIR="$XDG_CONFIG_HOME/aws"
-else
-  AWS_CONFIG_DIR="$HOME/.aws"
-fi
-CRED_FILE="$AWS_CONFIG_DIR/credentials"
+RUNTIME_CREDENTIAL_FILE="${OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE:-/var/lib/okawak_blog/aws/credentials}"
+RUNTIME_CREDENTIAL_DIR=$(dirname "$RUNTIME_CREDENTIAL_FILE")
+
+umask 077
 
 # 1. 最新キーを取得
 json=$(AWS_PROFILE=$SRC_PROFILE aws secretsmanager get-secret-value \
   --secret-id "$SECRET_NAME" --query SecretString --output text)
 
-new_id=$(echo "$json" | jq -r .aws_access_key_id)
-new_secret=$(echo "$json" | jq -r .aws_secret_access_key)
+new_id=$(printf '%s' "$json" | jq -er '.aws_access_key_id | select(type == "string" and length > 0)')
+new_secret=$(printf '%s' "$json" | jq -er '.aws_secret_access_key | select(type == "string" and length > 0)')
 
-# 2. credentials を置き換え（DST_PROFILE 部分だけ書き直す）
-tmp=$(mktemp)
-awk -v p="[$DST_PROFILE]" '
-  BEGIN {skip=0}
-  $0==p {print; getline; getline; skip=1; next}
-  skip && NF==0 {skip=0; next}
-  !skip {print}
-' "$CRED_FILE" 2>/dev/null || true >"$tmp"
+# 2. runtime 専用 credentials file を同一 directory 内で atomic に置き換える
+install -d -m 700 "$RUNTIME_CREDENTIAL_DIR"
+tmp=$(mktemp "$RUNTIME_CREDENTIAL_DIR/.credentials.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
 
-cat >>"$tmp" <<EOF
+cat >"$tmp" <<EOF
 [$DST_PROFILE]
 aws_access_key_id     = $new_id
 aws_secret_access_key = $new_secret
-region                = ap-northeast-1
 EOF
 
-install -m 600 -o "$USER" -g "$USER" "$tmp" "$CRED_FILE"
-rm -f "$tmp"
+chmod 600 "$tmp"
+mv -f "$tmp" "$RUNTIME_CREDENTIAL_FILE"
+trap - EXIT
 
 # 3. Leptos サービスを再起動
 sudo systemctl restart okawak_blog
 
-echo "$(date '+%F %T') credentials updated to $new_id" \
-  >>"$HOME/creds_update.log"
+echo "$(date '+%F %T') runtime credentials updated"

--- a/service/update_aws_creds.sh
+++ b/service/update_aws_creds.sh
@@ -16,17 +16,40 @@ fi
 
 umask 077
 
-# 1. 最新キーを取得
+prepare_runtime_credential_dir() {
+  if [ -L "$RUNTIME_CREDENTIAL_DIR" ]; then
+    echo "Runtime credential directory must not be a symbolic link: $RUNTIME_CREDENTIAL_DIR" >&2
+    exit 1
+  fi
+
+  if [ -e "$RUNTIME_CREDENTIAL_DIR" ]; then
+    if [ ! -d "$RUNTIME_CREDENTIAL_DIR" ]; then
+      echo "Runtime credential directory path is not a directory: $RUNTIME_CREDENTIAL_DIR" >&2
+      exit 1
+    fi
+    if [ ! -O "$RUNTIME_CREDENTIAL_DIR" ] || [ ! -w "$RUNTIME_CREDENTIAL_DIR" ]; then
+      echo "Existing runtime credential directory must be owned and writable by $SERVICE_USER: $RUNTIME_CREDENTIAL_DIR" >&2
+      exit 1
+    fi
+    return
+  fi
+
+  if ! install -d -m 700 "$RUNTIME_CREDENTIAL_DIR" 2>/dev/null; then
+    sudo install -d -m 700 -o "$SERVICE_USER" -g "$SERVICE_GROUP" "$RUNTIME_CREDENTIAL_DIR"
+  fi
+}
+
+# 1. 既存directoryの権限は変更せず、未作成のruntime専用directoryだけを作る
+prepare_runtime_credential_dir
+
+# 2. 最新キーを取得
 json=$(AWS_PROFILE=$SRC_PROFILE aws secretsmanager get-secret-value \
   --secret-id "$SECRET_NAME" --query SecretString --output text)
 
 new_id=$(printf '%s' "$json" | jq -er '.aws_access_key_id | select(type == "string" and length > 0)')
 new_secret=$(printf '%s' "$json" | jq -er '.aws_secret_access_key | select(type == "string" and length > 0)')
 
-# 2. runtime 専用 credentials file を同一 directory 内で atomic に置き換える
-if ! install -d -m 700 "$RUNTIME_CREDENTIAL_DIR" 2>/dev/null; then
-  sudo install -d -m 700 -o "$SERVICE_USER" -g "$SERVICE_GROUP" "$RUNTIME_CREDENTIAL_DIR"
-fi
+# 3. runtime 専用 credentials file を同一 directory 内で atomic に置き換える
 tmp=$(mktemp "$RUNTIME_CREDENTIAL_DIR/.credentials.XXXXXX")
 trap 'rm -f "$tmp"' EXIT
 
@@ -40,7 +63,7 @@ chmod 600 "$tmp"
 mv -f "$tmp" "$RUNTIME_CREDENTIAL_FILE"
 trap - EXIT
 
-# 3. 通常のrotationではLeptos serviceを再起動する。初回移行ではdeploy前に省略できる。
+# 4. 通常のrotationではLeptos serviceを再起動する。初回移行ではdeploy前に省略できる。
 if [ "${OKAWAK_BLOG_SKIP_RESTART:-0}" != "1" ]; then
   sudo systemctl restart okawak_blog
 fi

--- a/service/update_aws_creds.sh
+++ b/service/update_aws_creds.sh
@@ -6,6 +6,13 @@ SRC_PROFILE="secret-get"
 DST_PROFILE="blog-s3" # Leptos が使うプロファイル
 RUNTIME_CREDENTIAL_FILE="${OKAWAK_BLOG_RUNTIME_CREDENTIAL_FILE:-/var/lib/okawak_blog/aws/credentials}"
 RUNTIME_CREDENTIAL_DIR=$(dirname "$RUNTIME_CREDENTIAL_FILE")
+SERVICE_USER=$(id -un)
+SERVICE_GROUP=$(id -gn)
+
+if [ "$(id -u)" -eq 0 ]; then
+  echo "Run this script as the okawak service user, not root." >&2
+  exit 1
+fi
 
 umask 077
 
@@ -17,7 +24,9 @@ new_id=$(printf '%s' "$json" | jq -er '.aws_access_key_id | select(type == "stri
 new_secret=$(printf '%s' "$json" | jq -er '.aws_secret_access_key | select(type == "string" and length > 0)')
 
 # 2. runtime 専用 credentials file を同一 directory 内で atomic に置き換える
-install -d -m 700 "$RUNTIME_CREDENTIAL_DIR"
+if ! install -d -m 700 "$RUNTIME_CREDENTIAL_DIR" 2>/dev/null; then
+  sudo install -d -m 700 -o "$SERVICE_USER" -g "$SERVICE_GROUP" "$RUNTIME_CREDENTIAL_DIR"
+fi
 tmp=$(mktemp "$RUNTIME_CREDENTIAL_DIR/.credentials.XXXXXX")
 trap 'rm -f "$tmp"' EXIT
 
@@ -31,7 +40,9 @@ chmod 600 "$tmp"
 mv -f "$tmp" "$RUNTIME_CREDENTIAL_FILE"
 trap - EXIT
 
-# 3. Leptos サービスを再起動
-sudo systemctl restart okawak_blog
+# 3. 通常のrotationではLeptos serviceを再起動する。初回移行ではdeploy前に省略できる。
+if [ "${OKAWAK_BLOG_SKIP_RESTART:-0}" != "1" ]; then
+  sudo systemctl restart okawak_blog
+fi
 
 echo "$(date '+%F %T') runtime credentials updated"


### PR DESCRIPTION
## 概要

systemdの`ProtectHome=true`を維持したままAWS SDKがruntime credentialsを読めるようにし、process livenessとartifact readinessを分離します。

Closes #79

## 変更内容

- runtime credentialsを`/var/lib/okawak_blog/aws/credentials`へ統一
- systemd unitで`AWS_SHARED_CREDENTIALS_FILE`と`StateDirectoryMode=0700`を明示
- credential更新スクリプトをruntime専用fileのatomic置換へ簡素化
- secret JSONの必須値検証と0600 permissionを追加
- access key IDをlogへ残さないよう変更
- 初回移行用に`OKAWAK_BLOG_SKIP_RESTART=1`を追加
- `/api/ready`を追加し、site metadataを読めた場合だけ200を返す
- readinessの成功 / 失敗unit testとHTTP E2Eを追加
- service運用手順、README、architecture、AGENTSを更新
- CIへcredential scriptのsyntax checkを追加

## 背景とroot cause

従来は`AWS_PROFILE=blog-s3`がhome配下の共有credentialsを読む構成でしたが、同じunitで`ProtectHome=true`を指定していました。また、`/api/health`は常に`OK`を返すため、credentials、S3、artifact JSONの問題を検出できませんでした。

credential管理は`service/`へ残し、`site/infra`の`ArtifactReader`へ新しい管理責務を追加していません。readinessはserver境界で既存readerの最小readを行います。

## VPSでの初回移行

新しいunitをdeployする前にruntime credentialsを先行配置します。

```bash
OKAWAK_BLOG_SKIP_RESTART=1 ./service/update_aws_creds.sh
mise run production-deploy
curl --fail http://127.0.0.1:8008/api/ready
```

通常のrotationでは従来どおり`./service/update_aws_creds.sh`を実行するとserviceも再起動します。

## 検証

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p web --features ssr`
- `cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate`
- `bunx tsc --noEmit`
- `mise run test-e2e`（Chromium 6件成功）
- `bash -n service/update_aws_creds.sh`
- mock AWS / sudoによる通常rotationとbootstrap modeのcredential生成確認
- credential file permission 0600確認
- `git diff --check`
