### PR TITLE
refactor: move link index construction into links

### DIFF
--- a/crates/publish/README.md
+++ b/crates/publish/README.md
@@ -134,7 +134,7 @@ src/
 `lib.rs`はorchestrationとcrate外向けAPIを担います。公開するのは`publish`、
 `publish_with_bookmark_enricher`、`BookmarkEnricher`、`PublishError`、`Result`です。
 それ以外のmoduleはpublisher内部に閉じ、`error.rs`にpublisher全体のerrorを集約します。
-分類済み入力型は`classify.rs`、内部リンクの索引と解決規則は`links.rs`、
+分類済み入力型は`classify.rs`、内部リンク索引の構築と解決規則は`links.rs`、
 render済み出力型は`render.rs`が所有します。
 共有するartifactとsiteの契約だけを`crates/domain`に置きます。
 

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -1,6 +1,5 @@
 use crate::error::{PublishError, Result};
 use crate::ingest::{ContentKind, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file};
-use crate::links;
 use domain::{Category, PageKey, Slug};
 use log::{error, warn};
 use std::collections::HashSet;
@@ -147,17 +146,6 @@ fn process_article_file(
     })
 }
 
-pub(crate) fn build_link_index(article_files: &[ParsedArticleFile]) -> links::Index {
-    let mut index = links::Index::with_capacity(article_files.len());
-    for parsed_file in article_files {
-        index.insert(
-            parsed_file.source_path.clone(),
-            format!("/{}/{}", parsed_file.category.as_str(), parsed_file.slug),
-        );
-    }
-    index
-}
-
 fn derive_section_path(category_relative_path: &Path) -> Vec<String> {
     category_relative_path
         .parent()
@@ -217,124 +205,6 @@ fn parse_page_key(page: Option<&str>) -> Result<PageKey> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rstest::*;
-
-    #[rstest]
-    fn test_build_link_index_success() {
-        let front_matter = ObsidianFrontMatter {
-            title: "Test Article".to_string(),
-            kind: ContentKind::Article,
-            tags: Some(vec!["test".to_string()]),
-            summary: Some("Test summary".to_string()),
-            priority: Some(1),
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-02T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("tech".to_string()),
-            page: None,
-        };
-
-        let parsed_file = ParsedArticleFile {
-            category: Category::Tech,
-            slug: Slug::new("slug".to_string()).unwrap(),
-            source_path: "test".to_string(),
-            section_path: vec![],
-            markdown_body: "# Test Content".to_string(),
-            front_matter,
-        };
-        let article_files = vec![parsed_file];
-        let index = build_link_index(&article_files);
-
-        assert_eq!(index.resolve("test"), Some("/tech/slug"));
-    }
-
-    #[rstest]
-    fn test_build_link_index_empty() {
-        let article_files: Vec<ParsedArticleFile> = vec![];
-        let index = build_link_index(&article_files);
-
-        assert_eq!(index.resolve("test"), None);
-    }
-
-    #[rstest]
-    fn test_build_link_index_path_collision() {
-        let front_matter1 = ObsidianFrontMatter {
-            title: "Test Article 1".to_string(),
-            kind: ContentKind::Article,
-            tags: Some(vec!["test1".to_string()]),
-            summary: Some("Test summary 1".to_string()),
-            priority: Some(1),
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-02T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("tech".to_string()),
-            page: None,
-        };
-
-        let front_matter2 = ObsidianFrontMatter {
-            title: "Test Article 2".to_string(),
-            kind: ContentKind::Article,
-            tags: Some(vec!["test2".to_string()]),
-            summary: Some("Test summary 2".to_string()),
-            priority: Some(2),
-            created: "2025-01-03T00:00:00+09:00".to_string(),
-            updated: "2025-01-04T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("daily".to_string()),
-            page: None,
-        };
-
-        let parsed_file1 = ParsedArticleFile {
-            category: Category::Tech,
-            slug: Slug::new("slug1".to_string()).unwrap(),
-            source_path: "dir1/test".to_string(),
-            section_path: vec!["dir1".to_string()],
-            markdown_body: "# Test Content 1".to_string(),
-            front_matter: front_matter1,
-        };
-        let parsed_file2 = ParsedArticleFile {
-            category: Category::Daily,
-            slug: Slug::new("slug2".to_string()).unwrap(),
-            source_path: "dir2/test".to_string(),
-            section_path: vec!["dir2".to_string()],
-            markdown_body: "# Test Content 2".to_string(),
-            front_matter: front_matter2,
-        };
-        let article_files = vec![parsed_file1, parsed_file2];
-        let index = build_link_index(&article_files);
-
-        assert_eq!(index.resolve("dir1/test"), Some("/tech/slug1"));
-        assert_eq!(index.resolve("dir2/test"), Some("/daily/slug2"));
-    }
-
-    #[rstest]
-    fn test_build_link_index_url_normalization() {
-        let front_matter = ObsidianFrontMatter {
-            title: "URL Test".to_string(),
-            kind: ContentKind::Article,
-            tags: None,
-            summary: None,
-            priority: None,
-            created: "2025-01-01T00:00:00+09:00".to_string(),
-            updated: "2025-01-01T00:00:00+09:00".to_string(),
-            is_completed: true,
-            category: Some("tech".to_string()),
-            page: None,
-        };
-
-        let parsed_file = ParsedArticleFile {
-            category: Category::Tech,
-            slug: Slug::new("slug".to_string()).unwrap(),
-            source_path: "sub/dir/test".to_string(),
-            section_path: vec!["sub".to_string(), "dir".to_string()],
-            markdown_body: "# URL Test Content".to_string(),
-            front_matter,
-        };
-        let article_files = vec![parsed_file];
-        let index = build_link_index(&article_files);
-
-        assert_eq!(index.resolve("sub/dir/test"), Some("/tech/slug"));
-    }
 
     #[test]
     fn test_ensure_unique_category_landings_rejects_duplicates() {

--- a/crates/publish/src/ingest/converter.rs
+++ b/crates/publish/src/ingest/converter.rs
@@ -487,7 +487,6 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::links;
     use indoc::indoc;
     use rstest::*;
 
@@ -539,31 +538,6 @@ mod tests {
     ) {
         let result = generate_html_file(frontmatter, html_body);
         assert_eq!(result, expected);
-    }
-
-    #[rstest]
-    fn test_combined_conversion() {
-        let markdown_with_obsidian_links = r#"# My Article
-
-This is a test with [[Another Article|link]] and **bold** text.
-
-## Section Two
-
-- Item with [[Reference Note]]
-- Regular item"#;
-
-        let mut link_index = links::Index::default();
-        link_index.insert("Another Article".to_string(), "/tech/def456".to_string());
-        link_index.insert("Reference Note".to_string(), "/daily/ghi789".to_string());
-
-        let with_html_links = links::convert(markdown_with_obsidian_links, &link_index);
-        let html = convert_markdown_to_html(&with_html_links).unwrap();
-
-        assert!(html.contains("<h1>My Article</h1>"));
-        assert!(html.contains("<a href=\"/tech/def456\">link</a>"));
-        assert!(html.contains("<a href=\"/daily/ghi789\">Reference Note</a>"));
-        assert!(html.contains("<strong>bold</strong>"));
-        assert!(html.contains("<ul>"));
     }
 
     #[rstest]

--- a/crates/publish/src/lib.rs
+++ b/crates/publish/src/lib.rs
@@ -14,8 +14,7 @@ use crate::artifacts::{
     write_category_page, write_home_fragment, write_page_document, write_site_artifacts,
 };
 use crate::classify::{
-    build_link_index, classify_obsidian_files, ensure_unique_category_landings,
-    ensure_unique_page_keys,
+    classify_obsidian_files, ensure_unique_category_landings, ensure_unique_page_keys,
 };
 use crate::ingest::scan_obsidian_files;
 use crate::render::{render_article, render_category, render_home, render_page};
@@ -73,7 +72,7 @@ pub async fn publish_with_bookmark_enricher(
     ensure_unique_page_keys(&pages)?;
     ensure_unique_category_landings(&categories)?;
 
-    let link_index = build_link_index(&articles);
+    let link_index = links::Index::from_articles(&articles);
     let site_directories = SiteDirectories::prepare(output_dir)?;
 
     const CONCURRENT_LIMIT: usize = 4;

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -1,24 +1,27 @@
+use crate::classify::ParsedArticleFile;
 use regex::Regex;
 use std::{collections::HashMap, sync::LazyLock};
 
 /// Published article hrefs indexed by extensionless source paths.
-#[derive(Default)]
 pub(crate) struct Index {
     routes: HashMap<String, String>,
 }
 
 impl Index {
-    pub(crate) fn with_capacity(capacity: usize) -> Self {
-        Self {
-            routes: HashMap::with_capacity(capacity),
-        }
+    pub(crate) fn from_articles(articles: &[ParsedArticleFile]) -> Self {
+        let routes = articles
+            .iter()
+            .map(|article| {
+                (
+                    article.source_path.clone(),
+                    format!("/{}/{}", article.category.as_str(), article.slug),
+                )
+            })
+            .collect();
+        Self { routes }
     }
 
-    pub(crate) fn insert(&mut self, source_path: String, href: String) {
-        self.routes.insert(source_path, href);
-    }
-
-    pub(crate) fn resolve(&self, target: &str) -> Option<&str> {
+    fn resolve(&self, target: &str) -> Option<&str> {
         self.routes.get(target).map(String::as_str).or_else(|| {
             let suffix = format!("/{target}");
             self.routes.iter().find_map(|(source_path, href)| {
@@ -74,15 +77,75 @@ fn escape_markdown_link_destination(destination: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ingest::{ContentKind, ObsidianFrontMatter, convert_markdown_to_html};
+    use domain::{Category, Slug};
+
+    fn index(routes: &[(&str, &str)]) -> Index {
+        Index {
+            routes: routes
+                .iter()
+                .map(|(source_path, href)| ((*source_path).to_string(), (*href).to_string()))
+                .collect(),
+        }
+    }
+
+    fn article(source_path: &str, category: Category, slug: &str) -> ParsedArticleFile {
+        ParsedArticleFile {
+            category,
+            slug: Slug::new(slug.to_string()).unwrap(),
+            source_path: source_path.to_string(),
+            section_path: vec![],
+            markdown_body: "# Article".to_string(),
+            front_matter: ObsidianFrontMatter {
+                title: "Article".to_string(),
+                kind: ContentKind::Article,
+                tags: None,
+                summary: None,
+                priority: None,
+                created: "2025-01-01T00:00:00+09:00".to_string(),
+                updated: "2025-01-01T00:00:00+09:00".to_string(),
+                is_completed: true,
+                category: Some(category.as_str().to_string()),
+                page: None,
+            },
+        }
+    }
+
+    #[test]
+    fn index_is_built_from_articles() {
+        let articles = vec![article("sub/dir/test", Category::Tech, "slug")];
+
+        let index = Index::from_articles(&articles);
+
+        assert_eq!(index.resolve("sub/dir/test"), Some("/tech/slug"));
+    }
+
+    #[test]
+    fn index_is_empty_when_there_are_no_articles() {
+        let index = Index::from_articles(&[]);
+
+        assert_eq!(index.resolve("test"), None);
+    }
+
+    #[test]
+    fn index_preserves_distinct_source_paths() {
+        let articles = vec![
+            article("dir1/test", Category::Tech, "slug1"),
+            article("dir2/test", Category::Daily, "slug2"),
+        ];
+
+        let index = Index::from_articles(&articles);
+
+        assert_eq!(index.resolve("dir1/test"), Some("/tech/slug1"));
+        assert_eq!(index.resolve("dir2/test"), Some("/daily/slug2"));
+    }
 
     #[test]
     fn index_resolves_exact_and_path_suffix_targets() {
-        let mut index = Index::default();
-        index.insert(
-            "notes/another-note".to_string(),
-            "/tech/abc123def".to_string(),
-        );
-        index.insert("filename".to_string(), "/daily/xyz789abc".to_string());
+        let index = index(&[
+            ("notes/another-note", "/tech/abc123def"),
+            ("filename", "/daily/xyz789abc"),
+        ]);
 
         assert_eq!(index.resolve("notes/another-note"), Some("/tech/abc123def"));
         assert_eq!(index.resolve("another-note"), Some("/tech/abc123def"));
@@ -92,12 +155,10 @@ mod tests {
 
     #[test]
     fn convert_internal_links() {
-        let mut index = Index::default();
-        index.insert(
-            "notes/another-note".to_string(),
-            "/tech/abc123def".to_string(),
-        );
-        index.insert("filename".to_string(), "/daily/xyz789abc".to_string());
+        let index = index(&[
+            ("notes/another-note", "/tech/abc123def"),
+            ("filename", "/daily/xyz789abc"),
+        ]);
 
         assert_eq!(
             convert("Check out [[another-note]] for more info.", &index),
@@ -119,8 +180,7 @@ mod tests {
 
     #[test]
     fn convert_escapes_markdown_link_parts() {
-        let mut index = Index::default();
-        index.insert("File with <script>".to_string(), "/tech/abc123".to_string());
+        let index = index(&[("File with <script>", "/tech/abc123")]);
 
         assert_eq!(
             convert("[[File with <script>|Display & test]]", &index),
@@ -130,5 +190,30 @@ mod tests {
             convert("[[File \"quoted\"|Text with 'quotes']]", &index),
             "[Text with 'quotes'](/File \"quoted\")"
         );
+    }
+
+    #[test]
+    fn converted_links_are_rendered_as_html() {
+        let markdown = r#"# My Article
+
+This is a test with [[Another Article|link]] and **bold** text.
+
+## Section Two
+
+- Item with [[Reference Note]]
+- Regular item"#;
+        let index = index(&[
+            ("Another Article", "/tech/def456"),
+            ("Reference Note", "/daily/ghi789"),
+        ]);
+
+        let markdown = convert(markdown, &index);
+        let html = convert_markdown_to_html(&markdown).unwrap();
+
+        assert!(html.contains("<h1>My Article</h1>"));
+        assert!(html.contains("<a href=\"/tech/def456\">link</a>"));
+        assert!(html.contains("<a href=\"/daily/ghi789\">Reference Note</a>"));
+        assert!(html.contains("<strong>bold</strong>"));
+        assert!(html.contains("<ul>"));
     }
 }

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -64,7 +64,7 @@ okawak_blog/
   - crate外向けAPIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に限定する
   - path処理の対応環境はmacOSとLinuxとし、Windows形式のpathは対象外とする
   - ingest moduleによるObsidian vault走査、frontmatter parse、Markdown変換
-  - links moduleによる内部リンク索引とObsidian link解決
+  - links moduleによる内部リンク索引の構築とObsidian link解決
   - bookmark moduleによる外部HTTPを伴うbookmark enrichment
   - content kindごとの公開物生成と`section_path`の導出
   - artifacts moduleによる`site/`配下のHTML / JSON書き出しとcategory fallback page生成


### PR DESCRIPTION
## Summary

- move link-index construction from `classify.rs` to `links::Index::from_articles`
- move index-construction tests into `links.rs`
- keep `Index` lookup and mutation details private to the `links` module
- move the combined internal-link/Markdown conversion test to the module that owns link conversion
- update publisher and architecture documentation to reflect the responsibility boundary

## Why

`classify.rs` should classify source files into parsed content. Building the internal-link index is a derived step after classification and belongs with the index type and its resolution behavior.

This keeps `classify` independent of `links` and makes `links` the single owner of index construction and resolution.

## Impact

- no artifact or runtime contract changes
- no internal-link behavior changes
- `lib.rs` now orchestrates index construction through `links::Index::from_articles`

## Follow-up

A separate PR will introduce a domain `SectionPath` type while preserving the existing JSON array representation, and rename the publisher-only `source_path` field to `source_key`.

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `git diff --check`