### PR TITLE
fix: 本番faviconを明示配信する

### DIFF
--- a/crates/site/server/src/main.rs
+++ b/crates/site/server/src/main.rs
@@ -6,7 +6,7 @@ use leptos::prelude::*;
 use leptos_axum::{LeptosRoutes, file_and_error_handler, generate_route_list};
 use server::handlers::create_api_router;
 use server::http_cache::{ArtifactHttpCacheState, artifact_conditional_get};
-use tower_http::services::ServeDir;
+use tower_http::services::{ServeDir, ServeFile};
 use web::app::{App, shell};
 
 async fn health() -> &'static str {
@@ -47,6 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/assets",
             axum::routing::get_service(ServeDir::new("target/site/assets")),
         )
+        .route_service("/favicon.ico", ServeFile::new("target/site/favicon.ico"))
         // Leptos SSR routes must be registered last.
         .leptos_routes_with_context(
             &leptos_options,

--- a/crates/site/web/src/app.rs
+++ b/crates/site/web/src/app.rs
@@ -23,6 +23,7 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
             <head>
                 <meta charset="utf-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <link rel="icon" href="/favicon.ico" type="image/x-icon" />
                 // Load Font Awesome from the CDN.
                 <link
                     rel="stylesheet"

--- a/e2e/tests/artifact-routes.spec.ts
+++ b/e2e/tests/artifact-routes.spec.ts
@@ -70,6 +70,19 @@ test("runtime probes distinguish liveness and artifact readiness", async ({ requ
   expect(await readinessResponse.text()).toBe("READY");
 });
 
+test("site declares and serves its favicon", async ({ page, request }) => {
+  await page.goto("/");
+
+  const iconLink = page.locator('link[rel~="icon"]');
+  await expect(iconLink).toHaveCount(1);
+  await expect(iconLink).toHaveAttribute("href", "/favicon.ico");
+
+  const response = await request.get("/favicon.ico");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toMatch(/^image\//);
+  expect((await response.body()).byteLength).toBeGreaterThan(0);
+});
+
 test("home renders artifacts and hydrates article navigation", async ({ page }) => {
   const reactiveWarnings = captureReactiveWarnings(page);
 


### PR DESCRIPTION
## 概要

- SSR headへfavicon linkを明示的に追加
- Axumでroot直下のfavicon.icoを明示配信
- faviconのlink、HTTP status、Content-Type、bodyをbrowser E2Eで回帰検証

## 原因

source assetとcargo-leptosの出力にはfavicon.icoが存在していましたが、serverはpkgとassetsだけを明示的に静的配信していました。そのため、本番のfavicon.icoが404になっていました。

## 確認

- mise run format
- mise run test
- mise run clippy
- mise run test-e2e（fixture 12件、empty-home 1件）
- 修正前に追加テストが失敗し、修正後に成功することを確認

Closes #115
