### PR TITLE
fix: favicon URLをversioningする

### DIFF
--- a/crates/site/web/src/app.rs
+++ b/crates/site/web/src/app.rs
@@ -23,7 +23,12 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
             <head>
                 <meta charset="utf-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
-                <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+                <link
+                    rel="icon"
+                    href="/favicon.ico?v=f544a69c"
+                    type="image/x-icon"
+                    sizes="16x16 32x32 48x48"
+                />
                 // Load Font Awesome from the CDN.
                 <link
                     rel="stylesheet"

--- a/e2e/tests/artifact-routes.spec.ts
+++ b/e2e/tests/artifact-routes.spec.ts
@@ -75,9 +75,13 @@ test("site declares and serves its favicon", async ({ page, request }) => {
 
   const iconLink = page.locator('link[rel~="icon"]');
   await expect(iconLink).toHaveCount(1);
-  await expect(iconLink).toHaveAttribute("href", "/favicon.ico");
+  await expect(iconLink).toHaveAttribute(
+    "href",
+    "/favicon.ico?v=f544a69c",
+  );
+  await expect(iconLink).toHaveAttribute("sizes", "16x16 32x32 48x48");
 
-  const response = await request.get("/favicon.ico");
+  const response = await request.get("/favicon.ico?v=f544a69c");
   expect(response.status()).toBe(200);
   expect(response.headers()["content-type"]).toMatch(/^image\//);
   expect((await response.body()).byteLength).toBeGreaterThan(0);


### PR DESCRIPTION
## 概要

- faviconの参照URLへ内容由来のversionを付与
- ICOが持つ16、32、48pxのsizesを明示
- version付きURLのhead宣言とHTTP配信をbrowser E2Eで検証

## 原因と対応

本番ではfavicon.icoが正常に200で配信され、Content-Type、サイズ、source assetとのSHA-256一致も確認できました。一方でブラウザのfavicon専用キャッシュにより、HTMLとassetが更新されてもtab iconが更新されない状態が残りました。

既存assetと配信routeは維持し、headから参照するURLだけを変更することで、ブラウザとCloudflareに新しいfavicon resourceとして取得させます。

## 確認

- mise run format
- mise run clippy
- mise run test-e2e（fixture 12件、empty-home 1件）

Refs #115
