### PR TITLE
Move home page key validation to domain

### DIFF
--- a/crates/domain/src/entities/identifiers.rs
+++ b/crates/domain/src/entities/identifiers.rs
@@ -73,6 +73,12 @@ impl PageKey {
             });
         }
 
+        if value == "home" {
+            return Err(DomainError::InvalidPath {
+                path: "home is reserved for the home page".to_string(),
+            });
+        }
+
         if !value
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
@@ -103,7 +109,21 @@ impl_display_and_deserialize!(PageKey);
 
 #[cfg(test)]
 mod tests {
-    use super::Slug;
+    use super::{PageKey, Slug};
+
+    #[test]
+    fn test_page_key_rejects_reserved_home_key() {
+        let error = PageKey::new("home".to_string()).unwrap_err();
+
+        assert!(error.to_string().contains("reserved"));
+    }
+
+    #[test]
+    fn test_page_key_rejects_invalid_characters() {
+        for value in ["about/team", "About"] {
+            assert!(PageKey::new(value.to_string()).is_err());
+        }
+    }
 
     #[test]
     fn test_slug_deserializes_with_validation() {

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -194,13 +194,7 @@ fn parse_category(category: Option<&str>) -> Result<Category> {
 fn parse_page_key(page: Option<&str>) -> Result<PageKey> {
     let page =
         page.ok_or_else(|| PublishError::Parse("Completed pages require a page key".to_string()))?;
-    let page = page.trim();
-    if page == "home" {
-        return Err(PublishError::Parse(
-            "Static pages cannot use the reserved home page key".to_string(),
-        ));
-    }
-    PageKey::new(page.to_string()).map_err(|error| PublishError::Parse(error.to_string()))
+    PageKey::new(page.trim().to_string()).map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -295,31 +289,7 @@ mod tests {
 
     #[test]
     fn test_parse_page_key_success() {
-        assert_eq!(parse_page_key(Some("about")).unwrap().as_str(), "about");
-    }
-
-    #[test]
-    fn test_parse_page_key_rejects_nested_path() {
-        assert!(matches!(
-            parse_page_key(Some("about/team")),
-            Err(PublishError::Parse(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_page_key_rejects_reserved_home_key() {
-        assert!(matches!(
-            parse_page_key(Some("home")),
-            Err(PublishError::Parse(_))
-        ));
-    }
-
-    #[test]
-    fn test_parse_page_key_rejects_uppercase() {
-        assert!(matches!(
-            parse_page_key(Some("About")),
-            Err(PublishError::Parse(_))
-        ));
+        assert_eq!(parse_page_key(Some(" about ")).unwrap().as_str(), "about");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

- `home` の予約語検証をpublisherの`parse_page_key`からdomainの`PageKey::new`へ移動
- PageKeyの不変条件に関するテストをdomainへ移動
- `parse_page_key`を必須確認、trim、型変換のみに簡略化

## 理由

`home`を通常の固定ページキーとして許可すると、生成先とhome artifactの読取契約が一致しません。この制約はpublisher固有の入力検証ではなく、`PageKey`自体が保証すべき不変条件であるため、domainへ集約しました。

## 影響

`PageKey::new("home")`は英語のエラーメッセージを伴って失敗します。正常なページキーとartifact契約の挙動は変わりません。

## 確認

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`