### PR TITLE
Run browser E2E before publishing releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload Playwright traces
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-fixture-traces
           path: e2e/test-results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  BUN_VERSION: 1.3.14
+  CARGO_LEPTOS_VERSION: 0.3.7
 
 jobs:
   verify:
@@ -56,3 +58,61 @@ jobs:
 
       - name: Check web hydration
         run: cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate
+
+  browser-e2e:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Prepare Rust toolchain
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/cargo-leptos
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-browser-e2e-${{ env.CARGO_LEPTOS_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install cargo-leptos
+        run: |
+          if ! cargo leptos --version 2>/dev/null | grep -q "cargo-leptos ${CARGO_LEPTOS_VERSION}$"; then
+            cargo install cargo-leptos --version "${CARGO_LEPTOS_VERSION}" --locked
+          fi
+
+      - name: Install web dependencies
+        working-directory: crates/site/web
+        run: bun install --frozen-lockfile
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: bun install --frozen-lockfile
+
+      - name: Install Chromium
+        working-directory: e2e
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run fixture browser E2E
+        working-directory: e2e
+        run: bun run test
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-fixture-traces
+          path: e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -9,6 +9,8 @@ on:
 env:
   RUST_BACKTRACE: 1
   UPLOAD_PATH: crates/publish/publisher/dist/site
+  BUN_VERSION: 1.3.14
+  CARGO_LEPTOS_VERSION: 0.3.7
 
 jobs:
   deploy:
@@ -119,7 +121,30 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
 
-      - name: Upload immutable release and switch pointer
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install cargo-leptos
+        run: |
+          if ! cargo leptos --version 2>/dev/null | grep -q "cargo-leptos ${CARGO_LEPTOS_VERSION}$"; then
+            cargo install cargo-leptos --version "${CARGO_LEPTOS_VERSION}" --locked
+          fi
+
+      - name: Install web dependencies
+        working-directory: crates/site/web
+        run: bun install --frozen-lockfile
+
+      - name: Install E2E dependencies
+        working-directory: e2e
+        run: bun install --frozen-lockfile
+
+      - name: Install Chromium
+        working-directory: e2e
+        run: bunx playwright install --with-deps chromium
+
+      - name: Upload and validate immutable release
         run: |
           set -euo pipefail
           release_uri="s3://${{ secrets.S3_BUCKET }}/${ARTIFACT_PREFIX}"
@@ -139,6 +164,30 @@ jobs:
             --content-type "application/json" \
             --cache-control "public, max-age=31536000, immutable"
 
+          echo "REMOTE_HTML_COUNT=$remote_html_count" >> "$GITHUB_ENV"
+
+      - name: Run browser smoke test against immutable release
+        working-directory: e2e
+        env:
+          CI: "true"
+          OKAWAK_BLOG_ARTIFACT_BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          export OKAWAK_BLOG_ARTIFACT_PREFIX="$ARTIFACT_PREFIX"
+          bun run test:s3
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-s3-traces
+          path: e2e/test-results/s3/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Switch release pointer
+        run: |
+          set -euo pipefail
+
           # current.json is updated last. Readers either see the previous complete
           # release or this complete release, never an in-place partial upload.
           aws s3 cp "$RUNNER_TEMP/release.json" \
@@ -146,7 +195,7 @@ jobs:
             --content-type "application/json" \
             --cache-control "no-store"
 
-          echo "🪣 Published release ${RELEASE_ID} with ${remote_html_count} HTML files"
+          echo "🪣 Published release ${RELEASE_ID} with ${REMOTE_HTML_COUNT} HTML files"
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -57,7 +57,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-upload-${{ env.CARGO_LEPTOS_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Test publisher
         run: cargo test -p publisher

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload Playwright traces
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-s3-traces
           path: e2e/test-results/s3/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
 - `crates/site/infra`: server が artifact を読む外部境界（local / S3、設定、将来のcache）。vault読取、Markdown変換、uploadを置かない
 - `crates/site/server`: Axum + Leptos SSR host、reader注入、API、health/readiness
 - `crates/site/web`: Leptos UI / route / metadata。SSR時もstorage実装へ直接依存しない
-- `e2e`: repository root直下のbrowser E2E。通常CIはprivate submoduleやAWSに依存しないfixtureで検証し、実S3の手動smoke testは専用configへ分離する
+- `e2e`: repository root直下のbrowser E2E。通常CIはprivate submoduleやAWSに依存しないfixtureで検証し、実S3 smoke testはローカル手動確認とupload workflowの公開前gateに使う
 - `service`: systemd、nginx、運用補助
 - `terraform`: 読み取り専用。編集せず、このdirectoryでcommandを実行しない
 
@@ -66,7 +66,7 @@
 - `mise run clippy`
 - `mise run check`
 - `mise run test-e2e`
-- `mise run test-e2e-s3`（明示的な実S3手動確認のみ）
+- `mise run test-e2e-s3`（ローカルからの明示的な実S3確認）
 
 開発サーバーはS3 readerを標準とし、`mise run dev`で次を使う。
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ cargo install leptosfmt
 private Obsidian repoを使うpublisher側の開発では、必要なときだけ`mise run sync-obsidian`でsubmoduleを同期します。開発サーバーの表示確認ではlocal artifactを生成せず、GitHub Actionsが公開したS3 artifactを読みます。
 `mise run pull` は deploy 用に `main` の更新だけを行い、submodule も更新したい場合は `mise run pull-with-submodules` を使います。
 `crates/site/web/package.json` の依存のインストール/更新確認は root から `mise run web-install` / `mise run web-update` / `mise run web-outdated` で行えます。
-browser E2E の依存管理にも Bun を使います。初回は `mise run e2e-install-browser`、実行は `mise run test-e2e` を使ってください。E2E は root の `e2e/` に置き、private Obsidian submodule や S3 に依存しない固定 artifact で実行します。
+browser E2E の依存管理にも Bun を使います。初回は `mise run e2e-install-browser`、実行は `mise run test-e2e` を使ってください。E2E は root の `e2e/` に置き、通常CIではprivate Obsidian submoduleやS3に依存しない固定artifactで実行します。upload workflowはimmutable releaseを実S3 smoke testで検証し、成功後だけ`current.json`を切り替えます。
 
 開発端末での表示確認は、S3 readerを使う`mise run dev`または`mise run test-e2e-s3`を標準とします。taskはAWS CLIを実行せず、AWS SDKが設定済みprofileまたは環境変数credentialを読みます。bucketやcredentialは保存せず、`AWS_PROFILE`、region、`OKAWAK_BLOG_ARTIFACT_BUCKET`、必要な場合だけ`OKAWAK_BLOG_ARTIFACT_PREFIX`を実行時に渡します。詳細は[e2e/README.md](./e2e/README.md)を参照してください。
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -96,7 +96,7 @@ okawak_blog/
 - `e2e`
   - `crates/site/server`、`crates/site/web`、`crates/site/infra` をまたぐ browser E2E
   - 通常CIではprivate Obsidian submoduleやS3に依存しない固定artifact fixture
-  - 実S3の検証は専用Playwright configを使うローカル手動smoke testへ分離
+  - 実S3の検証は専用Playwright configを使い、ローカル手動確認とrelease公開前smoke testへ分離
   - Bun で依存を管理し、Playwright + Chromium で公開 route、metadata、hydration を検証
 
 `terraform/` は読み取り専用とし、このリポジトリの通常作業では編集しない。
@@ -293,7 +293,7 @@ releases/
         └── metadata/
 ```
 
-`current.json`とreleaseごとの`manifest.json`は同じ`ArtifactReleasePointerDocument`を使い、schema version、release ID、artifact prefix、publisher commit、Obsidian source commit、生成時刻を保持する。workflowは`site/`のuploadと検証を完了してから`current.json`を最後に更新する。これによりreaderは更新途中のreleaseを公開対象として選ばない。
+`current.json`とreleaseごとの`manifest.json`は同じ`ArtifactReleasePointerDocument`を使い、schema version、release ID、artifact prefix、publisher commit、Obsidian source commit、生成時刻を保持する。workflowは`site/`のuploadとobject数検証を終え、release prefixを直接読むbrowser E2Eが成功してから`current.json`を最後に更新する。これによりreaderは更新途中または表示検証に失敗したreleaseを公開対象として選ばない。
 
 ```mermaid
 flowchart TB
@@ -414,7 +414,7 @@ GitHub Actions publisher
   -> mise run dev / test-e2e-s3
 ```
 
-`dev`と`test-e2e-s3`はAWS SDKのcredential chainと実S3 artifactを使う。bucket、任意prefix、credentialは実行時envとローカルAWS設定から受け取り、repositoryには保存しない。固定fixtureを使う`test-e2e`は、開発環境の表示確認ではなく、外部状態に依存しないCI回帰テストとして維持する。
+`dev`と`test-e2e-s3`はAWS SDKのcredential chainと実S3 artifactを使う。bucket、任意prefix、credentialは実行時envとローカルAWS設定から受け取り、repositoryには保存しない。固定fixtureを使う`test-e2e`は、開発環境の表示確認ではなく、pull requestとmain pushで外部状態に依存せず実行するCI回帰テストとして維持する。upload workflowではOIDCの一時credentialを使い、immutable release prefixを`test-e2e-s3`で検証した後だけ公開pointerを切り替える。
 
 本番では GitHub Actions が artifact を S3 に置き、VPS 上の単一バイナリがそれを読む。
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,9 +18,9 @@ mise run test-e2e
 
 失敗時の trace は `e2e/test-results` に保存されます。
 
-## ローカルから実S3を確認する
+## 実S3を確認する
 
-CIへS3接続を組み込む前の手動統合確認には、通常の固定artifact E2Eとは分離した`test-e2e-s3`を使います。このtaskはAWS SDKの標準credential chainでS3を読み、`/api/ready`、home、article index、実articleのSSR表示とmetadataを確認します。
+通常の固定artifact E2Eとは分離した`test-e2e-s3`は、AWS SDKの標準credential chainでS3を読み、`/api/ready`、home、article index、実articleのSSR表示とmetadataを確認します。ローカルからの手動確認に加え、S3 upload workflowがimmutable releaseを公開する前のsmoke testにも使います。
 
 bucket名やcredentialはrepositoryへ保存せず、実行時に渡してください。task自身はAWS CLIを実行せず、server内のAWS SDKがcredentialを読みます。`aws configure --profile blog-s3`などでshared config / credentials fileへ設定済みなら`AWS_PROFILE=blog-s3`で選択でき、省略時はdefault profileが使われます。regionは`AWS_REGION`、`AWS_DEFAULT_REGION`、またはprofileで設定できます。
 
@@ -57,4 +57,9 @@ mise run test-e2e-s3
 
 credentialには対象keyへの`s3:GetObject`だけを付与したread-only profileを推奨します。`/api/health`が成功して`/api/ready`が失敗する場合は、profile/region、bucket/prefix、`current.json`とrelease artifactへのGetObject権限を確認してください。
 
-このtestは実データとAWS credentialに依存するため、通常の`mise run test-e2e`やCIからは実行されません。
+## CIでの実行
+
+- `.github/workflows/ci.yml`はpull requestとmain pushで固定fixtureの`bun run test`を実行し、AWS credentialやprivate submoduleなしで回帰を検出します。
+- `.github/workflows/upload.yml`は生成物をimmutable release prefixへuploadした後、そのprefixを`test-e2e-s3`で直接検証します。成功した場合だけ`current.json`を切り替えます。
+
+S3 smoke testはOIDCで取得したupload workflowの一時credentialを再利用し、pull requestへAWS credentialを渡しません。失敗時のPlaywright traceはGitHub Actions artifactに7日間保存されます。

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -39,6 +39,6 @@ export default defineConfig({
     },
     url: `${baseURL}/api/health`,
     reuseExistingServer: false,
-    timeout: 180_000,
+    timeout: 600_000,
   },
 });

--- a/e2e/playwright.empty-home.config.ts
+++ b/e2e/playwright.empty-home.config.ts
@@ -37,6 +37,6 @@ export default defineConfig({
     },
     url: `${baseURL}/api/health`,
     reuseExistingServer: false,
-    timeout: 180_000,
+    timeout: 600_000,
   },
 });

--- a/e2e/playwright.s3.config.ts
+++ b/e2e/playwright.s3.config.ts
@@ -44,6 +44,6 @@ export default defineConfig({
     },
     url: `${baseURL}/api/health`,
     reuseExistingServer: false,
-    timeout: 180_000,
+    timeout: 600_000,
   },
 });


### PR DESCRIPTION
## Summary

- run deterministic Playwright fixture tests after Rust CI succeeds
- smoke-test each immutable S3 release before switching `current.json`
- pin Bun and cargo-leptos versions and upload failure traces
- document the local and CI E2E responsibilities

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `cargo check -p web --features ssr`
- `cargo check -p web --lib --target wasm32-unknown-unknown --features hydrate`
- `mise run test-e2e`
- YAML syntax validation for both changed workflows

Closes #88
Related to #45