### PR TITLE
refactor: streamline publisher artifact processing

### DIFF
--- a/crates/domain/src/publishable.rs
+++ b/crates/domain/src/publishable.rs
@@ -53,15 +53,6 @@ impl ArticleMeta {
     }
 }
 
-/// Metadata for a publishable category landing page.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CategoryLandingMeta {
-    pub category: Category,
-    pub title: String,
-    pub description: Option<String>,
-    pub updated_at: String,
-}
-
 /// Rendered HTML body for a publishable article.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArticleBody {

--- a/crates/domain/src/publishable.rs
+++ b/crates/domain/src/publishable.rs
@@ -53,6 +53,15 @@ impl ArticleMeta {
     }
 }
 
+/// Metadata for a publishable category landing page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryLandingMeta {
+    pub category: Category,
+    pub title: String,
+    pub description: Option<String>,
+    pub updated_at: String,
+}
+
 /// Rendered HTML body for a publishable article.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArticleBody {

--- a/crates/publish/src/artifacts.rs
+++ b/crates/publish/src/artifacts.rs
@@ -2,7 +2,7 @@ mod builder;
 mod validator;
 mod writer;
 
-pub(crate) use builder::build_site_artifacts;
+pub(crate) use builder::{CategoryLandingMeta, build_site_artifacts};
 pub(crate) use validator::validate_site_artifacts;
 pub(crate) use writer::{
     SiteDirectories, write_article_page, write_category_page, write_home_fragment,

--- a/crates/publish/src/artifacts.rs
+++ b/crates/publish/src/artifacts.rs
@@ -2,7 +2,7 @@ mod builder;
 mod validator;
 mod writer;
 
-pub(crate) use builder::{CategoryLandingMetadata, build_site_artifacts};
+pub(crate) use builder::build_site_artifacts;
 pub(crate) use validator::validate_site_artifacts;
 pub(crate) use writer::{
     SiteDirectories, write_article_page, write_category_page, write_home_fragment,

--- a/crates/publish/src/artifacts/builder.rs
+++ b/crates/publish/src/artifacts/builder.rs
@@ -1,5 +1,5 @@
 use domain::{
-    ArticleMeta, CategoryLandingMeta, SiteMetadata, build_article_index, build_category_indexes,
+    ArticleMeta, Category, SiteMetadata, build_article_index, build_category_indexes,
     build_site_metadata,
 };
 
@@ -10,6 +10,14 @@ pub(crate) struct SiteArtifacts {
     pub(super) category_indexes: Vec<domain::CategoryIndex>,
     pub(super) category_landings: Vec<CategoryLandingMeta>,
     pub(super) site_metadata: SiteMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CategoryLandingMeta {
+    pub(crate) category: Category,
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+    pub(crate) updated_at: String,
 }
 
 pub(crate) fn build_site_artifacts(

--- a/crates/publish/src/artifacts/builder.rs
+++ b/crates/publish/src/artifacts/builder.rs
@@ -1,5 +1,5 @@
 use domain::{
-    ArticleMeta, Category, SiteMetadata, build_article_index, build_category_indexes,
+    ArticleMeta, CategoryLandingMeta, SiteMetadata, build_article_index, build_category_indexes,
     build_site_metadata,
 };
 
@@ -8,21 +8,13 @@ use domain::{
 pub(crate) struct SiteArtifacts {
     pub(crate) article_index: Vec<domain::PublishedArticleSummary>,
     pub(super) category_indexes: Vec<domain::CategoryIndex>,
-    pub(super) category_landings: Vec<CategoryLandingMetadata>,
+    pub(super) category_landings: Vec<CategoryLandingMeta>,
     pub(super) site_metadata: SiteMetadata,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CategoryLandingMetadata {
-    pub(crate) category: Category,
-    pub(crate) title: String,
-    pub(crate) description: Option<String>,
-    pub(crate) updated_at: String,
 }
 
 pub(crate) fn build_site_artifacts(
     article_metas: Vec<ArticleMeta>,
-    mut category_landings: Vec<CategoryLandingMetadata>,
+    mut category_landings: Vec<CategoryLandingMeta>,
 ) -> SiteArtifacts {
     let article_index = build_article_index(&article_metas);
     let mut category_indexes = build_category_indexes(&article_metas);

--- a/crates/publish/src/artifacts/writer.rs
+++ b/crates/publish/src/artifacts/writer.rs
@@ -157,10 +157,12 @@ fn build_fallback_category_page_html(category_index: &domain::CategoryIndex) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::super::builder::{CategoryLandingMetadata, build_site_artifacts};
+    use super::super::builder::build_site_artifacts;
     use super::super::validator::validate_site_artifacts;
     use super::*;
-    use domain::{ArticleMeta, ArticleMetaInput, Category, PageKey, SectionPath, Title};
+    use domain::{
+        ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta, PageKey, SectionPath, Title,
+    };
     use tempfile::TempDir;
 
     fn build_article_meta(
@@ -226,7 +228,7 @@ mod tests {
         );
         let site_artifacts = build_site_artifacts(
             vec![article_meta.clone()],
-            vec![CategoryLandingMetadata {
+            vec![CategoryLandingMeta {
                 category: Category::Tech,
                 title: "Tech".to_string(),
                 description: Some("Tech landing".to_string()),
@@ -328,7 +330,7 @@ mod tests {
     fn test_build_site_artifacts_includes_landing_only_category_in_indexes_and_metadata() {
         let artifacts = build_site_artifacts(
             vec![],
-            vec![CategoryLandingMetadata {
+            vec![CategoryLandingMeta {
                 category: Category::Physics,
                 title: "Physics".to_string(),
                 description: None,

--- a/crates/publish/src/artifacts/writer.rs
+++ b/crates/publish/src/artifacts/writer.rs
@@ -157,12 +157,10 @@ fn build_fallback_category_page_html(category_index: &domain::CategoryIndex) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::super::builder::build_site_artifacts;
+    use super::super::builder::{CategoryLandingMeta, build_site_artifacts};
     use super::super::validator::validate_site_artifacts;
     use super::*;
-    use domain::{
-        ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta, PageKey, SectionPath, Title,
-    };
+    use domain::{ArticleMeta, ArticleMetaInput, Category, PageKey, SectionPath, Title};
     use tempfile::TempDir;
 
     fn build_article_meta(

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -14,7 +14,7 @@ use crate::render::{
 };
 use crate::vault::{scan_markdown_files, validate_obsidian_dir};
 use crate::{classify, links};
-use futures::{StreamExt, TryStreamExt, stream};
+use futures::{StreamExt, stream};
 use log::info;
 use std::{
     path::{Path, PathBuf},
@@ -66,7 +66,8 @@ pub async fn publish_with_bookmark_enricher(
 
     const CONCURRENT_LIMIT: usize = 4;
 
-    let article_metas = stream::iter(articles)
+    // Drain each batch before propagating errors so started blocking writes can finish.
+    let article_results = stream::iter(articles)
         .map(|parsed_file| {
             process_article(
                 parsed_file,
@@ -76,10 +77,11 @@ pub async fn publish_with_bookmark_enricher(
             )
         })
         .buffer_unordered(CONCURRENT_LIMIT)
-        .try_collect::<Vec<_>>()
-        .await?;
+        .collect::<Vec<_>>()
+        .await;
+    let article_metas = article_results.into_iter().collect::<Result<Vec<_>>>()?;
 
-    stream::iter(pages)
+    let page_results = stream::iter(pages)
         .map(|parsed_file| {
             process_page(
                 parsed_file,
@@ -89,8 +91,9 @@ pub async fn publish_with_bookmark_enricher(
             )
         })
         .buffer_unordered(CONCURRENT_LIMIT)
-        .try_for_each(|()| async { Ok(()) })
-        .await?;
+        .collect::<Vec<_>>()
+        .await;
+    page_results.into_iter().collect::<Result<Vec<_>>>()?;
 
     if let Some(parsed_file) = home {
         process_home(
@@ -102,7 +105,7 @@ pub async fn publish_with_bookmark_enricher(
         .await?;
     }
 
-    let category_landings = stream::iter(categories)
+    let category_results = stream::iter(categories)
         .map(|parsed_file| {
             process_category(
                 parsed_file,
@@ -112,8 +115,9 @@ pub async fn publish_with_bookmark_enricher(
             )
         })
         .buffer_unordered(CONCURRENT_LIMIT)
-        .try_collect::<Vec<_>>()
-        .await?;
+        .collect::<Vec<_>>()
+        .await;
+    let category_landings = category_results.into_iter().collect::<Result<Vec<_>>>()?;
 
     let site_artifacts = build_site_artifacts(article_metas, category_landings);
     let site_directories_for_write = site_directories.clone();

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -1,6 +1,7 @@
 use crate::artifacts::{
-    SiteDirectories, build_site_artifacts, validate_site_artifacts, write_article_page,
-    write_category_page, write_home_fragment, write_page_document, write_site_artifacts,
+    CategoryLandingMeta, SiteDirectories, build_site_artifacts, validate_site_artifacts,
+    write_article_page, write_category_page, write_home_fragment, write_page_document,
+    write_site_artifacts,
 };
 use crate::classify::{
     ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile, classify_obsidian_files,
@@ -202,15 +203,18 @@ async fn process_category(
     link_index: &links::Index,
     enrich: BookmarkEnricher,
     site_directories: SiteDirectories,
-) -> Result<domain::CategoryLandingMeta> {
+) -> Result<CategoryLandingMeta> {
     let rendered = render_category(parsed_file, link_index, enrich).await?;
     run_artifact_write(move || {
-        let output_file_path = write_category_page(
-            &site_directories,
-            rendered.metadata.category,
-            &rendered.html,
-        )?;
-        Ok((rendered.metadata, output_file_path))
+        let output_file_path =
+            write_category_page(&site_directories, rendered.category, &rendered.html)?;
+        let metadata = CategoryLandingMeta {
+            category: rendered.category,
+            title: rendered.title,
+            description: rendered.description,
+            updated_at: rendered.updated_at,
+        };
+        Ok((metadata, output_file_path))
     })
     .await
 }

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -3,7 +3,8 @@ use crate::artifacts::{
     write_category_page, write_home_fragment, write_page_document, write_site_artifacts,
 };
 use crate::classify::{
-    classify_obsidian_files, ensure_unique_category_landings, ensure_unique_page_keys,
+    ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile, classify_obsidian_files,
+    ensure_unique_category_landings, ensure_unique_page_keys,
 };
 use crate::error::{PublishError, Result};
 use crate::render::{
@@ -14,7 +15,10 @@ use crate::vault::{scan_markdown_files, validate_obsidian_dir};
 use crate::{classify, links};
 use futures::{StreamExt, TryStreamExt, stream};
 use log::info;
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 pub async fn publish(obsidian_dir: &Path, output_dir: &Path) -> Result<()> {
     publish_with_bookmark_enricher(obsidian_dir, output_dir, rich_bookmark_enricher()).await
@@ -63,88 +67,52 @@ pub async fn publish_with_bookmark_enricher(
 
     let article_metas = stream::iter(articles)
         .map(|parsed_file| {
-            let enrich = Arc::clone(&enrich);
-            render_article(parsed_file, &link_index, enrich)
-        })
-        .buffer_unordered(CONCURRENT_LIMIT)
-        .try_fold(Vec::new(), |mut article_metas, rendered| {
-            let site_directories = site_directories.clone();
-            async move {
-                let (rendered, output_file_path) = tokio::task::spawn_blocking(move || {
-                    let output_file_path = write_article_page(
-                        &site_directories,
-                        rendered.meta.category,
-                        &rendered.meta.slug,
-                        &rendered.html,
-                    )?;
-                    Ok::<_, PublishError>((rendered, output_file_path))
-                })
-                .await??;
-                info!("...processed {}", output_file_path.display());
-                article_metas.push(rendered.meta);
-                Ok(article_metas)
-            }
-        })
-        .await?;
-
-    let rendered_pages = stream::iter(pages)
-        .map(|parsed_file| {
-            let enrich = Arc::clone(&enrich);
-            render_page(parsed_file, &link_index, enrich)
+            process_article(
+                parsed_file,
+                &link_index,
+                Arc::clone(&enrich),
+                site_directories.clone(),
+            )
         })
         .buffer_unordered(CONCURRENT_LIMIT)
         .try_collect::<Vec<_>>()
         .await?;
 
-    let rendered_home = match home {
-        Some(parsed_file) => {
-            Some(render_home(parsed_file, &link_index, Arc::clone(&enrich)).await?)
-        }
-        None => None,
-    };
-
-    let rendered_categories = stream::iter(categories)
+    stream::iter(pages)
         .map(|parsed_file| {
-            let enrich = Arc::clone(&enrich);
-            render_category(parsed_file, &link_index, enrich)
+            process_page(
+                parsed_file,
+                &link_index,
+                Arc::clone(&enrich),
+                site_directories.clone(),
+            )
+        })
+        .buffer_unordered(CONCURRENT_LIMIT)
+        .try_for_each(|()| async { Ok(()) })
+        .await?;
+
+    if let Some(parsed_file) = home {
+        process_home(
+            parsed_file,
+            &link_index,
+            Arc::clone(&enrich),
+            site_directories.clone(),
+        )
+        .await?;
+    }
+
+    let category_landings = stream::iter(categories)
+        .map(|parsed_file| {
+            process_category(
+                parsed_file,
+                &link_index,
+                Arc::clone(&enrich),
+                site_directories.clone(),
+            )
         })
         .buffer_unordered(CONCURRENT_LIMIT)
         .try_collect::<Vec<_>>()
         .await?;
-
-    for rendered_page in rendered_pages {
-        let site_directories = site_directories.clone();
-        let output_file_path = tokio::task::spawn_blocking(move || {
-            write_page_document(&site_directories, &rendered_page.document)
-        })
-        .await??;
-        info!("...processed {}", output_file_path.display());
-    }
-
-    if let Some(rendered_home) = rendered_home {
-        let site_directories = site_directories.clone();
-        let output_file_path = tokio::task::spawn_blocking(move || {
-            write_home_fragment(&site_directories, &rendered_home)
-        })
-        .await??;
-        info!("...processed {}", output_file_path.display());
-    }
-
-    let mut category_landings = Vec::with_capacity(rendered_categories.len());
-    for rendered_category in rendered_categories {
-        let site_directories = site_directories.clone();
-        let (metadata, output_file_path) = tokio::task::spawn_blocking(move || {
-            let output_file_path = write_category_page(
-                &site_directories,
-                rendered_category.metadata.category,
-                &rendered_category.html,
-            )?;
-            Ok::<_, PublishError>((rendered_category.metadata, output_file_path))
-        })
-        .await??;
-        info!("...processed {}", output_file_path.display());
-        category_landings.push(metadata);
-    }
 
     let site_artifacts = build_site_artifacts(article_metas, category_landings);
     let site_directories_for_write = site_directories.clone();
@@ -180,4 +148,80 @@ pub async fn publish_with_bookmark_enricher(
 
     info!("=== Publisher Completed ===");
     Ok(())
+}
+
+async fn process_article(
+    parsed_file: ParsedArticleFile,
+    link_index: &links::Index,
+    enrich: BookmarkEnricher,
+    site_directories: SiteDirectories,
+) -> Result<domain::ArticleMeta> {
+    let rendered = render_article(parsed_file, link_index, enrich).await?;
+    run_artifact_write(move || {
+        let output_file_path = write_article_page(
+            &site_directories,
+            rendered.meta.category,
+            &rendered.meta.slug,
+            &rendered.html,
+        )?;
+        Ok((rendered.meta, output_file_path))
+    })
+    .await
+}
+
+async fn process_page(
+    parsed_file: ParsedPageFile,
+    link_index: &links::Index,
+    enrich: BookmarkEnricher,
+    site_directories: SiteDirectories,
+) -> Result<()> {
+    let rendered = render_page(parsed_file, link_index, enrich).await?;
+    run_artifact_write(move || {
+        let output_file_path = write_page_document(&site_directories, &rendered.document)?;
+        Ok(((), output_file_path))
+    })
+    .await
+}
+
+async fn process_home(
+    parsed_file: ParsedHomeFile,
+    link_index: &links::Index,
+    enrich: BookmarkEnricher,
+    site_directories: SiteDirectories,
+) -> Result<()> {
+    let rendered = render_home(parsed_file, link_index, enrich).await?;
+    run_artifact_write(move || {
+        let output_file_path = write_home_fragment(&site_directories, &rendered)?;
+        Ok(((), output_file_path))
+    })
+    .await
+}
+
+async fn process_category(
+    parsed_file: ParsedCategoryFile,
+    link_index: &links::Index,
+    enrich: BookmarkEnricher,
+    site_directories: SiteDirectories,
+) -> Result<domain::CategoryLandingMeta> {
+    let rendered = render_category(parsed_file, link_index, enrich).await?;
+    run_artifact_write(move || {
+        let output_file_path = write_category_page(
+            &site_directories,
+            rendered.metadata.category,
+            &rendered.html,
+        )?;
+        Ok((rendered.metadata, output_file_path))
+    })
+    .await
+}
+
+async fn run_artifact_write<T>(
+    write: impl FnOnce() -> Result<(T, PathBuf)> + Send + 'static,
+) -> Result<T>
+where
+    T: Send + 'static,
+{
+    let (result, output_file_path) = tokio::task::spawn_blocking(write).await??;
+    info!("...processed {}", output_file_path.display());
+    Ok(result)
 }

--- a/crates/publish/src/render/content.rs
+++ b/crates/publish/src/render/content.rs
@@ -1,11 +1,10 @@
 use super::{bookmark::BookmarkEnricher, html::convert_markdown_to_html};
-use crate::artifacts::CategoryLandingMetadata;
 use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile};
 use crate::error::Result;
 use crate::links;
 use domain::{
-    ArticleBody, ArticleMeta, ArticleMetaInput, Category, HomeFragmentArtifactDocument,
-    PageArtifactDocument, Title,
+    ArticleBody, ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta,
+    HomeFragmentArtifactDocument, PageArtifactDocument, Title,
 };
 use log::warn;
 
@@ -19,7 +18,7 @@ pub(crate) struct RenderedPage {
 }
 
 pub(crate) struct RenderedCategoryLanding {
-    pub(crate) metadata: CategoryLandingMetadata,
+    pub(crate) metadata: CategoryLandingMeta,
     pub(crate) html: String,
 }
 
@@ -107,7 +106,7 @@ pub(crate) async fn render_category(
         html
     };
     Ok(RenderedCategoryLanding {
-        metadata: CategoryLandingMetadata {
+        metadata: CategoryLandingMeta {
             category: parsed_file.category,
             title,
             description,

--- a/crates/publish/src/render/content.rs
+++ b/crates/publish/src/render/content.rs
@@ -3,8 +3,8 @@ use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, Par
 use crate::error::Result;
 use crate::links;
 use domain::{
-    ArticleBody, ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta,
-    HomeFragmentArtifactDocument, PageArtifactDocument, Title,
+    ArticleBody, ArticleMeta, ArticleMetaInput, Category, HomeFragmentArtifactDocument,
+    PageArtifactDocument, Title,
 };
 use log::warn;
 
@@ -18,7 +18,10 @@ pub(crate) struct RenderedPage {
 }
 
 pub(crate) struct RenderedCategoryLanding {
-    pub(crate) metadata: CategoryLandingMeta,
+    pub(crate) category: Category,
+    pub(crate) title: String,
+    pub(crate) description: Option<String>,
+    pub(crate) updated_at: String,
     pub(crate) html: String,
 }
 
@@ -106,12 +109,10 @@ pub(crate) async fn render_category(
         html
     };
     Ok(RenderedCategoryLanding {
-        metadata: CategoryLandingMeta {
-            category: parsed_file.category,
-            title,
-            description,
-            updated_at: parsed_file.front_matter.updated,
-        },
+        category: parsed_file.category,
+        title,
+        description,
+        updated_at: parsed_file.front_matter.updated,
         html,
     })
 }


### PR DESCRIPTION
## Summary

- process each article, page, and category from rendering through artifact writing as one bounded concurrent task
- centralize blocking artifact writes and completion logging in `run_artifact_write`
- keep category landing metadata internal to the publisher while separating rendered category data from artifact-builder input

## Why

The publisher pipeline mixed concurrent rendering with sequential artifact writes and used different processing structures for each content type. This change gives articles, pages, and categories the same per-item processing boundary while keeping synchronous filesystem I/O off Tokio worker threads.

Category landing metadata currently remains a publisher-internal intermediate type. Moving the type together with its invariants and pure category-index integration rules into domain is tracked separately in #153.

## Impact

- artifact JSON contracts and output paths are unchanged
- article, page, and category processing is bounded by `CONCURRENT_LIMIT`
- writes to distinct content files may run concurrently
- home remains a single optional task but uses the same render-and-write boundary
- no publisher-only type is added to the shared domain API

## Validation

- `mise run format`
- `mise run check`
- `mise run clippy`
- `mise run test`

## Follow-up

- #153