### PR TITLE
refactor: introduce a dedicated home artifact contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ site/
 │   └── ...
 ├── pages/
 │   ├── about.json
-│   ├── home.json
 │   └── ...
+├── home.json
 └── metadata/
     └── site.json
 ```

--- a/crates/domain/src/artifact_document.rs
+++ b/crates/domain/src/artifact_document.rs
@@ -164,6 +164,15 @@ pub struct PageArtifactDocument {
     pub updated_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HomeFragmentArtifactDocument {
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub html: String,
+    pub updated_at: String,
+}
+
 impl From<&SiteMetadata> for SiteMetadataDocument {
     fn from(metadata: &SiteMetadata) -> Self {
         Self {
@@ -321,6 +330,22 @@ mod tests {
         assert!(json.contains("\"page\":\"about\""));
         assert!(json.contains("\"title\":\"About\""));
         assert!(json.contains("\"html\":\"<h1>About</h1>\""));
+    }
+
+    #[test]
+    fn test_home_fragment_artifact_document_serialization() {
+        let document = HomeFragmentArtifactDocument {
+            title: "Home".to_string(),
+            description: Some("Home introduction".to_string()),
+            html: "<p>Welcome</p>".to_string(),
+            updated_at: "2025-01-02T00:00:00+09:00".to_string(),
+        };
+
+        let json = serde_json::to_string(&document).unwrap();
+
+        assert!(!json.contains("\"page\""));
+        assert!(json.contains("\"title\":\"Home\""));
+        assert!(json.contains("\"html\":\"<p>Welcome</p>\""));
     }
 
     #[test]

--- a/crates/domain/src/site_page.rs
+++ b/crates/domain/src/site_page.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     ArticleIndexDocument, ArticleSummaryDocument, Category, CategoryIndexDocument, DomainError,
-    PageArtifactDocument, PageKey, Result, SiteMetadataDocument, Slug, Title,
+    HomeFragmentArtifactDocument, PageArtifactDocument, PageKey, Result, SiteMetadataDocument,
+    Slug, Title,
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -54,7 +55,14 @@ pub struct HomePageDocument {
     pub total_articles: usize,
     pub categories: Vec<SiteCategorySummary>,
     pub articles: Vec<SiteArticleCard>,
-    pub fragment: Option<StaticPageDocument>,
+    pub fragment: Option<HomeFragmentDocument>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HomeFragmentDocument {
+    pub title: String,
+    pub description: Option<String>,
+    pub html: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -179,7 +187,7 @@ pub fn build_static_page_canonical_path(document: &StaticPageDocument) -> String
 pub fn build_home_page_document(
     article_index: &ArticleIndexDocument,
     site_metadata: &SiteMetadataDocument,
-    home_fragment: Option<&PageArtifactDocument>,
+    home_fragment: Option<&HomeFragmentArtifactDocument>,
 ) -> Result<HomePageDocument> {
     let articles = article_index
         .articles
@@ -203,7 +211,30 @@ pub fn build_home_page_document(
         total_articles: site_metadata.total_articles,
         categories,
         articles,
-        fragment: home_fragment.map(build_static_page_document).transpose()?,
+        fragment: home_fragment
+            .map(build_home_fragment_document)
+            .transpose()?,
+    })
+}
+
+pub fn build_home_fragment_document(
+    artifact: &HomeFragmentArtifactDocument,
+) -> Result<HomeFragmentDocument> {
+    let title = artifact.title.trim();
+    let html = artifact.html.trim();
+
+    if title.is_empty() {
+        return Err(DomainError::validation("title"));
+    }
+
+    if html.is_empty() {
+        return Err(DomainError::validation("html"));
+    }
+
+    Ok(HomeFragmentDocument {
+        title: title.to_string(),
+        description: artifact.description.clone(),
+        html: artifact.html.clone(),
     })
 }
 
@@ -370,8 +401,7 @@ mod tests {
 
     #[test]
     fn test_build_home_page_document_with_fragment() {
-        let fragment = PageArtifactDocument {
-            page: PageKey::new("home".to_string()).unwrap(),
+        let fragment = HomeFragmentArtifactDocument {
             title: "Home".to_string(),
             description: Some("Home fragment".to_string()),
             html: "<p>Welcome</p>".to_string(),
@@ -392,13 +422,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            document
-                .fragment
-                .as_ref()
-                .map(|fragment| fragment.page.as_str()),
-            Some("home")
-        );
+        assert_eq!(document.fragment.as_ref().unwrap().title, "Home");
         assert!(document.fragment.as_ref().unwrap().html.contains("Welcome"));
     }
 

--- a/crates/publish/src/artifacts.rs
+++ b/crates/publish/src/artifacts.rs
@@ -1,9 +1,9 @@
 use crate::error::{PublishError, Result};
 
 use domain::{
-    ArticleIndexDocument, ArticleMeta, Category, CategoryIndexDocument, PageArtifactDocument,
-    SiteMetadata, SiteMetadataDocument, Slug, build_article_index, build_category_indexes,
-    build_site_metadata,
+    ArticleIndexDocument, ArticleMeta, Category, CategoryIndexDocument,
+    HomeFragmentArtifactDocument, PageArtifactDocument, SiteMetadata, SiteMetadataDocument, Slug,
+    build_article_index, build_category_indexes, build_site_metadata,
 };
 use serde::Serialize;
 use std::{
@@ -36,17 +36,10 @@ pub(crate) struct CategoryLandingMetadata {
     pub(crate) updated_at: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct HomeFragmentArtifact {
-    pub(crate) title: String,
-    pub(crate) description: Option<String>,
-    pub(crate) html: String,
-    pub(crate) updated_at: String,
-}
-
 /// Output directories for generated local site artifacts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SiteDirectories {
+    home_fragment_path: PathBuf,
     articles_dir: PathBuf,
     categories_dir: PathBuf,
     metadata_dir: PathBuf,
@@ -57,6 +50,7 @@ impl SiteDirectories {
     pub(crate) fn prepare(output_dir: impl AsRef<Path>) -> Result<Self> {
         let site_root = output_dir.as_ref().join("site");
         let site_directories = Self {
+            home_fragment_path: site_root.join("home.json"),
             articles_dir: site_root.join("articles"),
             categories_dir: site_root.join("categories"),
             metadata_dir: site_root.join("metadata"),
@@ -143,16 +137,10 @@ pub(crate) fn write_page_document(
 
 pub(crate) fn write_home_fragment(
     site_directories: &SiteDirectories,
-    home_fragment: HomeFragmentArtifact,
+    home_fragment: &HomeFragmentArtifactDocument,
 ) -> Result<PathBuf> {
-    let document = PageArtifactDocument {
-        page: domain::PageKey::new("home".to_string())?,
-        title: home_fragment.title,
-        description: home_fragment.description,
-        html: home_fragment.html,
-        updated_at: home_fragment.updated_at,
-    };
-    write_page_document(site_directories, &document)
+    write_json_pretty(&site_directories.home_fragment_path, home_fragment)?;
+    Ok(site_directories.home_fragment_path.clone())
 }
 
 pub(crate) fn write_category_page(
@@ -540,6 +528,27 @@ mod tests {
 
         assert_eq!(output_path, site_directories.pages_dir.join("about.json"));
         assert!(output_path.exists());
+    }
+
+    #[test]
+    fn test_write_home_fragment() {
+        let temp_dir = TempDir::new().unwrap();
+        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
+
+        let output_path = write_home_fragment(
+            &site_directories,
+            &HomeFragmentArtifactDocument {
+                title: "Home".to_string(),
+                description: Some("Home introduction".to_string()),
+                html: "<p>Welcome</p>".to_string(),
+                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(output_path, temp_dir.path().join("site/home.json"));
+        assert!(output_path.exists());
+        assert!(!site_directories.pages_dir.join("home.json").exists());
     }
 
     #[test]

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -140,7 +140,7 @@ pub async fn publish_with_bookmark_enricher(
     if let Some(rendered_home) = rendered_home {
         let site_directories = site_directories.clone();
         let output_file_path = tokio::task::spawn_blocking(move || {
-            write_home_fragment(&site_directories, rendered_home)
+            write_home_fragment(&site_directories, &rendered_home)
         })
         .await??;
         info!("...processed {}", output_file_path.display());

--- a/crates/publish/src/render.rs
+++ b/crates/publish/src/render.rs
@@ -1,9 +1,12 @@
 use crate::BookmarkEnricher;
-use crate::artifacts::{CategoryLandingMetadata, HomeFragmentArtifact};
+use crate::artifacts::CategoryLandingMetadata;
 use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile};
 use crate::error::Result;
 use crate::ingest::{FileMapping, convert_markdown_to_html, convert_obsidian_links};
-use domain::{ArticleBody, ArticleMeta, ArticleMetaInput, Category, PageArtifactDocument, Title};
+use domain::{
+    ArticleBody, ArticleMeta, ArticleMetaInput, Category, HomeFragmentArtifactDocument,
+    PageArtifactDocument, Title,
+};
 use log::warn;
 
 pub(crate) struct RenderedArticle {
@@ -80,9 +83,9 @@ pub(crate) async fn render_home(
     parsed_file: ParsedHomeFile,
     file_mapping: &FileMapping,
     enrich: BookmarkEnricher,
-) -> Result<HomeFragmentArtifact> {
+) -> Result<HomeFragmentArtifactDocument> {
     let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
-    Ok(HomeFragmentArtifact {
+    Ok(HomeFragmentArtifactDocument {
         title: parsed_file.front_matter.title,
         description: parsed_file.front_matter.summary,
         html,

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -232,12 +232,12 @@ async fn test_publish_with_home_fragment_file() {
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
 
-    let page_document =
-        fs::read_to_string(output_dir.join("site").join("pages").join("home.json")).unwrap();
+    let page_document = fs::read_to_string(output_dir.join("site").join("home.json")).unwrap();
 
-    assert!(page_document.contains("\"page\": \"home\""));
+    assert!(!page_document.contains("\"page\""));
     assert!(page_document.contains("\"title\": \"Home\""));
     assert!(page_document.contains("This fragment is generated from markdown."));
+    assert!(!output_dir.join("site/pages/home.json").exists());
 }
 
 #[tokio::test]

--- a/crates/site/infra/src/cache.rs
+++ b/crates/site/infra/src/cache.rs
@@ -1,8 +1,8 @@
 use crate::{ArtifactReader, ArtifactSnapshot, DynArtifactReader, DynArtifactSnapshot, Result};
 use async_trait::async_trait;
 use domain::{
-    ArticleIndexDocument, Category, CategoryIndexDocument, PageArtifactDocument, PageKey,
-    SiteMetadataDocument, Slug,
+    ArticleIndexDocument, Category, CategoryIndexDocument, HomeFragmentArtifactDocument,
+    PageArtifactDocument, PageKey, SiteMetadataDocument, Slug,
 };
 use std::{
     collections::HashMap,
@@ -110,6 +110,7 @@ struct CachingArtifactSnapshot {
     inner: DynArtifactSnapshot,
     article_index: OnceCell<ArticleIndexDocument>,
     site_metadata: OnceCell<SiteMetadataDocument>,
+    home_fragment: OnceCell<HomeFragmentArtifactDocument>,
     category_indexes: KeyedCache<CategoryIndexDocument>,
     category_html: KeyedCache<String>,
     article_html: KeyedCache<String>,
@@ -122,6 +123,7 @@ impl CachingArtifactSnapshot {
             inner,
             article_index: OnceCell::new(),
             site_metadata: OnceCell::new(),
+            home_fragment: OnceCell::new(),
             category_indexes: KeyedCache::new(),
             category_html: KeyedCache::new(),
             article_html: KeyedCache::new(),
@@ -176,6 +178,13 @@ impl ArtifactSnapshot for CachingArtifactSnapshot {
                 self.inner.read_article_html(category, slug)
             })
             .await
+    }
+
+    async fn read_home_fragment(&self) -> Result<HomeFragmentArtifactDocument> {
+        self.home_fragment
+            .get_or_try_init(|| self.inner.read_home_fragment())
+            .await
+            .cloned()
     }
 
     async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {
@@ -337,6 +346,15 @@ mod tests {
 
         async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String> {
             Ok(format!("{}/{}", category.as_str(), slug.as_str()))
+        }
+
+        async fn read_home_fragment(&self) -> Result<HomeFragmentArtifactDocument> {
+            Ok(HomeFragmentArtifactDocument {
+                title: "Home".to_string(),
+                description: None,
+                html: String::new(),
+                updated_at: String::new(),
+            })
         }
 
         async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {

--- a/crates/site/infra/src/lib.rs
+++ b/crates/site/infra/src/lib.rs
@@ -9,7 +9,7 @@ use aws_config::BehaviorVersion;
 use aws_sdk_s3::Client;
 use domain::{
     ArticleIndexDocument, ArtifactReleasePointerDocument, Category, CategoryIndexDocument,
-    PageArtifactDocument, PageKey, SiteMetadataDocument, Slug,
+    HomeFragmentArtifactDocument, PageArtifactDocument, PageKey, SiteMetadataDocument, Slug,
 };
 use std::{
     env,
@@ -49,6 +49,7 @@ pub trait ArtifactSnapshot: Send + Sync {
     async fn read_category_html(&self, category: &Category) -> Result<String>;
     async fn read_site_metadata(&self) -> Result<SiteMetadataDocument>;
     async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String>;
+    async fn read_home_fragment(&self) -> Result<HomeFragmentArtifactDocument>;
     async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument>;
 }
 
@@ -117,6 +118,10 @@ impl ArtifactSnapshot for LocalArtifactReader {
             slug.as_str()
         )))
         .await?)
+    }
+
+    async fn read_home_fragment(&self) -> Result<HomeFragmentArtifactDocument> {
+        self.read_json("home.json").await
     }
 
     async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {
@@ -319,6 +324,10 @@ impl ArtifactSnapshot for S3ArtifactSnapshot {
         .await
     }
 
+    async fn read_home_fragment(&self) -> Result<HomeFragmentArtifactDocument> {
+        self.read_json("home.json").await
+    }
+
     async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {
         let text = self
             .read_text(&format!("pages/{}.json", page.as_str()))
@@ -491,6 +500,17 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
+        fs::write(
+            root.join("home.json"),
+            serde_json::to_string_pretty(&HomeFragmentArtifactDocument {
+                title: "Home".to_string(),
+                description: Some("Home introduction".to_string()),
+                html: "<p>Welcome</p>".to_string(),
+                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
     }
 
     #[tokio::test]
@@ -515,6 +535,7 @@ mod tests {
             .read_page_document(&PageKey::new("about".to_string()).unwrap())
             .await
             .unwrap();
+        let home_fragment = snapshot.read_home_fragment().await.unwrap();
 
         assert_eq!(document.articles.len(), 1);
         assert_eq!(document.articles[0].slug, "intro00000001");
@@ -525,6 +546,8 @@ mod tests {
         assert_eq!(html, "<h1>Intro</h1>");
         assert_eq!(page.page.as_str(), "about");
         assert_eq!(page.title, "About");
+        assert_eq!(home_fragment.title, "Home");
+        assert_eq!(home_fragment.html, "<p>Welcome</p>");
     }
 
     #[test]

--- a/crates/site/server/src/http_cache.rs
+++ b/crates/site/server/src/http_cache.rs
@@ -220,8 +220,8 @@ mod tests {
     use async_trait::async_trait;
     use axum::{Router, body::Body, routing::get};
     use domain::{
-        ArticleIndexDocument, Category, CategoryIndexDocument, PageArtifactDocument, PageKey,
-        SiteMetadataDocument, Slug,
+        ArticleIndexDocument, Category, CategoryIndexDocument, HomeFragmentArtifactDocument,
+        PageArtifactDocument, PageKey, SiteMetadataDocument, Slug,
     };
     use infra::{ArtifactReader, ArtifactSnapshot, DynArtifactSnapshot, Result};
     use std::sync::{
@@ -281,6 +281,10 @@ mod tests {
         }
 
         async fn read_article_html(&self, _category: &Category, _slug: &Slug) -> Result<String> {
+            unreachable!()
+        }
+
+        async fn read_home_fragment(&self) -> Result<HomeFragmentArtifactDocument> {
             unreachable!()
         }
 

--- a/crates/site/web/src/routes/home.rs
+++ b/crates/site/web/src/routes/home.rs
@@ -5,8 +5,6 @@ use crate::{SITE_NAME, build_site_url};
 #[cfg(feature = "ssr")]
 use axum::http::StatusCode;
 #[cfg(feature = "ssr")]
-use domain::PageKey;
-#[cfg(feature = "ssr")]
 use domain::build_home_page_document;
 use domain::{
     HomePageDocument, build_category_path, build_home_page_canonical_path,
@@ -30,9 +28,7 @@ pub async fn get_home_page_document() -> Result<HomePageDocument, ServerFnError>
         let snapshot = artifact_reader.snapshot().await?;
         let article_index = snapshot.read_article_index().await?;
         let site_metadata = snapshot.read_site_metadata().await?;
-        let home_page_key = PageKey::new("home".to_string())
-            .map_err(|error| ServerFnError::new(format!("invalid home page key: {error}")))?;
-        let home_fragment = match snapshot.read_page_document(&home_page_key).await {
+        let home_fragment = match snapshot.read_home_fragment().await {
             Ok(fragment) => Some(fragment),
             Err(error) if error.is_not_found() => None,
             Err(error) => return Err(error.into()),

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -287,6 +287,7 @@ releases/
         ├── articles/
         ├── categories/
         ├── pages/
+        ├── home.json
         └── metadata/
 ```
 
