### PR TITLE
Fix reactive route parameter warnings

### DIFF
--- a/crates/site/web/src/routes/article.rs
+++ b/crates/site/web/src/routes/article.rs
@@ -157,7 +157,7 @@ pub fn ArticlePage() -> impl IntoView {
     view! {
         <Suspense fallback=move || {
             let (category_param, slug_param) = params
-                .with(|params: &ParamsMap| {
+                .with_untracked(|params: &ParamsMap| {
                     let slug = params.get("slug").unwrap_or_default();
                     (
                         params.get("category").unwrap_or_default(),

--- a/crates/site/web/src/routes/category.rs
+++ b/crates/site/web/src/routes/category.rs
@@ -125,7 +125,7 @@ pub fn CategoryPage() -> impl IntoView {
     view! {
         <Suspense fallback=move || {
             let category_param = params
-                .with(|params: &ParamsMap| params.get("category").unwrap_or_default());
+                .with_untracked(|params: &ParamsMap| params.get("category").unwrap_or_default());
             let canonical_url = if category_param.is_empty() {
                 build_site_url("/")
             } else {

--- a/e2e/tests/artifact-routes.spec.ts
+++ b/e2e/tests/artifact-routes.spec.ts
@@ -2,6 +2,16 @@ import { expect, test, type Page } from "@playwright/test";
 
 const SITE_NAME = "ぶくせんの探窟メモ";
 
+function captureReactiveWarnings(page: Page) {
+  const warnings: string[] = [];
+  page.on("console", (message) => {
+    if (message.text().includes("outside a reactive tracking context")) {
+      warnings.push(message.text());
+    }
+  });
+  return warnings;
+}
+
 async function expectMetadata(
   page: Page,
   title: string,
@@ -61,6 +71,8 @@ test("runtime probes distinguish liveness and artifact readiness", async ({ requ
 });
 
 test("home renders artifacts and hydrates article navigation", async ({ page }) => {
+  const reactiveWarnings = captureReactiveWarnings(page);
+
   const response = await page.goto("/");
 
   expect(response?.status()).toBe(200);
@@ -98,6 +110,7 @@ test("home renders artifacts and hydrates article navigation", async ({ page }) 
     "/tech/e2e-article",
     "article",
   );
+  expect(reactiveWarnings).toEqual([]);
 });
 
 test("site shell keeps the warm gradient background", async ({ page }) => {
@@ -178,6 +191,7 @@ test("about renders its page artifact", async ({ page }) => {
 });
 
 test("category renders landing content and grouped articles", async ({ page }) => {
+  const reactiveWarnings = captureReactiveWarnings(page);
   const response = await page.goto("/tech");
 
   expect(response?.status()).toBe(200);
@@ -188,6 +202,7 @@ test("category renders landing content and grouped articles", async ({ page }) =
   await expect(page.getByRole("link", { name: "E2E Article" })).toBeVisible();
   await expectFormattedFixtureDates(page);
   await expectMetadata(page, `Fixture Tech | ${SITE_NAME}`, "/tech");
+  expect(reactiveWarnings).toEqual([]);
 });
 
 test("category landing content stays within the mobile viewport", async ({ page }) => {


### PR DESCRIPTION
## 概要

Article / Category route の `Suspense` fallback で発生していた Leptos の reactive tracking warning を解消します。

## 原因

`Suspense` の fallback は reactive tracking context 外で評価されますが、その中で `use_params_map()` の値を `.with(...)` により追跡読み取りしていました。route parameter による Resource の再取得は別の追跡された source closure が担当しているため、fallback では現在値の非追跡読み取りが適切です。

## 変更内容

- Article fallback の route parameter 読み取りを `with_untracked` へ変更
- Category fallback の同型箇所も `with_untracked` へ変更
- Playwright E2E で article navigation と category表示時に reactive tracking warning が出ないことを検証

## 検証

- 修正前に追加E2Eが `article.rs:160` の警告を検出して失敗することを確認
- `mise run format`
- `mise run test-web`
- `mise run check`
- `mise run clippy`
- `mise run test-e2e`（通常11件 + empty-home 1件）
- `git diff --check`