### PR TITLE
refactor: introduce SectionPath value object

### DIFF
--- a/crates/domain/src/artifact_document.rs
+++ b/crates/domain/src/artifact_document.rs
@@ -1,6 +1,6 @@
 //! Shared artifact contract persisted by publisher and read by site/server.
 
-use crate::{CategoryIndex, PageKey, PublishedArticleSummary, SiteMetadata};
+use crate::{CategoryIndex, PageKey, PublishedArticleSummary, SectionPath, SiteMetadata};
 use serde::{Deserialize, Serialize};
 use std::time::SystemTime;
 
@@ -75,7 +75,7 @@ pub struct ArticleSummaryDocument {
     pub title: String,
     pub category: String,
     #[serde(default)]
-    pub section_path: Vec<String>,
+    pub section_path: SectionPath,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub tags: Vec<String>,
@@ -262,7 +262,7 @@ mod tests {
             slug: Slug::new("abc123def456".to_string()).unwrap(),
             title: Title::new("Test Output".to_string()).unwrap(),
             category: Category::Tech,
-            section_path: vec!["block".to_string()],
+            section_path: SectionPath::new(vec!["block".to_string()]),
             description: Some("Test description".to_string()),
             tags: vec!["test".to_string()],
             priority: Some(1),
@@ -284,7 +284,7 @@ mod tests {
             slug: Slug::new("emptytags001".to_string()).unwrap(),
             title: Title::new("Empty Tags".to_string()).unwrap(),
             category: Category::Daily,
-            section_path: vec![],
+            section_path: SectionPath::default(),
             description: None,
             tags: vec![],
             priority: None,
@@ -312,7 +312,7 @@ mod tests {
 
         let document: ArticleSummaryDocument = serde_json::from_str(json).unwrap();
 
-        assert_eq!(document.section_path, Vec::<String>::new());
+        assert_eq!(document.section_path, SectionPath::default());
     }
 
     #[test]

--- a/crates/domain/src/entities.rs
+++ b/crates/domain/src/entities.rs
@@ -6,7 +6,7 @@ mod attributes;
 mod identifiers;
 
 use crate::error::DomainError;
-pub use attributes::{Category, Title};
+pub use attributes::{Category, SectionPath, Title};
 pub use identifiers::{PageKey, Slug};
 use serde::{Deserialize, Deserializer, de::Error as DeError};
 use std::str::FromStr;

--- a/crates/domain/src/entities/attributes.rs
+++ b/crates/domain/src/entities/attributes.rs
@@ -4,6 +4,25 @@ use crate::error::{DomainError, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{fmt, str::FromStr};
 
+/// Ordered category-relative directory segments used for article grouping.
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SectionPath(Vec<String>);
+
+impl SectionPath {
+    pub fn new(segments: Vec<String>) -> Self {
+        Self(segments)
+    }
+
+    pub fn segments(&self) -> &[String] {
+        &self.0
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 /// Article title with business-rule validation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Title(String);
@@ -117,7 +136,27 @@ impl<'de> Deserialize<'de> for Category {
 
 #[cfg(test)]
 mod tests {
-    use super::{Category, Title};
+    use super::{Category, SectionPath, Title};
+
+    #[test]
+    fn test_section_path_exposes_ordered_segments() {
+        let path = SectionPath::new(vec!["rust".to_string(), "async".to_string()]);
+
+        assert_eq!(path.segments(), ["rust", "async"]);
+        assert!(!path.is_empty());
+        assert!(SectionPath::default().is_empty());
+    }
+
+    #[test]
+    fn test_section_path_serialization_remains_an_array() {
+        let path = SectionPath::new(vec!["rust".to_string(), "async".to_string()]);
+
+        let json = serde_json::to_string(&path).unwrap();
+        let deserialized: SectionPath = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(json, r#"["rust","async"]"#);
+        assert_eq!(deserialized, path);
+    }
 
     #[test]
     fn test_title_deserializes_with_trimmed_value() {

--- a/crates/domain/src/publishable.rs
+++ b/crates/domain/src/publishable.rs
@@ -1,6 +1,6 @@
 //! Domain models and pure functions for publishable site artifacts.
 
-use crate::{Category, DomainError, Result, Slug, Title};
+use crate::{Category, DomainError, Result, SectionPath, Slug, Title};
 use std::cmp::Ordering;
 
 /// Metadata for a publishable article.
@@ -9,7 +9,7 @@ pub struct ArticleMeta {
     pub slug: Slug,
     pub title: Title,
     pub category: Category,
-    pub section_path: Vec<String>,
+    pub section_path: SectionPath,
     pub description: Option<String>,
     pub tags: Vec<String>,
     pub priority: Option<i32>,
@@ -22,7 +22,7 @@ pub struct ArticleMetaInput {
     pub slug: Slug,
     pub title: Title,
     pub category: Category,
-    pub section_path: Vec<String>,
+    pub section_path: SectionPath,
     pub description: Option<String>,
     pub tags: Vec<String>,
     pub priority: Option<i32>,
@@ -88,7 +88,7 @@ pub struct PublishedArticleSummary {
     pub slug: Slug,
     pub title: Title,
     pub category: Category,
-    pub section_path: Vec<String>,
+    pub section_path: SectionPath,
     pub description: Option<String>,
     pub tags: Vec<String>,
     pub priority: Option<i32>,
@@ -211,7 +211,7 @@ mod tests {
             slug: Slug::new(slug.to_string()).unwrap(),
             title: Title::new(title.to_string()).unwrap(),
             category,
-            section_path: vec![],
+            section_path: SectionPath::default(),
             description: Some(format!("{title} summary")),
             tags: vec!["tag".to_string()],
             priority,
@@ -235,7 +235,7 @@ mod tests {
             slug: Slug::new("valid00000001".to_string()).unwrap(),
             title: Title::new("Valid".to_string()).unwrap(),
             category: Category::Tech,
-            section_path: vec!["block".to_string()],
+            section_path: SectionPath::new(vec!["block".to_string()]),
             description: Some("summary".to_string()),
             tags: vec!["tag".to_string()],
             priority: Some(1),

--- a/crates/domain/src/site_page.rs
+++ b/crates/domain/src/site_page.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     ArticleIndexDocument, ArticleSummaryDocument, Category, CategoryIndexDocument, DomainError,
-    HomeFragmentArtifactDocument, PageArtifactDocument, PageKey, Result, SiteMetadataDocument,
-    Slug, Title,
+    HomeFragmentArtifactDocument, PageArtifactDocument, PageKey, Result, SectionPath,
+    SiteMetadataDocument, Slug, Title,
 };
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -14,7 +14,7 @@ pub struct SiteArticleCard {
     pub title: Title,
     pub category: Category,
     pub category_display_name: String,
-    pub section_path: Vec<String>,
+    pub section_path: SectionPath,
     pub description: Option<String>,
     pub tags: Vec<String>,
     pub priority: Option<i32>,
@@ -92,7 +92,7 @@ pub struct StaticPageDocument {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CategorySectionGroup {
-    pub section_path: Vec<String>,
+    pub section_path: SectionPath,
     pub heading: String,
     pub articles: Vec<SiteArticleCard>,
 }
@@ -320,7 +320,7 @@ pub fn find_article_summary<'a>(
 fn build_category_section_groups(articles: &[SiteArticleCard]) -> Vec<CategorySectionGroup> {
     use std::collections::BTreeMap;
 
-    let mut grouped: BTreeMap<Vec<String>, Vec<SiteArticleCard>> = BTreeMap::new();
+    let mut grouped: BTreeMap<SectionPath, Vec<SiteArticleCard>> = BTreeMap::new();
     for article in articles {
         grouped
             .entry(article.section_path.clone())
@@ -338,11 +338,11 @@ fn build_category_section_groups(articles: &[SiteArticleCard]) -> Vec<CategorySe
         .collect()
 }
 
-fn build_section_heading(section_path: &[String]) -> String {
+fn build_section_heading(section_path: &SectionPath) -> String {
     if section_path.is_empty() {
         "全般".to_string()
     } else {
-        section_path.join(" / ")
+        section_path.segments().join(" / ")
     }
 }
 
@@ -356,7 +356,7 @@ mod tests {
             slug: "intro00000001".to_string(),
             title: "Intro".to_string(),
             category: "tech".to_string(),
-            section_path: vec!["block".to_string()],
+            section_path: SectionPath::new(vec!["block".to_string()]),
             description: Some("summary".to_string()),
             tags: vec!["rust".to_string()],
             priority: Some(10),
@@ -665,7 +665,7 @@ mod tests {
                         slug: "alpha0000001".to_string(),
                         title: "Alpha".to_string(),
                         category: "tech".to_string(),
-                        section_path: vec!["rust".to_string()],
+                        section_path: SectionPath::new(vec!["rust".to_string()]),
                         description: None,
                         tags: vec![],
                         priority: None,
@@ -676,7 +676,10 @@ mod tests {
                         slug: "beta00000001".to_string(),
                         title: "Beta".to_string(),
                         category: "tech".to_string(),
-                        section_path: vec!["rust".to_string(), "async".to_string()],
+                        section_path: SectionPath::new(vec![
+                            "rust".to_string(),
+                            "async".to_string(),
+                        ]),
                         description: None,
                         tags: vec![],
                         priority: None,
@@ -687,7 +690,7 @@ mod tests {
                         slug: "gamma0000001".to_string(),
                         title: "Gamma".to_string(),
                         category: "tech".to_string(),
-                        section_path: vec![],
+                        section_path: SectionPath::default(),
                         description: None,
                         tags: vec![],
                         priority: None,

--- a/crates/publish/src/artifacts.rs
+++ b/crates/publish/src/artifacts.rs
@@ -387,7 +387,7 @@ fn build_fallback_category_page_html(category_index: &domain::CategoryIndex) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use domain::{ArticleMeta, ArticleMetaInput, Category, PageKey, Title};
+    use domain::{ArticleMeta, ArticleMetaInput, Category, PageKey, SectionPath, Title};
     use tempfile::TempDir;
 
     fn build_article_meta(
@@ -401,7 +401,7 @@ mod tests {
             slug: Slug::new(slug.to_string()).unwrap(),
             title: Title::new(title.to_string()).unwrap(),
             category,
-            section_path: vec![],
+            section_path: SectionPath::default(),
             description: Some(format!("{title} summary")),
             tags: vec!["rust".to_string()],
             priority,

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -1,6 +1,6 @@
 use crate::error::{PublishError, Result};
 use crate::ingest::{ContentKind, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file};
-use domain::{Category, PageKey, Slug};
+use domain::{Category, PageKey, SectionPath, Slug};
 use log::{error, warn};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -8,10 +8,10 @@ use std::path::{Path, PathBuf};
 pub(crate) struct ParsedArticleFile {
     pub(crate) category: Category,
     pub(crate) slug: Slug,
-    /// Extensionless relative path used to resolve Obsidian internal links.
-    pub(crate) source_path: String,
+    /// Extensionless vault-relative key used to resolve Obsidian internal links.
+    pub(crate) source_key: String,
     /// Category-relative directories used to group articles in category navigation.
-    pub(crate) section_path: Vec<String>,
+    pub(crate) section_path: SectionPath,
     pub(crate) markdown_body: String,
     pub(crate) front_matter: ObsidianFrontMatter,
 }
@@ -130,7 +130,7 @@ fn process_article_file(
         relative_path,
         &parsed_file.front_matter.created,
     )?;
-    let source_path = relative_path
+    let source_key = relative_path
         .with_extension("")
         .to_string_lossy()
         .into_owned();
@@ -139,15 +139,15 @@ fn process_article_file(
     Ok(ParsedArticleFile {
         category,
         slug,
-        source_path,
+        source_key,
         section_path,
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })
 }
 
-fn derive_section_path(category_relative_path: &Path) -> Vec<String> {
-    category_relative_path
+fn derive_section_path(category_relative_path: &Path) -> SectionPath {
+    let segments = category_relative_path
         .parent()
         .map(|parent| {
             parent
@@ -155,7 +155,8 @@ fn derive_section_path(category_relative_path: &Path) -> Vec<String> {
                 .map(|component| component.to_string_lossy().into_owned())
                 .collect()
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+    SectionPath::new(segments)
 }
 
 pub(crate) fn ensure_unique_page_keys(pages: &[ParsedPageFile]) -> Result<()> {
@@ -282,14 +283,14 @@ mod tests {
     fn test_derive_section_path_from_category_relative_article() {
         let section_path = derive_section_path(Path::new("block1/hoge.md"));
 
-        assert_eq!(section_path, vec!["block1".to_string()]);
+        assert_eq!(section_path.segments(), ["block1"]);
     }
 
     #[test]
     fn test_derive_section_path_keeps_nested_sections() {
         let section_path = derive_section_path(Path::new("rust/async/hoge.md"));
 
-        assert_eq!(section_path, vec!["rust".to_string(), "async".to_string()]);
+        assert_eq!(section_path.segments(), ["rust", "async"]);
     }
 
     #[test]

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -2,7 +2,7 @@ use crate::classify::ParsedArticleFile;
 use regex::Regex;
 use std::{collections::HashMap, sync::LazyLock};
 
-/// Published article hrefs indexed by extensionless source paths.
+/// Published article hrefs indexed by extensionless source keys.
 pub(crate) struct Index {
     routes: HashMap<String, String>,
 }
@@ -13,7 +13,7 @@ impl Index {
             .iter()
             .map(|article| {
                 (
-                    article.source_path.clone(),
+                    article.source_key.clone(),
                     format!("/{}/{}", article.category.as_str(), article.slug),
                 )
             })
@@ -24,8 +24,8 @@ impl Index {
     fn resolve(&self, target: &str) -> Option<&str> {
         self.routes.get(target).map(String::as_str).or_else(|| {
             let suffix = format!("/{target}");
-            self.routes.iter().find_map(|(source_path, href)| {
-                source_path.ends_with(&suffix).then_some(href.as_str())
+            self.routes.iter().find_map(|(source_key, href)| {
+                source_key.ends_with(&suffix).then_some(href.as_str())
             })
         })
     }
@@ -78,23 +78,23 @@ fn escape_markdown_link_destination(destination: &str) -> String {
 mod tests {
     use super::*;
     use crate::ingest::{ContentKind, ObsidianFrontMatter, convert_markdown_to_html};
-    use domain::{Category, Slug};
+    use domain::{Category, SectionPath, Slug};
 
     fn index(routes: &[(&str, &str)]) -> Index {
         Index {
             routes: routes
                 .iter()
-                .map(|(source_path, href)| ((*source_path).to_string(), (*href).to_string()))
+                .map(|(source_key, href)| ((*source_key).to_string(), (*href).to_string()))
                 .collect(),
         }
     }
 
-    fn article(source_path: &str, category: Category, slug: &str) -> ParsedArticleFile {
+    fn article(source_key: &str, category: Category, slug: &str) -> ParsedArticleFile {
         ParsedArticleFile {
             category,
             slug: Slug::new(slug.to_string()).unwrap(),
-            source_path: source_path.to_string(),
-            section_path: vec![],
+            source_key: source_key.to_string(),
+            section_path: SectionPath::default(),
             markdown_body: "# Article".to_string(),
             front_matter: ObsidianFrontMatter {
                 title: "Article".to_string(),
@@ -128,7 +128,7 @@ mod tests {
     }
 
     #[test]
-    fn index_preserves_distinct_source_paths() {
+    fn index_preserves_distinct_source_keys() {
         let articles = vec![
             article("dir1/test", Category::Tech, "slug1"),
             article("dir2/test", Category::Daily, "slug2"),

--- a/crates/site/infra/src/lib.rs
+++ b/crates/site/infra/src/lib.rs
@@ -415,6 +415,7 @@ mod tests {
     use super::*;
     use domain::{
         ARTIFACT_RELEASE_SCHEMA_VERSION, ArticleSummaryDocument, CategoryMetadataDocument,
+        SectionPath,
     };
     use std::fs;
     use tempfile::TempDir;
@@ -432,7 +433,7 @@ mod tests {
                     slug: "intro00000001".to_string(),
                     title: "Intro".to_string(),
                     category: "tech".to_string(),
-                    section_path: vec!["block".to_string()],
+                    section_path: SectionPath::new(vec!["block".to_string()]),
                     description: Some("intro".to_string()),
                     tags: vec!["rust".to_string()],
                     priority: Some(1),
@@ -454,7 +455,7 @@ mod tests {
                     slug: "intro00000001".to_string(),
                     title: "Intro".to_string(),
                     category: "tech".to_string(),
-                    section_path: vec!["block".to_string()],
+                    section_path: SectionPath::new(vec!["block".to_string()]),
                     description: Some("intro".to_string()),
                     tags: vec!["rust".to_string()],
                     priority: Some(1),

--- a/crates/site/server/src/handlers/api/articles.rs
+++ b/crates/site/server/src/handlers/api/articles.rs
@@ -21,7 +21,7 @@ pub async fn list_articles(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use domain::ArticleSummaryDocument;
+    use domain::{ArticleSummaryDocument, SectionPath};
     use infra::LocalArtifactReader;
     use std::{fs, sync::Arc};
     use tempfile::TempDir;
@@ -37,7 +37,7 @@ mod tests {
                     slug: "sample0000001".to_string(),
                     title: "Sample".to_string(),
                     category: "tech".to_string(),
-                    section_path: vec!["block".to_string()],
+                    section_path: SectionPath::new(vec!["block".to_string()]),
                     description: Some("summary".to_string()),
                     tags: vec!["rust".to_string()],
                     priority: Some(1),

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -56,7 +56,7 @@ okawak_blog/
 
 - `crates/domain`
   - publisher と reader が共有する純粋契約
-  - `Category`、`Slug`、`PageKey`
+  - `Category`、`Slug`、`PageKey`、`SectionPath`
   - artifact contract
   - site page contract
 - `crates/publish`
@@ -226,6 +226,7 @@ Publish/
   - `section_path=["web"]`
 
 `section_path` は category page 上の grouped navigation に使う。Phase 3 では URL には含めない。
+Rust内では順序付きの階層であることを`SectionPath`型で表し、artifact JSONでは従来どおり文字列配列として保存する。
 
 Obsidian 側で実際に書く frontmatter とディレクトリ構造のテンプレートは [docs/content/obsidian-template.md](../content/obsidian-template.md) を参照する。
 


### PR DESCRIPTION
## Summary

- add the domain `SectionPath` value object for ordered category-relative directory segments
- replace raw `Vec<String>` section paths across domain, artifact, publisher, reader, and page contracts
- preserve the existing `section_path` JSON array representation with transparent Serde
- use `SectionPath` as the category-grouping key and centralize segment access
- rename the publisher-only `source_path` field to `source_key`
- update architecture documentation for the shared domain type

## Why

`section_path` represents one ordered hierarchy, but raw `Vec<String>` values were repeated across every layer. A dedicated type makes that domain meaning explicit and distinguishes it from the publisher's internal string key used for link lookup.

The former `source_path` value is not used as a filesystem path after classification; it is an extensionless lookup key. `source_key` describes that responsibility more accurately.

## Impact

- no artifact schema or JSON layout changes
- existing `section_path` arrays remain compatible
- no route or rendering behavior changes
- compile-time distinction between a section hierarchy and unrelated string collections

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `mise run test-e2e`
- `git diff --check`