@@ -338,6 +339,8 @@ flowchart LR
   - 最近の記事一覧
   - カテゴリ集計
   - optional な `fragment`
+- `HomeFragmentDocument`
+  - home pageへ組み込むtitle、description、HTML、updated_at
 - `ArticlePageDocument`
   - 記事メタデータ
   - 本文 HTML
@@ -346,7 +349,7 @@ flowchart LR
   - 記事一覧
   - `section_path` ごとの grouped section
 - `StaticPageDocument`
-  - `about` や `home` fragment の共通 page contract
+  - `about` などの固定ページ用contract
 
 `site/web` はこの page contract をもとに metadata と UI を組み立てる。SSR feature では Leptos context から `DynArtifactReader` を受け取り、server function の開始時にsnapshotを1回取得してpage documentを組み立てる。local / S3 などの storage 実装詳細には依存しない。hydrate build は `infra` に依存しない。
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -245,8 +245,8 @@ site/
 │   └── ...
 ├── pages/
 │   ├── about.json
-│   ├── home.json
 │   └── ...
+├── home.json
 └── metadata/
     └── site.json
 ```
@@ -264,12 +264,15 @@ artifact の意味は次の通り。
   - カテゴリ landing page 本文
   - landing Markdown が無い場合は fallback HTML を生成する
 - `pages/<page>.json`
-  - 固定ページまたは home fragment
+  - 固定ページ
+  - HTML 本文と title / description / updated_at を含む
+- `home.json`
+  - home pageへ実行時に組み込む任意のfragment
   - HTML 本文と title / description / updated_at を含む
 - `metadata/site.json`
   - 総記事数とカテゴリ集計
 
-`PageArtifactDocument` は HTML を JSON に包んで保持する。`about` と `home` は reader 側で同じページ artifact 契約を共有する。
+`PageArtifactDocument` は固定ページを保持する。homeは完成したpageではなく実行時に記事一覧やmetadataと合成する一部分なので、`HomeFragmentArtifactDocument` として独立させる。
 
 ### S3 release 契約
 
@@ -297,7 +300,7 @@ flowchart TB
         C1["categories/<category>/index.json"]
         C2["categories/<category>/page.html"]
         P1["pages/about.json"]
-        P2["pages/home.json"]
+        H1["home.json"]
         M1["metadata/site.json"]
     end
 ```

