### PR TITLE
refactor: simplify publisher classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ category: "tech"
 - `category`: `article` と `category` で使うカテゴリキーです。
 - `page`: `kind: page` のときに使う固定ページキーです。
 
-本文は closing `---` の次の行から始まり、Obsidian link や bookmark 埋め込みを含められます。front matter がない Markdown は publisher からはスキップされます。category 配下のディレクトリ構造は path から `section_path` として導出され、category page 上の grouped navigation に使われます。
+本文は closing `---` の次の行から始まり、Obsidian link や bookmark 埋め込みを含められます。front matter がない Markdown は publisher からはスキップされます。article は frontmatter の `category` と同名のディレクトリ配下に置く必要があります。category 配下のディレクトリ構造は path から `section_path` として導出され、category page 上の grouped navigation に使われます。
 
 ## 運用モデル
 

--- a/crates/publish/README.md
+++ b/crates/publish/README.md
@@ -98,6 +98,8 @@ repository rootの`mise run dev-local`はprivate Obsidian submoduleをremoteの�
 - 入力ディレクトリ: `./crates/publish/obsidian/Publish` (固定)
 - 出力ディレクトリ: `./crates/publish/dist` (固定)
 
+publisherのpath処理はmacOSとLinuxを対象とし、Windows形式のpathには対応しません。
+
 ## GitHub Actions連携
 
 AWS S3 への同期は GitHub Actions workflow が担当します。

