### PR TITLE
Cache immutable artifact snapshots

### DIFF
--- a/crates/site/infra/Cargo.toml
+++ b/crates/site/infra/Cargo.toml
@@ -14,8 +14,8 @@ aws-sdk-s3 = { workspace = true, default-features = false, features = ["default-
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "sync"] }
 
 [dev-dependencies]
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/site/infra/src/cache.rs
+++ b/crates/site/infra/src/cache.rs
@@ -1,0 +1,437 @@
+use crate::{ArtifactReader, ArtifactSnapshot, DynArtifactReader, DynArtifactSnapshot, Result};
+use async_trait::async_trait;
+use domain::{
+    ArticleIndexDocument, Category, CategoryIndexDocument, PageArtifactDocument, PageKey,
+    SiteMetadataDocument, Slug,
+};
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::sync::{Mutex, OnceCell};
+
+pub struct CachingArtifactReader {
+    inner: DynArtifactReader,
+    snapshot_ttl: Duration,
+    cached: Mutex<Option<CachedSnapshot>>,
+}
+
+struct CachedSnapshot {
+    loaded_at: Instant,
+    snapshot: DynArtifactSnapshot,
+}
+
+impl CachedSnapshot {
+    fn is_fresh(&self, now: Instant, ttl: Duration) -> bool {
+        now.duration_since(self.loaded_at) < ttl
+    }
+
+    fn has_same_identity(&self, candidate: &DynArtifactSnapshot) -> bool {
+        self.snapshot
+            .cache_identity()
+            .is_some_and(|identity| Some(identity) == candidate.cache_identity())
+    }
+}
+
+impl CachingArtifactReader {
+    pub fn new(inner: DynArtifactReader, snapshot_ttl: Duration) -> Self {
+        Self {
+            inner,
+            snapshot_ttl,
+            cached: Mutex::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl ArtifactReader for CachingArtifactReader {
+    async fn snapshot(&self) -> Result<DynArtifactSnapshot> {
+        if self.snapshot_ttl.is_zero() {
+            return self.inner.snapshot().await;
+        }
+
+        let mut cached = self.cached.lock().await;
+        if let Some(cached) = cached.as_ref()
+            && cached.is_fresh(Instant::now(), self.snapshot_ttl)
+        {
+            return Ok(Arc::clone(&cached.snapshot));
+        }
+
+        let inner_snapshot = self.inner.snapshot().await?;
+        if let Some(cached) = cached.as_mut()
+            && cached.has_same_identity(&inner_snapshot)
+        {
+            cached.loaded_at = Instant::now();
+            return Ok(Arc::clone(&cached.snapshot));
+        }
+
+        let snapshot: DynArtifactSnapshot = Arc::new(CachingArtifactSnapshot::new(inner_snapshot));
+        *cached = Some(CachedSnapshot {
+            loaded_at: Instant::now(),
+            snapshot: Arc::clone(&snapshot),
+        });
+        Ok(snapshot)
+    }
+}
+
+struct CachingArtifactSnapshot {
+    inner: DynArtifactSnapshot,
+    article_index: OnceCell<ArticleIndexDocument>,
+    site_metadata: OnceCell<SiteMetadataDocument>,
+    category_indexes: KeyedCache<CategoryIndexDocument>,
+    category_html: KeyedCache<String>,
+    article_html: KeyedCache<String>,
+    page_documents: KeyedCache<PageArtifactDocument>,
+}
+
+impl CachingArtifactSnapshot {
+    fn new(inner: DynArtifactSnapshot) -> Self {
+        Self {
+            inner,
+            article_index: OnceCell::new(),
+            site_metadata: OnceCell::new(),
+            category_indexes: KeyedCache::new(),
+            category_html: KeyedCache::new(),
+            article_html: KeyedCache::new(),
+            page_documents: KeyedCache::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ArtifactSnapshot for CachingArtifactSnapshot {
+    fn cache_identity(&self) -> Option<&str> {
+        self.inner.cache_identity()
+    }
+
+    async fn read_article_index(&self) -> Result<ArticleIndexDocument> {
+        self.article_index
+            .get_or_try_init(|| self.inner.read_article_index())
+            .await
+            .cloned()
+    }
+
+    async fn read_category_index(&self, category: &str) -> Result<CategoryIndexDocument> {
+        self.category_indexes
+            .get_or_try_init(category.to_string(), || {
+                self.inner.read_category_index(category)
+            })
+            .await
+    }
+
+    async fn read_category_html(&self, category: &Category) -> Result<String> {
+        self.category_html
+            .get_or_try_init(category.as_str().to_string(), || {
+                self.inner.read_category_html(category)
+            })
+            .await
+    }
+
+    async fn read_site_metadata(&self) -> Result<SiteMetadataDocument> {
+        self.site_metadata
+            .get_or_try_init(|| self.inner.read_site_metadata())
+            .await
+            .cloned()
+    }
+
+    async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String> {
+        self.article_html
+            .get_or_try_init(format!("{}/{}", category.as_str(), slug.as_str()), || {
+                self.inner.read_article_html(category, slug)
+            })
+            .await
+    }
+
+    async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {
+        self.page_documents
+            .get_or_try_init(page.as_str().to_string(), || {
+                self.inner.read_page_document(page)
+            })
+            .await
+    }
+}
+
+struct KeyedCache<T> {
+    entries: Mutex<HashMap<String, Arc<OnceCell<T>>>>,
+}
+
+impl<T> KeyedCache<T>
+where
+    T: Clone,
+{
+    fn new() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn get_or_try_init<F, Fut>(&self, key: String, load: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        let cell = {
+            let mut entries = self.entries.lock().await;
+            Arc::clone(
+                entries
+                    .entry(key)
+                    .or_insert_with(|| Arc::new(OnceCell::new())),
+            )
+        };
+
+        cell.get_or_try_init(load).await.cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::InfraError;
+    use domain::CategoryMetadataDocument;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct CountingReader {
+        snapshot_calls: Arc<AtomicUsize>,
+        article_reads: Arc<AtomicUsize>,
+        fail_next_article_read: Arc<AtomicBool>,
+        cache_identity: Option<&'static str>,
+    }
+
+    #[async_trait]
+    impl ArtifactReader for CountingReader {
+        async fn snapshot(&self) -> Result<DynArtifactSnapshot> {
+            self.snapshot_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Arc::new(CountingSnapshot {
+                article_reads: Arc::clone(&self.article_reads),
+                fail_next_article_read: Arc::clone(&self.fail_next_article_read),
+                cache_identity: self.cache_identity,
+            }))
+        }
+    }
+
+    struct CountingSnapshot {
+        article_reads: Arc<AtomicUsize>,
+        fail_next_article_read: Arc<AtomicBool>,
+        cache_identity: Option<&'static str>,
+    }
+
+    #[async_trait]
+    impl ArtifactSnapshot for CountingSnapshot {
+        fn cache_identity(&self) -> Option<&str> {
+            self.cache_identity
+        }
+
+        async fn read_article_index(&self) -> Result<ArticleIndexDocument> {
+            self.article_reads.fetch_add(1, Ordering::SeqCst);
+            tokio::task::yield_now().await;
+            if self.fail_next_article_read.swap(false, Ordering::SeqCst) {
+                return Err(InfraError::Io(std::io::Error::other("temporary failure")));
+            }
+            Ok(ArticleIndexDocument { articles: vec![] })
+        }
+
+        async fn read_category_index(&self, category: &str) -> Result<CategoryIndexDocument> {
+            Ok(CategoryIndexDocument {
+                category: category.to_string(),
+                title: None,
+                description: None,
+                updated_at: None,
+                articles: vec![],
+            })
+        }
+
+        async fn read_category_html(&self, category: &Category) -> Result<String> {
+            Ok(category.as_str().to_string())
+        }
+
+        async fn read_site_metadata(&self) -> Result<SiteMetadataDocument> {
+            Ok(SiteMetadataDocument {
+                total_articles: 0,
+                categories: Vec::<CategoryMetadataDocument>::new(),
+            })
+        }
+
+        async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String> {
+            Ok(format!("{}/{}", category.as_str(), slug.as_str()))
+        }
+
+        async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {
+            Ok(PageArtifactDocument {
+                page: page.clone(),
+                title: page.as_str().to_string(),
+                description: None,
+                html: String::new(),
+                updated_at: String::new(),
+            })
+        }
+    }
+
+    fn counting_reader(
+        fail_next_article_read: bool,
+    ) -> (CachingArtifactReader, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let snapshot_calls = Arc::new(AtomicUsize::new(0));
+        let article_reads = Arc::new(AtomicUsize::new(0));
+        let inner: DynArtifactReader = Arc::new(CountingReader {
+            snapshot_calls: Arc::clone(&snapshot_calls),
+            article_reads: Arc::clone(&article_reads),
+            fail_next_article_read: Arc::new(AtomicBool::new(fail_next_article_read)),
+            cache_identity: Some("release-1"),
+        });
+        (
+            CachingArtifactReader::new(inner, Duration::from_secs(60)),
+            snapshot_calls,
+            article_reads,
+        )
+    }
+
+    #[tokio::test]
+    async fn reuses_snapshot_and_single_flights_concurrent_artifact_reads() {
+        let (reader, snapshot_calls, article_reads) = counting_reader(false);
+        let first = reader.snapshot().await.unwrap();
+        let second = reader.snapshot().await.unwrap();
+
+        let (first_result, second_result) =
+            tokio::join!(first.read_article_index(), second.read_article_index());
+
+        assert!(first_result.is_ok());
+        assert!(second_result.is_ok());
+        assert_eq!(snapshot_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(article_reads.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn zero_ttl_disables_snapshot_and_artifact_cache() {
+        let snapshot_calls = Arc::new(AtomicUsize::new(0));
+        let article_reads = Arc::new(AtomicUsize::new(0));
+        let inner: DynArtifactReader = Arc::new(CountingReader {
+            snapshot_calls: Arc::clone(&snapshot_calls),
+            article_reads: Arc::clone(&article_reads),
+            fail_next_article_read: Arc::new(AtomicBool::new(false)),
+            cache_identity: Some("release-1"),
+        });
+        let reader = CachingArtifactReader::new(inner, Duration::ZERO);
+
+        reader
+            .snapshot()
+            .await
+            .unwrap()
+            .read_article_index()
+            .await
+            .unwrap();
+        reader
+            .snapshot()
+            .await
+            .unwrap()
+            .read_article_index()
+            .await
+            .unwrap();
+
+        assert_eq!(snapshot_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(article_reads.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn artifact_errors_are_not_cached() {
+        let (reader, _, article_reads) = counting_reader(true);
+        let snapshot = reader.snapshot().await.unwrap();
+
+        assert!(snapshot.read_article_index().await.is_err());
+        assert!(snapshot.read_article_index().await.is_ok());
+        assert_eq!(article_reads.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn keyed_cache_single_flights_each_key_independently() {
+        let cache = KeyedCache::new();
+        let loads = AtomicUsize::new(0);
+
+        let (first, second) = tokio::join!(
+            cache.get_or_try_init("same".to_string(), || async {
+                loads.fetch_add(1, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                Ok("value".to_string())
+            }),
+            cache.get_or_try_init("same".to_string(), || async {
+                loads.fetch_add(1, Ordering::SeqCst);
+                Ok("other".to_string())
+            })
+        );
+
+        assert_eq!(first.unwrap(), "value");
+        assert_eq!(second.unwrap(), "value");
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn snapshot_expires_at_ttl_boundary() {
+        let (reader, snapshot_calls, _) = counting_reader(false);
+        let snapshot = reader.snapshot().await.unwrap();
+        let loaded_at = Instant::now();
+        let cached = CachedSnapshot {
+            loaded_at,
+            snapshot,
+        };
+
+        assert!(cached.is_fresh(loaded_at, Duration::from_secs(5)));
+        assert!(!cached.is_fresh(loaded_at + Duration::from_secs(5), Duration::from_secs(5)));
+        assert_eq!(snapshot_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn same_release_identity_preserves_artifact_cache_after_refresh() {
+        let snapshot_calls = Arc::new(AtomicUsize::new(0));
+        let article_reads = Arc::new(AtomicUsize::new(0));
+        let inner: DynArtifactReader = Arc::new(CountingReader {
+            snapshot_calls: Arc::clone(&snapshot_calls),
+            article_reads: Arc::clone(&article_reads),
+            fail_next_article_read: Arc::new(AtomicBool::new(false)),
+            cache_identity: Some("release-1"),
+        });
+        let reader = CachingArtifactReader::new(inner, Duration::from_millis(1));
+
+        reader
+            .snapshot()
+            .await
+            .unwrap()
+            .read_article_index()
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        reader
+            .snapshot()
+            .await
+            .unwrap()
+            .read_article_index()
+            .await
+            .unwrap();
+
+        assert_eq!(snapshot_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(article_reads.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn missing_or_different_release_identity_does_not_reuse_cache() {
+        let article_reads = Arc::new(AtomicUsize::new(0));
+        let snapshot = |cache_identity| -> DynArtifactSnapshot {
+            Arc::new(CountingSnapshot {
+                article_reads: Arc::clone(&article_reads),
+                fail_next_article_read: Arc::new(AtomicBool::new(false)),
+                cache_identity,
+            })
+        };
+        let cached = CachedSnapshot {
+            loaded_at: Instant::now(),
+            snapshot: snapshot(Some("release-1")),
+        };
+
+        assert!(!cached.has_same_identity(&snapshot(Some("release-2"))));
+
+        let legacy = CachedSnapshot {
+            loaded_at: Instant::now(),
+            snapshot: snapshot(None),
+        };
+        assert!(!legacy.has_same_identity(&snapshot(None)));
+    }
+}

--- a/crates/site/infra/src/error.rs
+++ b/crates/site/infra/src/error.rs
@@ -12,6 +12,8 @@ pub enum InfraError {
     Utf8(#[from] std::string::FromUtf8Error),
     #[error("missing artifact configuration: {0}")]
     MissingConfig(&'static str),
+    #[error("invalid artifact configuration {key}: {value}")]
+    InvalidConfig { key: &'static str, value: String },
     #[error("unsupported artifact source: {0}")]
     UnsupportedSource(String),
     #[error("failed to read s3 object s3://{bucket}/{key}: {source}")]

--- a/crates/site/infra/src/lib.rs
+++ b/crates/site/infra/src/lib.rs
@@ -1,5 +1,7 @@
+mod cache;
 mod error;
 
+pub use cache::CachingArtifactReader;
 pub use error::{InfraError, Result};
 
 use async_trait::async_trait;
@@ -13,6 +15,7 @@ use std::{
     env,
     path::{Path, PathBuf},
     sync::Arc,
+    time::Duration,
 };
 
 const DEFAULT_LOCAL_SITE_ROOT: &str = "crates/publish/publisher/dist/site";
@@ -20,6 +23,8 @@ const ARTIFACT_SOURCE_ENV: &str = "OKAWAK_BLOG_ARTIFACT_SOURCE";
 const ARTIFACT_LOCAL_ROOT_ENV: &str = "OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT";
 const ARTIFACT_BUCKET_ENV: &str = "OKAWAK_BLOG_ARTIFACT_BUCKET";
 const ARTIFACT_PREFIX_ENV: &str = "OKAWAK_BLOG_ARTIFACT_PREFIX";
+const ARTIFACT_CACHE_TTL_SECONDS_ENV: &str = "OKAWAK_BLOG_ARTIFACT_CACHE_TTL_SECONDS";
+const DEFAULT_ARTIFACT_CACHE_TTL_SECONDS: u64 = 5;
 
 pub type DynArtifactReader = Arc<dyn ArtifactReader>;
 pub type DynArtifactSnapshot = Arc<dyn ArtifactSnapshot>;
@@ -31,6 +36,10 @@ pub trait ArtifactReader: Send + Sync {
 
 #[async_trait]
 pub trait ArtifactSnapshot: Send + Sync {
+    fn cache_identity(&self) -> Option<&str> {
+        None
+    }
+
     async fn read_article_index(&self) -> Result<ArticleIndexDocument>;
     async fn read_category_index(&self, category: &str) -> Result<CategoryIndexDocument>;
     async fn read_category_html(&self, category: &Category) -> Result<String>;
@@ -164,6 +173,7 @@ pub struct S3ArtifactReader {
 pub struct S3ArtifactSnapshot {
     client: Client,
     location: S3ArtifactLocation,
+    cache_identity: Option<String>,
 }
 
 impl S3ArtifactReader {
@@ -177,8 +187,12 @@ impl S3ArtifactReader {
 }
 
 impl S3ArtifactSnapshot {
-    fn new(client: Client, location: S3ArtifactLocation) -> Self {
-        Self { client, location }
+    fn new(client: Client, location: S3ArtifactLocation, cache_identity: Option<String>) -> Self {
+        Self {
+            client,
+            location,
+            cache_identity,
+        }
     }
 
     async fn read_text(&self, relative: &str) -> Result<String> {
@@ -211,28 +225,37 @@ impl S3ArtifactSnapshot {
 #[async_trait]
 impl ArtifactReader for S3ArtifactReader {
     async fn snapshot(&self) -> Result<DynArtifactSnapshot> {
-        let base = S3ArtifactSnapshot::new(self.client.clone(), self.location.clone());
-        let location = match base
+        let base = S3ArtifactSnapshot::new(self.client.clone(), self.location.clone(), None);
+        let (location, cache_identity) = match base
             .read_json::<ArtifactReleasePointerDocument>("current.json")
             .await
         {
             Ok(pointer) => {
                 pointer.validate()?;
-                self.location.with_relative_prefix(&pointer.artifact_prefix)
+                let cache_identity = pointer.artifact_prefix.clone();
+                (
+                    self.location.with_relative_prefix(&pointer.artifact_prefix),
+                    Some(cache_identity),
+                )
             }
-            Err(error) if error.is_not_found() => self.location.clone(),
+            Err(error) if error.is_not_found() => (self.location.clone(), None),
             Err(error) => return Err(error),
         };
 
         Ok(Arc::new(S3ArtifactSnapshot::new(
             self.client.clone(),
             location,
+            cache_identity,
         )))
     }
 }
 
 #[async_trait]
 impl ArtifactSnapshot for S3ArtifactSnapshot {
+    fn cache_identity(&self) -> Option<&str> {
+        self.cache_identity.as_deref()
+    }
+
     async fn read_article_index(&self) -> Result<ArticleIndexDocument> {
         self.read_json("articles/index.json").await
     }
@@ -270,8 +293,13 @@ impl ArtifactSnapshot for S3ArtifactSnapshot {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArtifactSourceConfig {
-    Local { site_root: PathBuf },
-    S3 { location: S3ArtifactLocation },
+    Local {
+        site_root: PathBuf,
+    },
+    S3 {
+        location: S3ArtifactLocation,
+        cache_ttl: Duration,
+    },
 }
 
 impl ArtifactSourceConfig {
@@ -292,8 +320,20 @@ impl ArtifactSourceConfig {
                 let bucket = read_var(ARTIFACT_BUCKET_ENV)
                     .ok_or(InfraError::MissingConfig(ARTIFACT_BUCKET_ENV))?;
                 let prefix = read_var(ARTIFACT_PREFIX_ENV);
+                let cache_ttl = read_var(ARTIFACT_CACHE_TTL_SECONDS_ENV)
+                    .map(|value| {
+                        value.parse::<u64>().map(Duration::from_secs).map_err(|_| {
+                            InfraError::InvalidConfig {
+                                key: ARTIFACT_CACHE_TTL_SECONDS_ENV,
+                                value,
+                            }
+                        })
+                    })
+                    .transpose()?
+                    .unwrap_or(Duration::from_secs(DEFAULT_ARTIFACT_CACHE_TTL_SECONDS));
                 Ok(Self::S3 {
                     location: S3ArtifactLocation::new(bucket, prefix)?,
+                    cache_ttl,
                 })
             }
             unsupported => Err(InfraError::UnsupportedSource(unsupported.to_string())),
@@ -313,10 +353,14 @@ pub async fn build_artifact_reader(config: ArtifactSourceConfig) -> Result<DynAr
         ArtifactSourceConfig::Local { site_root } => {
             Ok(Arc::new(LocalArtifactReader::new(site_root)))
         }
-        ArtifactSourceConfig::S3 { location } => {
+        ArtifactSourceConfig::S3 {
+            location,
+            cache_ttl,
+        } => {
             let shared_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
             let client = Client::new(&shared_config);
-            Ok(Arc::new(S3ArtifactReader::new(client, location)))
+            let reader: DynArtifactReader = Arc::new(S3ArtifactReader::new(client, location));
+            Ok(Arc::new(CachingArtifactReader::new(reader, cache_ttl)))
         }
     }
 }
@@ -523,8 +567,44 @@ mod tests {
             source,
             ArtifactSourceConfig::S3 {
                 location: S3ArtifactLocation::new("blog-bucket", Some("/public/site/")).unwrap(),
+                cache_ttl: Duration::from_secs(DEFAULT_ARTIFACT_CACHE_TTL_SECONDS),
             }
         );
+    }
+
+    #[test]
+    fn test_artifact_source_config_from_env_uses_s3_cache_ttl_override() {
+        let source = ArtifactSourceConfig::from_env_with(|key| match key {
+            ARTIFACT_SOURCE_ENV => Some("s3".to_string()),
+            ARTIFACT_BUCKET_ENV => Some("blog-bucket".to_string()),
+            ARTIFACT_CACHE_TTL_SECONDS_ENV => Some("0".to_string()),
+            _ => None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            source,
+            ArtifactSourceConfig::S3 {
+                location: S3ArtifactLocation::new("blog-bucket", None::<String>).unwrap(),
+                cache_ttl: Duration::ZERO,
+            }
+        );
+    }
+
+    #[test]
+    fn test_artifact_source_config_from_env_rejects_invalid_s3_cache_ttl() {
+        let result = ArtifactSourceConfig::from_env_with(|key| match key {
+            ARTIFACT_SOURCE_ENV => Some("s3".to_string()),
+            ARTIFACT_BUCKET_ENV => Some("blog-bucket".to_string()),
+            ARTIFACT_CACHE_TTL_SECONDS_ENV => Some("soon".to_string()),
+            _ => None,
+        });
+
+        assert!(matches!(
+            result,
+            Err(InfraError::InvalidConfig { key, value })
+                if key == ARTIFACT_CACHE_TTL_SECONDS_ENV && value == "soon"
+        ));
     }
 
     #[test]

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -369,10 +369,13 @@ artifact の読取は2段階の境界を経由する。
   - dev / test 用
   - `mise` のローカル task で利用
   - configured local rootをそのままsnapshotにする
+  - file更新の即時反映を維持するためmemory cache decoratorを適用しない
 - S3 reader
   - 本番用
   - `service/okawak_blog.service` 側の env で選択
-  - `current.json`をsnapshot取得時に1回だけ読み、全artifact keyを同じrelease prefixへ固定する
+  - `current.json`を読み、全artifact keyを同じrelease prefixへ固定する
+  - release snapshotを短いTTLで再利用し、同一snapshot内のimmutable artifactをmemory cacheする
+  - 同じartifactへのconcurrent missは1回のunderlying readへまとめ、load errorはcacheしない
   - 移行互換として`current.json`が存在しない場合だけ従来のbucket rootを読む
 
 reader 側の設定は主に次の env で切り替える。
@@ -382,8 +385,13 @@ reader 側の設定は主に次の env で切り替える。
 - `OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT`
 - `OKAWAK_BLOG_ARTIFACT_BUCKET`
 - `OKAWAK_BLOG_ARTIFACT_PREFIX`
+- `OKAWAK_BLOG_ARTIFACT_CACHE_TTL_SECONDS`
+  - S3の`current.json`を再確認する間隔
+  - defaultは5秒。`0`でcacheを無効化する
 
 `OKAWAK_BLOG_SITE_ORIGIN` は canonical / Open Graph 用の absolute URL 生成に使う。
+
+cacheはrelease snapshot単位で所有する。TTL経過後に`current.json`を再確認し、release identityが同じならartifact cacheを保持する。identityが変わった場合だけ新しいcacheへ切り替わり、既存requestが保持する古いsnapshotはそのrequestの完了まで有効である。legacy rootにはidentityを付けず、TTLごとにcacheを作り直す。snapshot更新失敗時に期限切れcacheへfallbackせず、errorを返して次回requestで再試行する。stale-if-errorやretry policyは別の配信最適化として扱う。
 
 本番のAWS SDKは`AWS_SHARED_CREDENTIALS_FILE=/var/lib/okawak_blog/aws/credentials`を明示して使う。runtime credentialsはsystemdの`StateDirectory=okawak_blog`配下に置き、`ProtectHome=true`を維持したまま読み取れる構成とする。credential fileの生成・更新は`service/update_aws_creds.sh`が担い、`site/infra`にはcredential管理責務を持ち込まない。
 

--- a/service/README.md
+++ b/service/README.md
@@ -52,3 +52,16 @@ curl --fail http://127.0.0.1:8008/api/ready
 
 - `/api/health`: process liveness。artifactの状態は確認しません。
 - `/api/ready`: configured `ArtifactReader`からsite metadataを読めた場合だけ`200 OK`を返します。credentials、S3、local artifact、JSON decodeの問題がある場合は`503 Service Unavailable`です。
+
+## Artifact cache
+
+本番のS3 readerは、release snapshotとそのimmutable artifactをprocess memoryでcacheします。
+
+- `OKAWAK_BLOG_ARTIFACT_CACHE_TTL_SECONDS=5`: production unitの既定値
+- TTL内は同じrelease snapshotを再利用するため、新しい`current.json`の反映には最大でTTL分の遅延が生じる
+- TTL経過時にrelease identityが同じなら、取得済みartifactは引き続きcacheする
+- `0`を指定するとsnapshotとartifactのcacheを無効化する
+- load errorはcacheしない。期限切れsnapshotの更新に失敗した場合もstale contentへfallbackしない
+- local readerにはcacheを適用しない
+
+値は0以上の整数秒で指定します。不正値の場合はserver起動時のconfiguration errorになります。

--- a/service/okawak_blog.service
+++ b/service/okawak_blog.service
@@ -19,6 +19,7 @@ Environment=AWS_REGION=ap-northeast-1
 Environment=AWS_SHARED_CREDENTIALS_FILE=/var/lib/okawak_blog/aws/credentials
 Environment=OKAWAK_BLOG_ARTIFACT_SOURCE=s3
 Environment=OKAWAK_BLOG_ARTIFACT_BUCKET=okawak-blog-resources-bucket
+Environment=OKAWAK_BLOG_ARTIFACT_CACHE_TTL_SECONDS=5
 Environment=OKAWAK_BLOG_SITE_ORIGIN=https://www.okawak.net
 
 StateDirectory=okawak_blog


### PR DESCRIPTION
## 概要

S3のimmutable release snapshotとartifactをprocess memoryで再利用し、requestごとのS3 readを削減します。

Closes #84
Related to #45

## 変更内容

- storage非依存の`CachingArtifactReader` / `CachingArtifactSnapshot` decoratorを追加
- `current.json`の再確認間隔をdefault 5秒のTTLで制御
- release identityが同じ場合は取得済みartifact cacheを保持
- release identityが変わった場合だけ新しいsnapshot cacheへ切替
- article index、site metadata、category/article HTML、page documentをtyped cache
- 同じartifactへのconcurrent missを`tokio::sync::OnceCell`でsingle-flight化
- load errorはcacheせず、次のreadで再試行
- legacy rootにはidentityを付けず、TTLごとにcacheを作り直す
- local readerにはdecoratorを適用せず、file更新の即時反映を維持

## 設定

- `OKAWAK_BLOG_ARTIFACT_CACHE_TTL_SECONDS`
  - default: 5秒
  - `0`: snapshot / artifact cache無効
  - 不正値: 起動時configuration error

production unitでは5秒を明示しています。新releaseの反映遅延は最大でこのTTLです。

## 非対象

retry、stale-if-error、fallback reader、ETag / Last-Modified、CDNは本PRに含めません。

## 検証

- `mise run format`
- `mise run test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p web --features ssr`
- `cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate`
- service script syntax / unit tests
- `mise run test-e2e`（通常5件 + empty-home 1件）
- `git diff --check`