--- a/docs/content/obsidian-template.md
+++ b/docs/content/obsidian-template.md
@@ -182,7 +182,7 @@ updated: "2026-04-12T10:00:00+09:00"
 メモ:
 
 - home 全体を Markdown に置き換えるのではなく、intro 部分の fragment として扱う
-- 対応する artifact は `site/pages/home.json`
+- 対応する artifact は `site/home.json`
 
 ## 必須フィールドの目安
 

--- a/e2e/fixtures/empty-site/home.json
+++ b/e2e/fixtures/empty-site/home.json
@@ -1,5 +1,4 @@
 {
-  "page": "home",
   "title": "Empty Fixture Home",
   "description": "Empty home fixture description",
   "html": "<p>Empty home fixture content</p>",

--- a/e2e/fixtures/site/home.json
+++ b/e2e/fixtures/site/home.json
@@ -1,5 +1,4 @@
 {
-  "page": "home",
   "title": "Fixture Home",
   "description": "Home fixture description",
   "html": "<p>Fixture home content</p>",


### PR DESCRIPTION
Closes #141

## Summary

- add `HomeFragmentArtifactDocument` as the persisted contract for optional home content
- publish the singleton home artifact as `site/home.json` instead of `site/pages/home.json`
- add dedicated reader and cache paths for the home fragment
- compose `HomePageDocument` from `HomeFragmentDocument`, article summaries, and site metadata
- update fixtures and architecture/content documentation for the new artifact layout

## Why

The home content is an optional fragment of the composed home page, not a routable static page. Reusing the page artifact contract forced a meaningless `PageKey("home")` and placed the singleton under the page collection. A dedicated contract makes that distinction explicit across publisher, storage, and runtime boundaries.

The `Fragment` suffix is retained because this artifact contains only the authored home introduction; the runtime still composes the complete home page with the article index and site metadata.

## Impact

- artifact layout changes from `pages/home.json` to `home.json`
- `PageArtifactDocument` remains limited to routable static pages
- publisher and server should be deployed together for this contract change
- missing home content remains supported

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `mise run test-e2e`
- `git diff --check`