--- a/crates/publish/README.md
+++ b/crates/publish/README.md
@@ -39,6 +39,8 @@ category: "tech"
 ---
 ```
 
+article は frontmatter の `category` と同名のディレクトリ配下に置いてください。たとえば `category: tech` の記事は `tech/` 配下に配置し、不一致の場合は publish に失敗します。
+
 #### リンク形式
 - 内部リンク: `[[記事名]]`
 - 表示テキスト付きリンク: `[[記事名|表示テキスト]]`

--- a/crates/publish/src/artifacts.rs
+++ b/crates/publish/src/artifacts.rs
@@ -36,6 +36,14 @@ pub(crate) struct CategoryLandingMetadata {
     pub(crate) updated_at: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HomeFragmentArtifact {
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+    pub(crate) html: String,
+    pub(crate) updated_at: String,
+}
+
 /// Output directories for generated local site artifacts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SiteDirectories {
@@ -131,6 +139,20 @@ pub(crate) fn write_page_document(
         .join(format!("{}.json", page_document.page));
     write_json_pretty(&output_file_path, page_document)?;
     Ok(output_file_path)
+}
+
+pub(crate) fn write_home_fragment(
+    site_directories: &SiteDirectories,
+    home_fragment: HomeFragmentArtifact,
+) -> Result<PathBuf> {
+    let document = PageArtifactDocument {
+        page: domain::PageKey::new("home".to_string())?,
+        title: home_fragment.title,
+        description: home_fragment.description,
+        html: home_fragment.html,
+        updated_at: home_fragment.updated_at,
+    };
+    write_page_document(site_directories, &document)
 }
 
 pub(crate) fn write_category_page(

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -12,6 +12,7 @@ pub(crate) struct ParsedArticleFile {
     pub(crate) slug: Slug,
     /// Extensionless relative path used to resolve Obsidian wiki links.
     pub(crate) mapping_key: String,
+    /// Category-relative directories used to group articles in category navigation.
     pub(crate) section_path: Vec<String>,
     pub(crate) markdown_body: String,
     pub(crate) front_matter: ObsidianFrontMatter,
@@ -92,18 +93,18 @@ fn process_valid_article_file(
     obsidian_dir: &Path,
 ) -> Result<ParsedArticleFile> {
     let relative_path = file_path.strip_prefix(obsidian_dir)?;
+    let category = parse_category(parsed_file.front_matter.category.as_deref())?;
+    let category_relative_path = relative_path.strip_prefix(category.as_str())?;
     let slug = crate::slug::generate_slug(
         &parsed_file.front_matter.title,
         relative_path,
         &parsed_file.front_matter.created,
     )?;
-    let category = parse_category(parsed_file.front_matter.category.as_deref())?;
     let mapping_key = relative_path
         .with_extension("")
         .to_string_lossy()
         .into_owned();
-    let section_path =
-        derive_section_path(relative_path, parsed_file.front_matter.category.as_deref());
+    let section_path = derive_section_path(category_relative_path);
 
     Ok(ParsedArticleFile {
         category,
@@ -151,8 +152,8 @@ pub(crate) fn build_file_mapping(valid_files: &[ParsedArticleFile]) -> FileMappi
     mapping
 }
 
-fn derive_section_path(relative_path: &Path, category: Option<&str>) -> Vec<String> {
-    let mut path_components: Vec<String> = relative_path
+fn derive_section_path(category_relative_path: &Path) -> Vec<String> {
+    category_relative_path
         .parent()
         .map(|parent| {
             parent
@@ -160,15 +161,7 @@ fn derive_section_path(relative_path: &Path, category: Option<&str>) -> Vec<Stri
                 .map(|component| component.to_string_lossy().into_owned())
                 .collect()
         })
-        .unwrap_or_default();
-
-    if let (Some(category), Some(first_component)) = (category, path_components.first())
-        && first_component == category
-    {
-        path_components.remove(0);
-    }
-
-    path_components
+        .unwrap_or_default()
 }
 
 pub(crate) fn ensure_unique_page_keys(valid_pages: &[ParsedPageFile]) -> Result<()> {
@@ -382,15 +375,43 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_section_path_drops_category_root() {
-        let section_path = derive_section_path(Path::new("tech/block1/hoge.md"), Some("tech"));
+    fn test_process_valid_article_file_rejects_category_path_mismatch() {
+        let obsidian_dir = Path::new("/vault");
+        let parsed_file = ParsedObsidianFile {
+            front_matter: ObsidianFrontMatter {
+                title: "Test Article".to_string(),
+                kind: ContentKind::Article,
+                tags: None,
+                summary: None,
+                priority: None,
+                created: "2025-01-01T00:00:00+09:00".to_string(),
+                updated: "2025-01-01T00:00:00+09:00".to_string(),
+                is_completed: true,
+                category: Some("tech".to_string()),
+                page: None,
+            },
+            markdown_body: "# Test Article".to_string(),
+        };
+
+        let result = process_valid_article_file(
+            Path::new("/vault/daily/article.md"),
+            parsed_file,
+            obsidian_dir,
+        );
+
+        assert!(matches!(result, Err(PublishError::StripPrefix(_))));
+    }
+
+    #[test]
+    fn test_derive_section_path_from_category_relative_article() {
+        let section_path = derive_section_path(Path::new("block1/hoge.md"));
 
         assert_eq!(section_path, vec!["block1".to_string()]);
     }
 
     #[test]
     fn test_derive_section_path_keeps_nested_sections() {
-        let section_path = derive_section_path(Path::new("tech/rust/async/hoge.md"), Some("tech"));
+        let section_path = derive_section_path(Path::new("rust/async/hoge.md"));
 
         assert_eq!(section_path, vec!["rust".to_string(), "async".to_string()]);
     }

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -2,14 +2,14 @@ use crate::error::{PublishError, Result};
 use crate::ingest::{
     ContentKind, FileMapping, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file,
 };
-use domain::{Category, PageKey};
+use domain::{Category, PageKey, Slug};
 use log::{error, warn};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 pub(crate) struct ParsedArticleFile {
     pub(crate) category: Category,
-    pub(crate) slug: String,
+    pub(crate) slug: Slug,
     pub(crate) mapping_key: String,
     pub(crate) section_path: Vec<String>,
     pub(crate) markdown_body: String,
@@ -238,7 +238,7 @@ mod tests {
 
         let parsed_file = ParsedArticleFile {
             category: Category::Tech,
-            slug: "slug".to_string(),
+            slug: Slug::new("slug".to_string()).unwrap(),
             mapping_key: "test".to_string(),
             section_path: vec![],
             markdown_body: "# Test Content".to_string(),
@@ -290,7 +290,7 @@ mod tests {
 
         let parsed_file1 = ParsedArticleFile {
             category: Category::Tech,
-            slug: "slug1".to_string(),
+            slug: Slug::new("slug1".to_string()).unwrap(),
             mapping_key: "dir1/test".to_string(),
             section_path: vec!["dir1".to_string()],
             markdown_body: "# Test Content 1".to_string(),
@@ -298,7 +298,7 @@ mod tests {
         };
         let parsed_file2 = ParsedArticleFile {
             category: Category::Daily,
-            slug: "slug2".to_string(),
+            slug: Slug::new("slug2".to_string()).unwrap(),
             mapping_key: "dir2/test".to_string(),
             section_path: vec!["dir2".to_string()],
             markdown_body: "# Test Content 2".to_string(),
@@ -329,7 +329,7 @@ mod tests {
 
         let parsed_file = ParsedArticleFile {
             category: Category::Tech,
-            slug: "slug".to_string(),
+            slug: Slug::new("slug".to_string()).unwrap(),
             mapping_key: "sub/dir/test".to_string(),
             section_path: vec!["sub".to_string(), "dir".to_string()],
             markdown_body: "# URL Test Content".to_string(),

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -90,7 +90,7 @@ fn process_valid_article_file(
     parsed_file: ParsedObsidianFile,
     obsidian_dir: &Path,
 ) -> Result<ParsedArticleFile> {
-    let relative_path = get_relative_path(file_path, obsidian_dir)?;
+    let relative_path = file_path.strip_prefix(obsidian_dir)?;
     let slug = crate::slug::generate_slug(
         &parsed_file.front_matter.title,
         relative_path,
@@ -139,15 +139,6 @@ fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<Parsed
 fn normalize_path_for_url(path: &Path) -> String {
     path.to_string_lossy()
         .replace(std::path::MAIN_SEPARATOR, "/")
-}
-
-fn get_relative_path<'a>(file_path: &'a Path, base_dir: &Path) -> Result<&'a Path> {
-    file_path.strip_prefix(base_dir).map_err(|_| {
-        PublishError::InvalidPath(format!(
-            "Failed to strip prefix from {}",
-            file_path.display()
-        ))
-    })
 }
 
 pub(crate) fn build_file_mapping(valid_files: &[ParsedArticleFile]) -> FileMapping {

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -24,6 +24,11 @@ pub(crate) struct ParsedPageFile {
     pub(crate) front_matter: ObsidianFrontMatter,
 }
 
+pub(crate) struct ParsedHomeFile {
+    pub(crate) markdown_body: String,
+    pub(crate) front_matter: ObsidianFrontMatter,
+}
+
 pub(crate) struct ParsedCategoryFile {
     pub(crate) category: Category,
     pub(crate) markdown_body: String,
@@ -33,6 +38,7 @@ pub(crate) struct ParsedCategoryFile {
 pub(crate) struct ClassifiedFiles {
     pub(crate) articles: Vec<ParsedArticleFile>,
     pub(crate) pages: Vec<ParsedPageFile>,
+    pub(crate) home: Option<ParsedHomeFile>,
     pub(crate) categories: Vec<ParsedCategoryFile>,
     pub(crate) skipped: usize,
     pub(crate) errors: usize,
@@ -44,6 +50,7 @@ pub(crate) fn classify_obsidian_files(
 ) -> ClassifiedFiles {
     let mut articles = Vec::new();
     let mut pages = Vec::new();
+    let mut home = None;
     let mut categories = Vec::new();
     let mut skipped = 0usize;
     let mut errors = 0usize;
@@ -52,14 +59,38 @@ pub(crate) fn classify_obsidian_files(
         match parse_obsidian_file(&file_path) {
             Ok(Some(parsed)) if parsed.front_matter.is_completed => {
                 let result: Result<()> = match parsed.front_matter.kind {
-                    ContentKind::Article => {
-                        process_valid_article_file(&file_path, parsed, obsidian_dir)
-                            .map(|f| articles.push(f))
+                    ContentKind::Article => process_article_file(&file_path, parsed, obsidian_dir)
+                        .map(|f| articles.push(f)),
+                    ContentKind::Page => {
+                        parse_page_key(parsed.front_matter.page.as_deref()).map(|page| {
+                            pages.push(ParsedPageFile {
+                                page,
+                                markdown_body: parsed.markdown_body,
+                                front_matter: parsed.front_matter,
+                            });
+                        })
                     }
-                    ContentKind::Page => process_valid_page_file(parsed).map(|f| pages.push(f)),
-                    ContentKind::Home => process_valid_home_file(parsed).map(|f| pages.push(f)),
+                    ContentKind::Home => {
+                        if home.is_some() {
+                            Err(PublishError::Parse(
+                                "Duplicate home content detected".to_string(),
+                            ))
+                        } else {
+                            home = Some(ParsedHomeFile {
+                                markdown_body: parsed.markdown_body,
+                                front_matter: parsed.front_matter,
+                            });
+                            Ok(())
+                        }
+                    }
                     ContentKind::Category => {
-                        process_valid_category_file(parsed).map(|f| categories.push(f))
+                        parse_category(parsed.front_matter.category.as_deref()).map(|category| {
+                            categories.push(ParsedCategoryFile {
+                                category,
+                                markdown_body: parsed.markdown_body,
+                                front_matter: parsed.front_matter,
+                            });
+                        })
                     }
                 };
                 if let Err(e) = result {
@@ -81,13 +112,14 @@ pub(crate) fn classify_obsidian_files(
     ClassifiedFiles {
         articles,
         pages,
+        home,
         categories,
         skipped,
         errors,
     }
 }
 
-fn process_valid_article_file(
+fn process_article_file(
     file_path: &Path,
     parsed_file: ParsedObsidianFile,
     obsidian_dir: &Path,
@@ -116,34 +148,9 @@ fn process_valid_article_file(
     })
 }
 
-fn process_valid_page_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
-    Ok(ParsedPageFile {
-        page: parse_page_key(parsed_file.front_matter.page.as_deref())?,
-        markdown_body: parsed_file.markdown_body,
-        front_matter: parsed_file.front_matter,
-    })
-}
-
-fn process_valid_home_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
-    Ok(ParsedPageFile {
-        page: PageKey::new("home".to_string())
-            .map_err(|error| PublishError::Parse(error.to_string()))?,
-        markdown_body: parsed_file.markdown_body,
-        front_matter: parsed_file.front_matter,
-    })
-}
-
-fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<ParsedCategoryFile> {
-    Ok(ParsedCategoryFile {
-        category: parse_category(parsed_file.front_matter.category.as_deref())?,
-        markdown_body: parsed_file.markdown_body,
-        front_matter: parsed_file.front_matter,
-    })
-}
-
-pub(crate) fn build_file_mapping(valid_files: &[ParsedArticleFile]) -> FileMapping {
-    let mut mapping = FileMapping::with_capacity(valid_files.len());
-    for parsed_file in valid_files {
+pub(crate) fn build_file_mapping(article_files: &[ParsedArticleFile]) -> FileMapping {
+    let mut mapping = FileMapping::with_capacity(article_files.len());
+    for parsed_file in article_files {
         mapping.insert(
             parsed_file.mapping_key.clone(),
             format!("/{}/{}", parsed_file.category.as_str(), parsed_file.slug),
@@ -164,9 +171,9 @@ fn derive_section_path(category_relative_path: &Path) -> Vec<String> {
         .unwrap_or_default()
 }
 
-pub(crate) fn ensure_unique_page_keys(valid_pages: &[ParsedPageFile]) -> Result<()> {
-    let mut seen = HashSet::with_capacity(valid_pages.len());
-    for parsed_page in valid_pages {
+pub(crate) fn ensure_unique_page_keys(pages: &[ParsedPageFile]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(pages.len());
+    for parsed_page in pages {
         if !seen.insert(parsed_page.page.as_str()) {
             return Err(PublishError::Parse(format!(
                 "Duplicate page key detected: {}",
@@ -177,11 +184,9 @@ pub(crate) fn ensure_unique_page_keys(valid_pages: &[ParsedPageFile]) -> Result<
     Ok(())
 }
 
-pub(crate) fn ensure_unique_category_landings(
-    valid_categories: &[ParsedCategoryFile],
-) -> Result<()> {
-    let mut seen = HashSet::with_capacity(valid_categories.len());
-    for parsed_category in valid_categories {
+pub(crate) fn ensure_unique_category_landings(categories: &[ParsedCategoryFile]) -> Result<()> {
+    let mut seen = HashSet::with_capacity(categories.len());
+    for parsed_category in categories {
         if !seen.insert(parsed_category.category.as_str()) {
             return Err(PublishError::Parse(format!(
                 "Duplicate category landing detected: {}",
@@ -201,7 +206,13 @@ fn parse_category(category: Option<&str>) -> Result<Category> {
 fn parse_page_key(page: Option<&str>) -> Result<PageKey> {
     let page =
         page.ok_or_else(|| PublishError::Parse("Completed pages require a page key".to_string()))?;
-    PageKey::new(page.trim().to_string()).map_err(|error| PublishError::Parse(error.to_string()))
+    let page = page.trim();
+    if page == "home" {
+        return Err(PublishError::Parse(
+            "Static pages cannot use the reserved home page key".to_string(),
+        ));
+    }
+    PageKey::new(page.to_string()).map_err(|error| PublishError::Parse(error.to_string()))
 }
 
 #[cfg(test)]
@@ -232,8 +243,8 @@ mod tests {
             markdown_body: "# Test Content".to_string(),
             front_matter,
         };
-        let valid_files = vec![parsed_file];
-        let mapping = build_file_mapping(&valid_files);
+        let article_files = vec![parsed_file];
+        let mapping = build_file_mapping(&article_files);
 
         assert_eq!(mapping.len(), 1);
         assert!(mapping.contains_key("test"));
@@ -242,8 +253,8 @@ mod tests {
 
     #[rstest]
     fn test_build_file_mapping_empty() {
-        let valid_files: Vec<ParsedArticleFile> = vec![];
-        let mapping = build_file_mapping(&valid_files);
+        let article_files: Vec<ParsedArticleFile> = vec![];
+        let mapping = build_file_mapping(&article_files);
 
         assert_eq!(mapping.len(), 0);
     }
@@ -292,8 +303,8 @@ mod tests {
             markdown_body: "# Test Content 2".to_string(),
             front_matter: front_matter2,
         };
-        let valid_files = vec![parsed_file1, parsed_file2];
-        let mapping = build_file_mapping(&valid_files);
+        let article_files = vec![parsed_file1, parsed_file2];
+        let mapping = build_file_mapping(&article_files);
 
         assert_eq!(mapping.len(), 2);
         assert!(mapping.contains_key("dir1/test"));
@@ -323,8 +334,8 @@ mod tests {
             markdown_body: "# URL Test Content".to_string(),
             front_matter,
         };
-        let valid_files = vec![parsed_file];
-        let mapping = build_file_mapping(&valid_files);
+        let article_files = vec![parsed_file];
+        let mapping = build_file_mapping(&article_files);
 
         let href = mapping.get("sub/dir/test").unwrap();
         assert_eq!(href, "/tech/slug");
@@ -332,7 +343,7 @@ mod tests {
 
     #[test]
     fn test_ensure_unique_category_landings_rejects_duplicates() {
-        let valid_categories = vec![
+        let categories = vec![
             ParsedCategoryFile {
                 category: Category::Tech,
                 markdown_body: "# Tech".to_string(),
@@ -367,7 +378,7 @@ mod tests {
             },
         ];
 
-        let result = ensure_unique_category_landings(&valid_categories);
+        let result = ensure_unique_category_landings(&categories);
 
         assert!(
             matches!(result, Err(PublishError::Parse(message)) if message.contains("Duplicate category landing"))
@@ -375,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_valid_article_file_rejects_category_path_mismatch() {
+    fn test_process_article_file_rejects_category_path_mismatch() {
         let obsidian_dir = Path::new("/vault");
         let parsed_file = ParsedObsidianFile {
             front_matter: ObsidianFrontMatter {
@@ -393,7 +404,7 @@ mod tests {
             markdown_body: "# Test Article".to_string(),
         };
 
-        let result = process_valid_article_file(
+        let result = process_article_file(
             Path::new("/vault/daily/article.md"),
             parsed_file,
             obsidian_dir,
@@ -425,6 +436,14 @@ mod tests {
     fn test_parse_page_key_rejects_nested_path() {
         assert!(matches!(
             parse_page_key(Some("about/team")),
+            Err(PublishError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_page_key_rejects_reserved_home_key() {
+        assert!(matches!(
+            parse_page_key(Some("home")),
             Err(PublishError::Parse(_))
         ));
     }

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 pub(crate) struct ParsedArticleFile {
     pub(crate) category: Category,
     pub(crate) slug: Slug,
+    /// Extensionless relative path used to resolve Obsidian wiki links.
     pub(crate) mapping_key: String,
     pub(crate) section_path: Vec<String>,
     pub(crate) markdown_body: String,
@@ -97,7 +98,10 @@ fn process_valid_article_file(
         &parsed_file.front_matter.created,
     )?;
     let category = parse_category(parsed_file.front_matter.category.as_deref())?;
-    let mapping_key = normalize_path_for_url(&relative_path.with_extension(""));
+    let mapping_key = relative_path
+        .with_extension("")
+        .to_string_lossy()
+        .into_owned();
     let section_path =
         derive_section_path(relative_path, parsed_file.front_matter.category.as_deref());
 
@@ -134,11 +138,6 @@ fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<Parsed
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })
-}
-
-fn normalize_path_for_url(path: &Path) -> String {
-    path.to_string_lossy()
-        .replace(std::path::MAIN_SEPARATOR, "/")
 }
 
 pub(crate) fn build_file_mapping(valid_files: &[ParsedArticleFile]) -> FileMapping {

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -96,7 +96,7 @@ fn process_valid_article_file(
         relative_path,
         &parsed_file.front_matter.created,
     )?;
-    let category = parse_category(&parsed_file.front_matter)?;
+    let category = parse_category(parsed_file.front_matter.category.as_deref())?;
     let mapping_key = normalize_path_for_url(&relative_path.with_extension(""));
     let section_path =
         derive_section_path(relative_path, parsed_file.front_matter.category.as_deref());
@@ -113,7 +113,7 @@ fn process_valid_article_file(
 
 fn process_valid_page_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPageFile> {
     Ok(ParsedPageFile {
-        page: parse_page_key(&parsed_file.front_matter)?,
+        page: parse_page_key(parsed_file.front_matter.page.as_deref())?,
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })
@@ -130,7 +130,7 @@ fn process_valid_home_file(parsed_file: ParsedObsidianFile) -> Result<ParsedPage
 
 fn process_valid_category_file(parsed_file: ParsedObsidianFile) -> Result<ParsedCategoryFile> {
     Ok(ParsedCategoryFile {
-        category: parse_category(&parsed_file.front_matter)?,
+        category: parse_category(parsed_file.front_matter.category.as_deref())?,
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })
@@ -200,19 +200,15 @@ pub(crate) fn ensure_unique_category_landings(
     Ok(())
 }
 
-fn parse_category(front_matter: &ObsidianFrontMatter) -> Result<Category> {
-    let category = front_matter
-        .category
-        .as_deref()
+fn parse_category(category: Option<&str>) -> Result<Category> {
+    let category = category
         .ok_or_else(|| PublishError::Parse("Completed content requires a category".to_string()))?;
     category.parse().map_err(Into::into)
 }
 
-fn parse_page_key(front_matter: &ObsidianFrontMatter) -> Result<PageKey> {
-    let page = front_matter
-        .page
-        .as_deref()
-        .ok_or_else(|| PublishError::Parse("Completed pages require a page key".to_string()))?;
+fn parse_page_key(page: Option<&str>) -> Result<PageKey> {
+    let page =
+        page.ok_or_else(|| PublishError::Parse("Completed pages require a page key".to_string()))?;
     PageKey::new(page.trim().to_string()).map_err(|error| PublishError::Parse(error.to_string()))
 }
 
@@ -402,61 +398,43 @@ mod tests {
 
     #[test]
     fn test_parse_page_key_success() {
-        let front_matter = ObsidianFrontMatter {
-            title: "About".to_string(),
-            kind: ContentKind::Page,
-            tags: None,
-            summary: Some("About this site".to_string()),
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: None,
-            page: Some("about".to_string()),
-        };
-
-        assert_eq!(parse_page_key(&front_matter).unwrap().as_str(), "about");
+        assert_eq!(parse_page_key(Some("about")).unwrap().as_str(), "about");
     }
 
     #[test]
     fn test_parse_page_key_rejects_nested_path() {
-        let front_matter = ObsidianFrontMatter {
-            title: "About".to_string(),
-            kind: ContentKind::Page,
-            tags: None,
-            summary: None,
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: None,
-            page: Some("about/team".to_string()),
-        };
-
         assert!(matches!(
-            parse_page_key(&front_matter),
+            parse_page_key(Some("about/team")),
             Err(PublishError::Parse(_))
         ));
     }
 
     #[test]
     fn test_parse_page_key_rejects_uppercase() {
-        let front_matter = ObsidianFrontMatter {
-            title: "About".to_string(),
-            kind: ContentKind::Page,
-            tags: None,
-            summary: None,
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: None,
-            page: Some("About".to_string()),
-        };
-
         assert!(matches!(
-            parse_page_key(&front_matter),
+            parse_page_key(Some("About")),
             Err(PublishError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_page_key_rejects_missing_value() {
+        assert!(matches!(
+            parse_page_key(None),
+            Err(PublishError::Parse(message)) if message.contains("require a page key")
+        ));
+    }
+
+    #[test]
+    fn test_parse_category_success() {
+        assert_eq!(parse_category(Some("tech")).unwrap(), Category::Tech);
+    }
+
+    #[test]
+    fn test_parse_category_rejects_missing_value() {
+        assert!(matches!(
+            parse_category(None),
+            Err(PublishError::Parse(message)) if message.contains("requires a category")
         ));
     }
 

--- a/crates/publish/src/error.rs
+++ b/crates/publish/src/error.rs
@@ -19,6 +19,9 @@ pub enum PublishError {
     #[error("blocking task failed: {0}")]
     Join(#[from] tokio::task::JoinError),
 
+    #[error(transparent)]
+    StripPrefix(#[from] std::path::StripPrefixError),
+
     #[error("invalid file path: {0}")]
     InvalidPath(String),
 

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -10,14 +10,14 @@ mod slug;
 
 use crate::artifacts::{
     SiteDirectories, build_site_artifacts, validate_site_artifacts, write_article_page,
-    write_category_page, write_page_document, write_site_artifacts,
+    write_category_page, write_home_fragment, write_page_document, write_site_artifacts,
 };
 use crate::classify::{
     build_file_mapping, classify_obsidian_files, ensure_unique_category_landings,
     ensure_unique_page_keys,
 };
 use crate::ingest::scan_obsidian_files;
-use crate::render::{render_article, render_category, render_page};
+use crate::render::{render_article, render_category, render_home, render_page};
 pub use error::{PublishError, Result};
 use futures::{StreamExt, TryStreamExt, future::BoxFuture, stream};
 use log::info;
@@ -54,6 +54,7 @@ pub async fn publish_with_bookmark_enricher(
     let classify::ClassifiedFiles {
         articles,
         pages,
+        home,
         categories,
         skipped,
         errors,
@@ -61,6 +62,7 @@ pub async fn publish_with_bookmark_enricher(
 
     info!("Valid article files: {}", articles.len());
     info!("Valid page files: {}", pages.len());
+    info!("Valid home file: {}", usize::from(home.is_some()));
     info!("Valid category files: {}", categories.len());
     info!("Skipped files: {skipped}");
     if errors > 0 {
@@ -110,6 +112,13 @@ pub async fn publish_with_bookmark_enricher(
         .try_collect::<Vec<_>>()
         .await?;
 
+    let rendered_home = match home {
+        Some(parsed_file) => {
+            Some(render_home(parsed_file, &file_mapping, Arc::clone(&enrich)).await?)
+        }
+        None => None,
+    };
+
     let rendered_categories = stream::iter(categories)
         .map(|parsed_file| {
             let enrich = Arc::clone(&enrich);
@@ -123,6 +132,15 @@ pub async fn publish_with_bookmark_enricher(
         let site_directories = site_directories.clone();
         let output_file_path = tokio::task::spawn_blocking(move || {
             write_page_document(&site_directories, &rendered_page.document)
+        })
+        .await??;
+        info!("...processed {}", output_file_path.display());
+    }
+
+    if let Some(rendered_home) = rendered_home {
+        let site_directories = site_directories.clone();
+        let output_file_path = tokio::task::spawn_blocking(move || {
+            write_home_fragment(&site_directories, rendered_home)
         })
         .await??;
         info!("...processed {}", output_file_path.display());

--- a/crates/publish/src/render.rs
+++ b/crates/publish/src/render.rs
@@ -3,9 +3,7 @@ use crate::artifacts::CategoryLandingMetadata;
 use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedPageFile};
 use crate::error::Result;
 use crate::ingest::{FileMapping, convert_markdown_to_html, convert_obsidian_links};
-use domain::{
-    ArticleBody, ArticleMeta, ArticleMetaInput, Category, PageArtifactDocument, Slug, Title,
-};
+use domain::{ArticleBody, ArticleMeta, ArticleMetaInput, Category, PageArtifactDocument, Title};
 use log::warn;
 
 pub(crate) struct RenderedArticle {
@@ -44,7 +42,7 @@ pub(crate) async fn render_article(
 ) -> Result<RenderedArticle> {
     let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
     let meta = ArticleMeta::new(ArticleMetaInput {
-        slug: Slug::new(parsed_file.slug)?,
+        slug: parsed_file.slug,
         title: Title::new(parsed_file.front_matter.title)?,
         category: parsed_file.category,
         section_path: parsed_file.section_path,

--- a/crates/publish/src/render.rs
+++ b/crates/publish/src/render.rs
@@ -1,6 +1,6 @@
 use crate::BookmarkEnricher;
-use crate::artifacts::CategoryLandingMetadata;
-use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedPageFile};
+use crate::artifacts::{CategoryLandingMetadata, HomeFragmentArtifact};
+use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile};
 use crate::error::Result;
 use crate::ingest::{FileMapping, convert_markdown_to_html, convert_obsidian_links};
 use domain::{ArticleBody, ArticleMeta, ArticleMetaInput, Category, PageArtifactDocument, Title};
@@ -73,6 +73,20 @@ pub(crate) async fn render_page(
             html,
             updated_at: parsed_file.front_matter.updated,
         },
+    })
+}
+
+pub(crate) async fn render_home(
+    parsed_file: ParsedHomeFile,
+    file_mapping: &FileMapping,
+    enrich: BookmarkEnricher,
+) -> Result<HomeFragmentArtifact> {
+    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    Ok(HomeFragmentArtifact {
+        title: parsed_file.front_matter.title,
+        description: parsed_file.front_matter.summary,
+        html,
+        updated_at: parsed_file.front_matter.updated,
     })
 }
 

--- a/crates/publish/src/slug.rs
+++ b/crates/publish/src/slug.rs
@@ -1,4 +1,5 @@
 use crate::error::{PublishError, Result};
+use domain::Slug;
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
@@ -7,7 +8,7 @@ pub(crate) fn generate_slug<P: AsRef<Path>>(
     title: &str,
     relative_path: P,
     created: &str,
-) -> Result<String> {
+) -> Result<Slug> {
     let relative_path_str = relative_path
         .as_ref()
         .to_str()
@@ -29,7 +30,7 @@ pub(crate) fn generate_slug<P: AsRef<Path>>(
             acc
         });
 
-    Ok(slug)
+    Slug::new(slug).map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -48,8 +49,8 @@ mod tests {
 
         let slug = generate_slug(title, &relative_path, created)?;
 
-        assert_eq!(slug.len(), 12);
-        assert!(slug.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(slug.as_str().len(), 12);
+        assert!(slug.as_str().chars().all(|c| c.is_ascii_hexdigit()));
 
         Ok(())
     }

--- a/crates/publish/tests/e2e_test.rs
+++ b/crates/publish/tests/e2e_test.rs
@@ -112,7 +112,7 @@ async fn test_end_to_end_obsidian_processing() {
         次は[[Rustでのパフォーマンス最適化]]について学んでみましょう。
     "#};
 
-    let basic_file = obsidian_dir.join("basic-rust-concepts.md");
+    let basic_file = obsidian_dir.join("tech").join("basic-rust-concepts.md");
     fs::write(&basic_file, basic_concepts).unwrap();
 
     // Draft blog article.
@@ -328,7 +328,8 @@ async fn test_large_volume_processing() {
     let obsidian_dir = temp_dir.path().join("obsidian");
     let output_dir = temp_dir.path().join("dist");
 
-    fs::create_dir_all(&obsidian_dir).unwrap();
+    let tech_dir = obsidian_dir.join("tech");
+    fs::create_dir_all(&tech_dir).unwrap();
     write_about_page(&obsidian_dir);
 
     // Generate 100 test files.
@@ -379,7 +380,7 @@ async fn test_large_volume_processing() {
             (i + 1) % 100
         );
 
-        let file_path = obsidian_dir.join(format!("test-article-{i:03}.md"));
+        let file_path = tech_dir.join(format!("test-article-{i:03}.md"));
         fs::write(&file_path, content).unwrap();
     }
 
@@ -411,7 +412,8 @@ async fn test_publish_rejects_content_errors_without_writing_artifacts() {
     let obsidian_dir = temp_dir.path().join("obsidian");
     let output_dir = temp_dir.path().join("dist");
 
-    fs::create_dir_all(&obsidian_dir).unwrap();
+    let tech_dir = obsidian_dir.join("tech");
+    fs::create_dir_all(&tech_dir).unwrap();
 
     // Valid file.
     let valid_file = indoc! {r#"
@@ -467,9 +469,9 @@ async fn test_publish_rejects_content_errors_without_writing_artifacts() {
         This should be skipped.
     "#};
 
-    fs::write(obsidian_dir.join("valid.md"), valid_file).unwrap();
-    fs::write(obsidian_dir.join("invalid.md"), invalid_yaml).unwrap();
-    fs::write(obsidian_dir.join("incomplete.md"), incomplete_file).unwrap();
+    fs::write(tech_dir.join("valid.md"), valid_file).unwrap();
+    fs::write(tech_dir.join("invalid.md"), invalid_yaml).unwrap();
+    fs::write(tech_dir.join("incomplete.md"), incomplete_file).unwrap();
 
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_err(), "Publishing must reject content errors");

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -30,8 +30,10 @@ fn offline_bookmark_enricher() -> BookmarkEnricher {
 }
 
 fn write_required_article(obsidian_dir: &Path) {
+    let category_dir = obsidian_dir.join("tech");
+    fs::create_dir_all(&category_dir).unwrap();
     fs::write(
-        obsidian_dir.join("required-article.md"),
+        category_dir.join("required-article.md"),
         indoc! {r#"
             ---
             title: "Required Article"
@@ -71,7 +73,7 @@ async fn test_publish_with_sample_file() {
     let output_dir = temp_dir.path().join("dist");
 
     // Create the Obsidian directory and a sample file.
-    fs::create_dir_all(&obsidian_dir).unwrap();
+    fs::create_dir_all(obsidian_dir.join("tech")).unwrap();
 
     let sample_content = indoc! {r#"
         ---
@@ -90,7 +92,7 @@ async fn test_publish_with_sample_file() {
         This is a test article.
     "#};
 
-    let sample_file = obsidian_dir.join("test.md");
+    let sample_file = obsidian_dir.join("tech/test.md");
     fs::write(&sample_file, sample_content).unwrap();
     write_about_page(&obsidian_dir);
 
@@ -127,7 +129,7 @@ async fn test_publish_skips_incomplete_file() {
     let output_dir = temp_dir.path().join("dist");
 
     // Create the Obsidian directory and a file with `is_completed: false`.
-    fs::create_dir_all(&obsidian_dir).unwrap();
+    fs::create_dir_all(obsidian_dir.join("tech")).unwrap();
 
     let incomplete_content = indoc! {r#"
         ---
@@ -146,7 +148,7 @@ async fn test_publish_skips_incomplete_file() {
         This article is not completed.
     "#};
 
-    let sample_file = obsidian_dir.join("incomplete.md");
+    let sample_file = obsidian_dir.join("tech/incomplete.md");
     fs::write(&sample_file, incomplete_content).unwrap();
     write_required_article(&obsidian_dir);
     write_about_page(&obsidian_dir);
@@ -327,7 +329,7 @@ async fn test_publish_with_bookmark_enricher() {
     let obsidian_dir = temp_dir.path().join("obsidian");
     let output_dir = temp_dir.path().join("dist");
 
-    fs::create_dir_all(&obsidian_dir).unwrap();
+    fs::create_dir_all(obsidian_dir.join("tech")).unwrap();
 
     // Use an offline enricher that converts bookmarks with fallback data only.
     let sample_content = indoc! {r#"
@@ -349,7 +351,7 @@ async fn test_publish_with_bookmark_enricher() {
         </div>
     "#};
 
-    let sample_file = obsidian_dir.join("bookmark.md");
+    let sample_file = obsidian_dir.join("tech/bookmark.md");
     fs::write(&sample_file, sample_content).unwrap();
     write_about_page(&obsidian_dir);
 

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -241,6 +241,40 @@ async fn test_publish_with_home_fragment_file() {
 }
 
 #[tokio::test]
+async fn test_publish_rejects_duplicate_home_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let obsidian_dir = temp_dir.path().join("obsidian");
+    let output_dir = temp_dir.path().join("dist");
+
+    fs::create_dir_all(&obsidian_dir).unwrap();
+    let home_content = indoc! {r#"
+        ---
+        title: "Home"
+        kind: home
+        summary: "Home intro"
+        created: "2025-01-01T00:00:00+09:00"
+        updated: "2025-01-01T00:00:00+09:00"
+        is_completed: true
+        ---
+
+        # Welcome
+    "#};
+
+    fs::write(obsidian_dir.join("home.md"), home_content).unwrap();
+    fs::write(obsidian_dir.join("another-home.md"), home_content).unwrap();
+    write_required_article(&obsidian_dir);
+    write_about_page(&obsidian_dir);
+
+    let result = publish(&obsidian_dir, &output_dir).await;
+
+    assert!(matches!(
+        result,
+        Err(PublishError::ContentErrors { count: 1 })
+    ));
+    assert!(!output_dir.exists());
+}
+
+#[tokio::test]
 async fn test_publish_with_category_landing_file() {
     let temp_dir = TempDir::new().unwrap();
     let obsidian_dir = temp_dir.path().join("obsidian");

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -195,7 +195,7 @@ updated: "2025-01-16T09:30:00+09:00"
 
 ### ディレクトリ構造と `section_path`
 
-category 配下のディレクトリ構造は frontmatter に重ねて書かず、publisher が path から `section_path` を導出する。
+article は frontmatter の `category` と同名のディレクトリ配下に置く。publisher はこの一致を検証し、category 相対 path から `section_path` を導出する。
 
 例:
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -62,6 +62,7 @@ okawak_blog/
 - `crates/publish`
   - 単一のpublisher crate
   - crate外向けAPIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に限定する
+  - path処理の対応環境はmacOSとLinuxとし、Windows形式のpathは対象外とする
   - ingest moduleによるObsidian vault走査、frontmatter parse、Markdown変換、Obsidian link解決
   - bookmark moduleによる外部HTTPを伴うbookmark enrichment
   - content kindごとの公開物生成と`section_path`の導出

--- a/docs/content/obsidian-template.md
+++ b/docs/content/obsidian-template.md
@@ -9,9 +9,10 @@
 - Markdown は LF 改行の frontmatter を前提にする
 - `is_completed: true` のものだけを公開対象として扱う
 - `kind` によって `article` / `category` / `page` / `home` を判定する
+- article は frontmatter の `category` と同名のディレクトリ配下に置く
 - category 配下のディレクトリ構造は `section_path` として path から導出する
 
-## 推奨ディレクトリ構造
+## ディレクトリ構造
 
 ```text
 Publish/
