### PR TITLE
refactor: extract internal link index

### DIFF
--- a/crates/publish/README.md
+++ b/crates/publish/README.md
@@ -126,6 +126,7 @@ src/
 │   ├── converter.rs
 │   ├── parser.rs
 │   └── scanner.rs
+├── links.rs
 ├── render.rs
 └── slug.rs
 ```
@@ -133,7 +134,8 @@ src/
 `lib.rs`はorchestrationとcrate外向けAPIを担います。公開するのは`publish`、
 `publish_with_bookmark_enricher`、`BookmarkEnricher`、`PublishError`、`Result`です。
 それ以外のmoduleはpublisher内部に閉じ、`error.rs`にpublisher全体のerrorを集約します。
-分類済み入力型は`classify.rs`、render済み出力型は`render.rs`が所有します。
+分類済み入力型は`classify.rs`、内部リンクの索引と解決規則は`links.rs`、
+render済み出力型は`render.rs`が所有します。
 共有するartifactとsiteの契約だけを`crates/domain`に置きます。
 
 ### 処理フロー
@@ -141,7 +143,7 @@ src/
 1. **スキャン**: 指定ディレクトリ内のMarkdownファイルを検索
 2. **解析**: 各ファイルのフロントマターを解析
 3. **フィルタリング**: `is_completed: true` のファイルのみを処理対象とする
-4. **リンクマッピング**: ファイル間のリンク関係を構築
+4. **リンク索引**: 公開対象の記事から内部リンク索引を構築
 5. **変換**: Markdown→HTML変換とリッチブックマーク処理
 6. **出力**: HTMLファイルの生成
 

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -1,7 +1,6 @@
 use crate::error::{PublishError, Result};
-use crate::ingest::{
-    ContentKind, FileMapping, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file,
-};
+use crate::ingest::{ContentKind, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file};
+use crate::links;
 use domain::{Category, PageKey, Slug};
 use log::{error, warn};
 use std::collections::HashSet;
@@ -10,8 +9,8 @@ use std::path::{Path, PathBuf};
 pub(crate) struct ParsedArticleFile {
     pub(crate) category: Category,
     pub(crate) slug: Slug,
-    /// Extensionless relative path used to resolve Obsidian wiki links.
-    pub(crate) mapping_key: String,
+    /// Extensionless relative path used to resolve Obsidian internal links.
+    pub(crate) source_path: String,
     /// Category-relative directories used to group articles in category navigation.
     pub(crate) section_path: Vec<String>,
     pub(crate) markdown_body: String,
@@ -132,7 +131,7 @@ fn process_article_file(
         relative_path,
         &parsed_file.front_matter.created,
     )?;
-    let mapping_key = relative_path
+    let source_path = relative_path
         .with_extension("")
         .to_string_lossy()
         .into_owned();
@@ -141,22 +140,22 @@ fn process_article_file(
     Ok(ParsedArticleFile {
         category,
         slug,
-        mapping_key,
+        source_path,
         section_path,
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })
 }
 
-pub(crate) fn build_file_mapping(article_files: &[ParsedArticleFile]) -> FileMapping {
-    let mut mapping = FileMapping::with_capacity(article_files.len());
+pub(crate) fn build_link_index(article_files: &[ParsedArticleFile]) -> links::Index {
+    let mut index = links::Index::with_capacity(article_files.len());
     for parsed_file in article_files {
-        mapping.insert(
-            parsed_file.mapping_key.clone(),
+        index.insert(
+            parsed_file.source_path.clone(),
             format!("/{}/{}", parsed_file.category.as_str(), parsed_file.slug),
         );
     }
-    mapping
+    index
 }
 
 fn derive_section_path(category_relative_path: &Path) -> Vec<String> {
@@ -221,7 +220,7 @@ mod tests {
     use rstest::*;
 
     #[rstest]
-    fn test_build_file_mapping_success() {
+    fn test_build_link_index_success() {
         let front_matter = ObsidianFrontMatter {
             title: "Test Article".to_string(),
             kind: ContentKind::Article,
@@ -238,29 +237,27 @@ mod tests {
         let parsed_file = ParsedArticleFile {
             category: Category::Tech,
             slug: Slug::new("slug".to_string()).unwrap(),
-            mapping_key: "test".to_string(),
+            source_path: "test".to_string(),
             section_path: vec![],
             markdown_body: "# Test Content".to_string(),
             front_matter,
         };
         let article_files = vec![parsed_file];
-        let mapping = build_file_mapping(&article_files);
+        let index = build_link_index(&article_files);
 
-        assert_eq!(mapping.len(), 1);
-        assert!(mapping.contains_key("test"));
-        assert_eq!(mapping.get("test").unwrap(), "/tech/slug");
+        assert_eq!(index.resolve("test"), Some("/tech/slug"));
     }
 
     #[rstest]
-    fn test_build_file_mapping_empty() {
+    fn test_build_link_index_empty() {
         let article_files: Vec<ParsedArticleFile> = vec![];
-        let mapping = build_file_mapping(&article_files);
+        let index = build_link_index(&article_files);
 
-        assert_eq!(mapping.len(), 0);
+        assert_eq!(index.resolve("test"), None);
     }
 
     #[rstest]
-    fn test_build_file_mapping_path_collision() {
+    fn test_build_link_index_path_collision() {
         let front_matter1 = ObsidianFrontMatter {
             title: "Test Article 1".to_string(),
             kind: ContentKind::Article,
@@ -290,7 +287,7 @@ mod tests {
         let parsed_file1 = ParsedArticleFile {
             category: Category::Tech,
             slug: Slug::new("slug1".to_string()).unwrap(),
-            mapping_key: "dir1/test".to_string(),
+            source_path: "dir1/test".to_string(),
             section_path: vec!["dir1".to_string()],
             markdown_body: "# Test Content 1".to_string(),
             front_matter: front_matter1,
@@ -298,21 +295,20 @@ mod tests {
         let parsed_file2 = ParsedArticleFile {
             category: Category::Daily,
             slug: Slug::new("slug2".to_string()).unwrap(),
-            mapping_key: "dir2/test".to_string(),
+            source_path: "dir2/test".to_string(),
             section_path: vec!["dir2".to_string()],
             markdown_body: "# Test Content 2".to_string(),
             front_matter: front_matter2,
         };
         let article_files = vec![parsed_file1, parsed_file2];
-        let mapping = build_file_mapping(&article_files);
+        let index = build_link_index(&article_files);
 
-        assert_eq!(mapping.len(), 2);
-        assert!(mapping.contains_key("dir1/test"));
-        assert!(mapping.contains_key("dir2/test"));
+        assert_eq!(index.resolve("dir1/test"), Some("/tech/slug1"));
+        assert_eq!(index.resolve("dir2/test"), Some("/daily/slug2"));
     }
 
     #[rstest]
-    fn test_build_file_mapping_url_normalization() {
+    fn test_build_link_index_url_normalization() {
         let front_matter = ObsidianFrontMatter {
             title: "URL Test".to_string(),
             kind: ContentKind::Article,
@@ -329,16 +325,15 @@ mod tests {
         let parsed_file = ParsedArticleFile {
             category: Category::Tech,
             slug: Slug::new("slug".to_string()).unwrap(),
-            mapping_key: "sub/dir/test".to_string(),
+            source_path: "sub/dir/test".to_string(),
             section_path: vec!["sub".to_string(), "dir".to_string()],
             markdown_body: "# URL Test Content".to_string(),
             front_matter,
         };
         let article_files = vec![parsed_file];
-        let mapping = build_file_mapping(&article_files);
+        let index = build_link_index(&article_files);
 
-        let href = mapping.get("sub/dir/test").unwrap();
-        assert_eq!(href, "/tech/slug");
+        assert_eq!(index.resolve("sub/dir/test"), Some("/tech/slug"));
     }
 
     #[test]

--- a/crates/publish/src/ingest.rs
+++ b/crates/publish/src/ingest.rs
@@ -2,7 +2,7 @@ mod converter;
 mod parser;
 mod scanner;
 
-pub(crate) use converter::{FileMapping, convert_markdown_to_html, convert_obsidian_links};
+pub(crate) use converter::convert_markdown_to_html;
 pub(crate) use parser::{
     ContentKind, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file,
 };

--- a/crates/publish/src/ingest/converter.rs
+++ b/crates/publish/src/ingest/converter.rs
@@ -15,9 +15,6 @@ static SAFE_BOOKMARK_RE: LazyLock<Regex> = LazyLock::new(|| {
 static HREF_ATTR_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"href="([^"]*)""#).expect("Invalid href regex"));
 
-/// Mapping from an Obsidian file path without extension to a published article href.
-pub(crate) type FileMapping = HashMap<String, String>;
-
 pub(crate) fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
     let (markdown_content, katex_placeholders) = extract_katex_placeholders(markdown_content);
 
@@ -487,65 +484,10 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
     result
 }
 
-/// Convert Obsidian wiki links to published HTML links.
-pub(crate) fn convert_obsidian_links(content: &str, file_mapping: &FileMapping) -> String {
-    static OBSIDIAN_LINK_REGEX: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"\[\[([^\]]+)\]\]").expect("Invalid regex pattern"));
-
-    OBSIDIAN_LINK_REGEX
-        .replace_all(content, |caps: &regex::Captures| {
-            let link_content = &caps[1];
-
-            let (link_target, display_text) = if let Some(pipe_pos) = link_content.find('|') {
-                let (link, display) = link_content.split_at(pipe_pos);
-                (link.trim(), display[1..].trim())
-            } else {
-                (link_content.trim(), link_content.trim())
-            };
-
-            let href = if let Some(href) = file_mapping.get(link_target) {
-                href.clone()
-            } else {
-                let mut found = false;
-                let mut result_href = format!("/{link_target}");
-
-                for (key, href) in file_mapping {
-                    if key.ends_with(&format!("/{link_target}")) || key == link_target {
-                        result_href = href.clone();
-                        found = true;
-                        break;
-                    }
-                }
-
-                if !found {
-                    log::warn!("Warning: Link target '{link_target}' not found in file mapping");
-                }
-
-                result_href
-            };
-
-            format!(
-                "[{}]({})",
-                escape_markdown_link_text(display_text),
-                escape_markdown_link_destination(&href)
-            )
-        })
-        .to_string()
-}
-
-fn escape_markdown_link_text(text: &str) -> String {
-    text.replace('\\', "\\\\")
-        .replace('[', "\\[")
-        .replace(']', "\\]")
-}
-
-fn escape_markdown_link_destination(destination: &str) -> String {
-    destination.replace(')', "\\)")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::links;
     use indoc::indoc;
     use rstest::*;
 
@@ -580,36 +522,6 @@ mod tests {
     }
 
     #[rstest]
-    fn test_obsidian_links_conversion() {
-        let mut file_mapping = FileMapping::new();
-        file_mapping.insert(
-            "notes/another-note".to_string(),
-            "/tech/abc123def".to_string(),
-        );
-        file_mapping.insert("docs/filename".to_string(), "/daily/xyz789abc".to_string());
-        file_mapping.insert("Another Note".to_string(), "/tech/abc123def".to_string());
-        file_mapping.insert("filename".to_string(), "/daily/xyz789abc".to_string());
-
-        let result =
-            convert_obsidian_links("Check out [[Another Note]] for more info.", &file_mapping);
-        assert_eq!(
-            result,
-            "Check out [Another Note](/tech/abc123def) for more info."
-        );
-
-        let result =
-            convert_obsidian_links("See [[filename|Custom Display Text]] here.", &file_mapping);
-        assert_eq!(result, "See [Custom Display Text](/daily/xyz789abc) here.");
-
-        let result = convert_obsidian_links("Link to [[nonexistent]] file.", &file_mapping);
-        assert_eq!(result, "Link to [nonexistent](/nonexistent) file.");
-
-        let result =
-            convert_obsidian_links("This is normal text with no special links.", &file_mapping);
-        assert_eq!(result, "This is normal text with no special links.");
-    }
-
-    #[rstest]
     #[case::basic_html_file(
         "title: Test Article\nslug: test123",
         "<h1>Test Content</h1>\n<p>This is a paragraph.</p>",
@@ -640,11 +552,11 @@ This is a test with [[Another Article|link]] and **bold** text.
 - Item with [[Reference Note]]
 - Regular item"#;
 
-        let mut file_mapping = FileMapping::new();
-        file_mapping.insert("Another Article".to_string(), "/tech/def456".to_string());
-        file_mapping.insert("Reference Note".to_string(), "/daily/ghi789".to_string());
+        let mut link_index = links::Index::default();
+        link_index.insert("Another Article".to_string(), "/tech/def456".to_string());
+        link_index.insert("Reference Note".to_string(), "/daily/ghi789".to_string());
 
-        let with_html_links = convert_obsidian_links(markdown_with_obsidian_links, &file_mapping);
+        let with_html_links = links::convert(markdown_with_obsidian_links, &link_index);
         let html = convert_markdown_to_html(&with_html_links).unwrap();
 
         assert!(html.contains("<h1>My Article</h1>"));
@@ -735,19 +647,6 @@ This is a test with [[Another Article|link]] and **bold** text.
         );
         assert!(result.contains(r#"<span class="okawak-katex-inline">y</span>"#));
         assert!(!result.contains(r#"<span class="okawak-katex-inline">x</span>"#));
-    }
-
-    #[rstest]
-    fn test_markdown_link_escaping() {
-        let mut file_mapping = FileMapping::new();
-        file_mapping.insert("File with <script>".to_string(), "/tech/abc123".to_string());
-
-        let result = convert_obsidian_links("[[File with <script>|Display & test]]", &file_mapping);
-        assert_eq!(result, "[Display & test](/tech/abc123)");
-
-        let result =
-            convert_obsidian_links("[[File \"quoted\"|Text with 'quotes']]", &file_mapping);
-        assert_eq!(result, "[Text with 'quotes'](/File \"quoted\")");
     }
 
     #[rstest]

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -5,6 +5,7 @@ mod bookmark;
 mod classify;
 mod error;
 mod ingest;
+mod links;
 mod render;
 mod slug;
 
@@ -13,7 +14,7 @@ use crate::artifacts::{
     write_category_page, write_home_fragment, write_page_document, write_site_artifacts,
 };
 use crate::classify::{
-    build_file_mapping, classify_obsidian_files, ensure_unique_category_landings,
+    build_link_index, classify_obsidian_files, ensure_unique_category_landings,
     ensure_unique_page_keys,
 };
 use crate::ingest::scan_obsidian_files;
@@ -72,7 +73,7 @@ pub async fn publish_with_bookmark_enricher(
     ensure_unique_page_keys(&pages)?;
     ensure_unique_category_landings(&categories)?;
 
-    let file_mapping = build_file_mapping(&articles);
+    let link_index = build_link_index(&articles);
     let site_directories = SiteDirectories::prepare(output_dir)?;
 
     const CONCURRENT_LIMIT: usize = 4;
@@ -80,7 +81,7 @@ pub async fn publish_with_bookmark_enricher(
     let article_metas = stream::iter(articles)
         .map(|parsed_file| {
             let enrich = Arc::clone(&enrich);
-            render_article(parsed_file, &file_mapping, enrich)
+            render_article(parsed_file, &link_index, enrich)
         })
         .buffer_unordered(CONCURRENT_LIMIT)
         .try_fold(Vec::new(), |mut article_metas, rendered| {
@@ -106,7 +107,7 @@ pub async fn publish_with_bookmark_enricher(
     let rendered_pages = stream::iter(pages)
         .map(|parsed_file| {
             let enrich = Arc::clone(&enrich);
-            render_page(parsed_file, &file_mapping, enrich)
+            render_page(parsed_file, &link_index, enrich)
         })
         .buffer_unordered(CONCURRENT_LIMIT)
         .try_collect::<Vec<_>>()
@@ -114,7 +115,7 @@ pub async fn publish_with_bookmark_enricher(
 
     let rendered_home = match home {
         Some(parsed_file) => {
-            Some(render_home(parsed_file, &file_mapping, Arc::clone(&enrich)).await?)
+            Some(render_home(parsed_file, &link_index, Arc::clone(&enrich)).await?)
         }
         None => None,
     };
@@ -122,7 +123,7 @@ pub async fn publish_with_bookmark_enricher(
     let rendered_categories = stream::iter(categories)
         .map(|parsed_file| {
             let enrich = Arc::clone(&enrich);
-            render_category(parsed_file, &file_mapping, enrich)
+            render_category(parsed_file, &link_index, enrich)
         })
         .buffer_unordered(CONCURRENT_LIMIT)
         .try_collect::<Vec<_>>()

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -1,0 +1,134 @@
+use regex::Regex;
+use std::{collections::HashMap, sync::LazyLock};
+
+/// Published article hrefs indexed by extensionless source paths.
+#[derive(Default)]
+pub(crate) struct Index {
+    routes: HashMap<String, String>,
+}
+
+impl Index {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            routes: HashMap::with_capacity(capacity),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, source_path: String, href: String) {
+        self.routes.insert(source_path, href);
+    }
+
+    pub(crate) fn resolve(&self, target: &str) -> Option<&str> {
+        self.routes.get(target).map(String::as_str).or_else(|| {
+            let suffix = format!("/{target}");
+            self.routes.iter().find_map(|(source_path, href)| {
+                source_path.ends_with(&suffix).then_some(href.as_str())
+            })
+        })
+    }
+}
+
+/// Convert Obsidian internal links to published Markdown links.
+pub(crate) fn convert(content: &str, index: &Index) -> String {
+    static OBSIDIAN_LINK_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\[\[([^\]]+)\]\]").expect("Invalid regex pattern"));
+
+    OBSIDIAN_LINK_REGEX
+        .replace_all(content, |captures: &regex::Captures| {
+            let link_content = &captures[1];
+
+            let (link_target, display_text) = if let Some(pipe_position) = link_content.find('|') {
+                let (link, display) = link_content.split_at(pipe_position);
+                (link.trim(), display[1..].trim())
+            } else {
+                (link_content.trim(), link_content.trim())
+            };
+
+            let href = index
+                .resolve(link_target)
+                .map(str::to_owned)
+                .unwrap_or_else(|| {
+                    log::warn!("Internal link target '{link_target}' was not found");
+                    format!("/{link_target}")
+                });
+
+            format!(
+                "[{}]({})",
+                escape_markdown_link_text(display_text),
+                escape_markdown_link_destination(&href)
+            )
+        })
+        .to_string()
+}
+
+fn escape_markdown_link_text(text: &str) -> String {
+    text.replace('\\', "\\\\")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
+}
+
+fn escape_markdown_link_destination(destination: &str) -> String {
+    destination.replace(')', "\\)")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_resolves_exact_and_path_suffix_targets() {
+        let mut index = Index::default();
+        index.insert(
+            "notes/another-note".to_string(),
+            "/tech/abc123def".to_string(),
+        );
+        index.insert("filename".to_string(), "/daily/xyz789abc".to_string());
+
+        assert_eq!(index.resolve("notes/another-note"), Some("/tech/abc123def"));
+        assert_eq!(index.resolve("another-note"), Some("/tech/abc123def"));
+        assert_eq!(index.resolve("filename"), Some("/daily/xyz789abc"));
+        assert_eq!(index.resolve("missing"), None);
+    }
+
+    #[test]
+    fn convert_internal_links() {
+        let mut index = Index::default();
+        index.insert(
+            "notes/another-note".to_string(),
+            "/tech/abc123def".to_string(),
+        );
+        index.insert("filename".to_string(), "/daily/xyz789abc".to_string());
+
+        assert_eq!(
+            convert("Check out [[another-note]] for more info.", &index),
+            "Check out [another-note](/tech/abc123def) for more info."
+        );
+        assert_eq!(
+            convert("See [[filename|Custom Display Text]] here.", &index),
+            "See [Custom Display Text](/daily/xyz789abc) here."
+        );
+        assert_eq!(
+            convert("Link to [[nonexistent]] file.", &index),
+            "Link to [nonexistent](/nonexistent) file."
+        );
+        assert_eq!(
+            convert("This is normal text with no special links.", &index),
+            "This is normal text with no special links."
+        );
+    }
+
+    #[test]
+    fn convert_escapes_markdown_link_parts() {
+        let mut index = Index::default();
+        index.insert("File with <script>".to_string(), "/tech/abc123".to_string());
+
+        assert_eq!(
+            convert("[[File with <script>|Display & test]]", &index),
+            "[Display & test](/tech/abc123)"
+        );
+        assert_eq!(
+            convert("[[File \"quoted\"|Text with 'quotes']]", &index),
+            "[Text with 'quotes'](/File \"quoted\")"
+        );
+    }
+}

--- a/crates/publish/src/render.rs
+++ b/crates/publish/src/render.rs
@@ -2,7 +2,8 @@ use crate::BookmarkEnricher;
 use crate::artifacts::CategoryLandingMetadata;
 use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile};
 use crate::error::Result;
-use crate::ingest::{FileMapping, convert_markdown_to_html, convert_obsidian_links};
+use crate::ingest::convert_markdown_to_html;
+use crate::links;
 use domain::{
     ArticleBody, ArticleMeta, ArticleMetaInput, Category, HomeFragmentArtifactDocument,
     PageArtifactDocument, Title,
@@ -25,10 +26,10 @@ pub(crate) struct RenderedCategoryLanding {
 
 async fn render_html(
     markdown_body: &str,
-    file_mapping: &FileMapping,
+    link_index: &links::Index,
     enrich: &BookmarkEnricher,
 ) -> Result<String> {
-    let markdown_with_links = convert_obsidian_links(markdown_body, file_mapping);
+    let markdown_with_links = links::convert(markdown_body, link_index);
     let html_body = convert_markdown_to_html(&markdown_with_links)?;
     let fallback = html_body.clone();
     let html = enrich(html_body).await.unwrap_or_else(|e| {
@@ -40,10 +41,10 @@ async fn render_html(
 
 pub(crate) async fn render_article(
     parsed_file: ParsedArticleFile,
-    file_mapping: &FileMapping,
+    link_index: &links::Index,
     enrich: BookmarkEnricher,
 ) -> Result<RenderedArticle> {
-    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
     let meta = ArticleMeta::new(ArticleMetaInput {
         slug: parsed_file.slug,
         title: Title::new(parsed_file.front_matter.title)?,
@@ -64,10 +65,10 @@ pub(crate) async fn render_article(
 
 pub(crate) async fn render_page(
     parsed_file: ParsedPageFile,
-    file_mapping: &FileMapping,
+    link_index: &links::Index,
     enrich: BookmarkEnricher,
 ) -> Result<RenderedPage> {
-    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
     Ok(RenderedPage {
         document: PageArtifactDocument {
             page: parsed_file.page,
@@ -81,10 +82,10 @@ pub(crate) async fn render_page(
 
 pub(crate) async fn render_home(
     parsed_file: ParsedHomeFile,
-    file_mapping: &FileMapping,
+    link_index: &links::Index,
     enrich: BookmarkEnricher,
 ) -> Result<HomeFragmentArtifactDocument> {
-    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
     Ok(HomeFragmentArtifactDocument {
         title: parsed_file.front_matter.title,
         description: parsed_file.front_matter.summary,
@@ -95,10 +96,10 @@ pub(crate) async fn render_home(
 
 pub(crate) async fn render_category(
     parsed_file: ParsedCategoryFile,
-    file_mapping: &FileMapping,
+    link_index: &links::Index,
     enrich: BookmarkEnricher,
 ) -> Result<RenderedCategoryLanding> {
-    let html = render_html(&parsed_file.markdown_body, file_mapping, &enrich).await?;
+    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
     let title = normalize_category_title(parsed_file.category, &parsed_file.front_matter.title);
     let description = normalize_category_description(parsed_file.front_matter.summary.as_deref());
     let html = if html.trim().is_empty() {

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -63,7 +63,8 @@ okawak_blog/
   - 単一のpublisher crate
   - crate外向けAPIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に限定する
   - path処理の対応環境はmacOSとLinuxとし、Windows形式のpathは対象外とする
-  - ingest moduleによるObsidian vault走査、frontmatter parse、Markdown変換、Obsidian link解決
+  - ingest moduleによるObsidian vault走査、frontmatter parse、Markdown変換
+  - links moduleによる内部リンク索引とObsidian link解決
   - bookmark moduleによる外部HTTPを伴うbookmark enrichment
   - content kindごとの公開物生成と`section_path`の導出
   - artifacts moduleによる`site/`配下のHTML / JSON書き出しとcategory fallback page生成


### PR DESCRIPTION
## Summary

- add a root-level `links` module with `links::Index`
- move internal-link lookup and `[[...]]` conversion out of `ingest::converter`
- keep link-index construction in `classify` as `build_link_index`
- rename the classified article key from `mapping_key` to `source_path`
- update publisher and architecture documentation for the new module boundary

## Why

`FileMapping` was defined in the Markdown converter even though it was constructed from classified articles and represented a shared boundary between classification and rendering. This mixed internal-link indexing and resolution with Markdown-to-HTML conversion.

The new `links::Index` encapsulates the source-path-to-published-href lookup and its exact/suffix resolution rules. `classify` constructs the index, while the converter remains focused on Markdown processing.

## Impact

- no artifact or runtime contract changes
- internal-link output and missing-target fallback behavior remain unchanged
- publisher-internal APIs and module ownership are clearer

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `git diff --check`