@@ -81,6 +82,7 @@ Obsidian link や bookmark 埋め込みを含めてよい。
 
 - `kind` を省略した場合は `article` として扱う
 - `category` は必須
+- article の path の先頭ディレクトリは `category` と一致させる。不一致の場合は publish に失敗する
 - `Publish/tech/rust/async.md` のような path なら `section_path=["rust"]` が自動で付く
 
 ## 2. カテゴリトップページ


### PR DESCRIPTION
## Summary

- propagate `StripPrefixError` directly and remove redundant path helpers
- preserve `Slug` as a domain type through publisher classification
- narrow category and page parsing inputs and remove unnecessary `valid` naming/thin wrappers
- require article paths to start with the frontmatter category and derive `section_path` from the category-relative path
- classify, render, and write home content through a dedicated flow while preserving the current artifact contract
- document the category-directory constraint and unsupported Windows path behavior

## Why

The classifier mixed validation state, path normalization, and content-kind-specific conversion. The refactor makes each input and intermediate type describe its actual responsibility, validates the article directory invariant at the classification boundary, and keeps home content distinct from ordinary static pages.

## Impact

Completed articles must be placed below a directory matching their frontmatter `category`. Static pages cannot use the reserved `home` page key. The generated artifact layout remains compatible with the current reader, including `pages/home.json`.

## Follow-up

A separate PR will update the artifact contract so home uses a dedicated document and reader path instead of `PageArtifactDocument`, `PageKey("home")`, and `pages/home.json`. This PR intentionally keeps that external contract unchanged.

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `git diff --check`