### PR TITLE
refactor: model category landing contracts in domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 
 依存と配置の境界:
 
-- `crates/domain`: publisher と reader が共有する純粋な型・契約・ルール。I/O、`async`、AWS SDK、Axum、Leptos を持ち込まない。WASM 互換を意識する
+- `crates/domain`: 公開コンテンツの純粋なdomain model・ルールと、publisher / readerが共有する契約。I/O、`async`、AWS SDK、Axum、Leptos を持ち込まない。WASM 互換を意識する
 - `crates/publish`: 単一のpublisher crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`render` moduleをcontent描画・Markdown変換・bookmark enrichmentの境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。publisher専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
 - `crates/site/infra`: server が artifact を読む外部境界（local / S3、設定、将来のcache）。vault読取、Markdown変換、uploadを置かない
 - `crates/site/server`: Axum + Leptos SSR host、reader注入、API、health/readiness、release-aware conditional GET
@@ -37,7 +37,7 @@
 - `service`: systemd、Cloudflare Tunnel、運用補助
 - `terraform`: 読み取り専用。編集せず、このdirectoryでcommandを実行しない
 
-`domain`、`publish`、`site` の責務をまたぐ純粋契約だけを `domain` へ置く。publisher専用処理を reader 側へ移さず、ビルド時に解決できる責務をruntimeへ持ち込まない。
+公開コンテンツの純粋なdomain model・ルールと、`domain`、`publish`、`site` の責務をまたぐ純粋契約を `domain` へ置く。publisher専用のI/Oや変換処理を reader 側へ移さず、ビルド時に解決できる責務をruntimeへ持ち込まない。
 
 ## 非目標
 

--- a/crates/domain/src/artifact_document.rs
+++ b/crates/domain/src/artifact_document.rs
@@ -128,11 +128,12 @@ pub struct CategoryIndexDocument {
 
 impl From<&CategoryIndex> for CategoryIndexDocument {
     fn from(index: &CategoryIndex) -> Self {
+        let landing = index.landing.as_ref();
         Self {
             category: index.category.as_str().to_string(),
-            title: None,
-            description: None,
-            updated_at: None,
+            title: landing.map(|landing| landing.title.as_str().to_string()),
+            description: landing.and_then(|landing| landing.description.clone()),
+            updated_at: landing.map(|landing| landing.updated_at.clone()),
             articles: index
                 .articles
                 .iter()
@@ -192,7 +193,7 @@ impl From<&SiteMetadata> for SiteMetadataDocument {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Category, PageKey, Slug, Title};
+    use crate::{Category, CategoryLandingMeta, CategoryLandingMetaInput, PageKey, Slug, Title};
 
     fn release_pointer(prefix: &str) -> ArtifactReleasePointerDocument {
         ArtifactReleasePointerDocument {
@@ -360,5 +361,30 @@ mod tests {
         assert_eq!(document.title, None);
         assert_eq!(document.description, None);
         assert_eq!(document.updated_at, None);
+    }
+
+    #[test]
+    fn test_category_index_document_uses_landing_metadata() {
+        let landing = CategoryLandingMeta::new(CategoryLandingMetaInput {
+            category: Category::Tech,
+            title: Title::new("Technology".to_string()).unwrap(),
+            description: Some("Technology landing".to_string()),
+            updated_at: "2025-01-02T00:00:00+09:00".to_string(),
+        })
+        .unwrap();
+        let index = CategoryIndex {
+            category: Category::Tech,
+            landing: Some(landing),
+            articles: vec![],
+        };
+
+        let document = CategoryIndexDocument::from(&index);
+
+        assert_eq!(document.title.as_deref(), Some("Technology"));
+        assert_eq!(document.description.as_deref(), Some("Technology landing"));
+        assert_eq!(
+            document.updated_at.as_deref(),
+            Some("2025-01-02T00:00:00+09:00")
+        );
     }
 }

--- a/crates/domain/src/entities/attributes.rs
+++ b/crates/domain/src/entities/attributes.rs
@@ -37,7 +37,7 @@ impl Title {
             });
         }
 
-        if trimmed.len() > 200 {
+        if trimmed.chars().count() > 200 {
             return Err(DomainError::InvalidTitle {
                 reason: "タイトルは200文字以内である必要があります".to_string(),
             });
@@ -162,6 +162,12 @@ mod tests {
     fn test_title_deserializes_with_trimmed_value() {
         let title: Title = serde_json::from_str(r#""  Intro  ""#).unwrap();
         assert_eq!(title.as_str(), "Intro");
+    }
+
+    #[test]
+    fn test_title_validates_unicode_character_count() {
+        assert!(Title::new("あ".repeat(200)).is_ok());
+        assert!(Title::new("あ".repeat(201)).is_err());
     }
 
     #[test]

--- a/crates/domain/src/publishable.rs
+++ b/crates/domain/src/publishable.rs
@@ -96,10 +96,44 @@ pub struct PublishedArticleSummary {
     pub updated_at: String,
 }
 
+/// Metadata for a rendered category landing page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryLandingMeta {
+    pub category: Category,
+    pub title: Title,
+    pub description: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryLandingMetaInput {
+    pub category: Category,
+    pub title: Title,
+    pub description: Option<String>,
+    pub updated_at: String,
+}
+
+impl CategoryLandingMeta {
+    pub fn new(input: CategoryLandingMetaInput) -> Result<Self> {
+        if input.updated_at.trim().is_empty() {
+            return Err(DomainError::validation("updated_at"));
+        }
+
+        Ok(Self {
+            category: input.category,
+            title: input.title,
+            description: input.description,
+            updated_at: input.updated_at,
+        })
+    }
+}
+
 /// Category-specific index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CategoryIndex {
     pub category: Category,
+    /// Landing metadata included in the category index artifact when available.
+    pub landing: Option<CategoryLandingMeta>,
     pub articles: Vec<PublishedArticleSummary>,
 }
 
@@ -147,8 +181,11 @@ pub fn build_article_index(article_metas: &[ArticleMeta]) -> Vec<PublishedArticl
     summaries
 }
 
-/// Build per-category indexes.
-pub fn build_category_indexes(article_metas: &[ArticleMeta]) -> Vec<CategoryIndex> {
+/// Build per-category indexes, including categories represented only by a landing page.
+pub fn build_category_indexes(
+    article_metas: &[ArticleMeta],
+    category_landings: Vec<CategoryLandingMeta>,
+) -> Vec<CategoryIndex> {
     use std::collections::HashMap;
 
     let mut grouped: HashMap<Category, Vec<PublishedArticleSummary>> = HashMap::new();
@@ -159,22 +196,33 @@ pub fn build_category_indexes(article_metas: &[ArticleMeta]) -> Vec<CategoryInde
             .push(build_article_summary_from_meta(article_meta));
     }
 
+    let mut landings_by_category: HashMap<_, _> = category_landings
+        .into_iter()
+        .map(|landing| (landing.category, landing))
+        .collect();
+    for category in landings_by_category.keys() {
+        grouped.entry(*category).or_default();
+    }
+
     let mut indexes: Vec<_> = grouped
         .into_iter()
         .map(|(category, mut articles)| {
             articles.sort_by(compare_summaries);
-            CategoryIndex { category, articles }
+            CategoryIndex {
+                category,
+                landing: landings_by_category.remove(&category),
+                articles,
+            }
         })
         .collect();
     indexes.sort_by(|a, b| a.category.as_str().cmp(b.category.as_str()));
     indexes
 }
 
-/// Build metadata for the generated site.
-pub fn build_site_metadata(article_metas: &[ArticleMeta]) -> SiteMetadata {
-    let category_indexes = build_category_indexes(article_metas);
+/// Build site metadata from completed category indexes.
+pub fn build_site_metadata(category_indexes: &[CategoryIndex]) -> SiteMetadata {
     let categories = category_indexes
-        .into_iter()
+        .iter()
         .map(|index| CategoryMetadata {
             category: index.category,
             article_count: index.articles.len(),
@@ -182,7 +230,10 @@ pub fn build_site_metadata(article_metas: &[ArticleMeta]) -> SiteMetadata {
         .collect();
 
     SiteMetadata {
-        total_articles: article_metas.len(),
+        total_articles: category_indexes
+            .iter()
+            .map(|index| index.articles.len())
+            .sum(),
         categories,
     }
 }
@@ -199,6 +250,16 @@ fn compare_summaries(a: &PublishedArticleSummary, b: &PublishedArticleSummary) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn build_category_landing(category: Category, title: &str) -> CategoryLandingMeta {
+        CategoryLandingMeta::new(CategoryLandingMetaInput {
+            category,
+            title: Title::new(title.to_string()).unwrap(),
+            description: Some(format!("{title} landing")),
+            updated_at: "2025-01-03T00:00:00+09:00".to_string(),
+        })
+        .unwrap()
+    }
 
     fn build_article(
         title: &str,
@@ -259,6 +320,18 @@ mod tests {
     }
 
     #[test]
+    fn test_category_landing_meta_requires_updated_at() {
+        let input = CategoryLandingMetaInput {
+            category: Category::Tech,
+            title: Title::new("Tech".to_string()).unwrap(),
+            description: None,
+            updated_at: "   ".to_string(),
+        };
+
+        assert!(CategoryLandingMeta::new(input).is_err());
+    }
+
+    #[test]
     fn test_build_article_index_orders_by_priority_desc() {
         let articles = vec![
             build_article(
@@ -303,9 +376,42 @@ mod tests {
         ];
 
         let metas: Vec<_> = articles.into_iter().map(|article| article.meta).collect();
-        let indexes = build_category_indexes(&metas);
-        assert_eq!(indexes.len(), 2);
+        let indexes = build_category_indexes(
+            &metas,
+            vec![
+                build_category_landing(Category::Tech, "Technology"),
+                build_category_landing(Category::Physics, "Physics"),
+            ],
+        );
+
+        assert_eq!(indexes.len(), 3);
+        assert_eq!(indexes[0].category, Category::Daily);
         assert_eq!(indexes[0].articles.len(), 1);
-        assert_eq!(indexes[1].articles.len(), 1);
+        assert_eq!(indexes[1].category, Category::Physics);
+        assert_eq!(indexes[1].articles.len(), 0);
+        assert_eq!(
+            indexes[1].landing.as_ref().unwrap().title.as_str(),
+            "Physics"
+        );
+        assert_eq!(indexes[2].category, Category::Tech);
+        assert_eq!(indexes[2].articles.len(), 1);
+        assert_eq!(
+            indexes[2].landing.as_ref().unwrap().title.as_str(),
+            "Technology"
+        );
+    }
+
+    #[test]
+    fn test_build_site_metadata_includes_landing_only_category() {
+        let indexes = build_category_indexes(
+            &[],
+            vec![build_category_landing(Category::Physics, "Physics")],
+        );
+        let metadata = build_site_metadata(&indexes);
+
+        assert_eq!(metadata.total_articles, 0);
+        assert_eq!(metadata.categories.len(), 1);
+        assert_eq!(metadata.categories[0].category, Category::Physics);
+        assert_eq!(metadata.categories[0].article_count, 0);
     }
 }

--- a/crates/publish/src/artifacts.rs
+++ b/crates/publish/src/artifacts.rs
@@ -2,7 +2,7 @@ mod builder;
 mod validator;
 mod writer;
 
-pub(crate) use builder::{CategoryLandingMeta, build_site_artifacts};
+pub(crate) use builder::build_site_artifacts;
 pub(crate) use validator::validate_site_artifacts;
 pub(crate) use writer::{
     SiteDirectories, write_article_page, write_category_page, write_home_fragment,

--- a/crates/publish/src/artifacts/builder.rs
+++ b/crates/publish/src/artifacts/builder.rs
@@ -1,5 +1,5 @@
 use domain::{
-    ArticleMeta, Category, SiteMetadata, build_article_index, build_category_indexes,
+    ArticleMeta, CategoryLandingMeta, SiteMetadata, build_article_index, build_category_indexes,
     build_site_metadata,
 };
 
@@ -8,59 +8,20 @@ use domain::{
 pub(crate) struct SiteArtifacts {
     pub(crate) article_index: Vec<domain::PublishedArticleSummary>,
     pub(super) category_indexes: Vec<domain::CategoryIndex>,
-    pub(super) category_landings: Vec<CategoryLandingMeta>,
     pub(super) site_metadata: SiteMetadata,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CategoryLandingMeta {
-    pub(crate) category: Category,
-    pub(crate) title: String,
-    pub(crate) description: Option<String>,
-    pub(crate) updated_at: String,
 }
 
 pub(crate) fn build_site_artifacts(
     article_metas: Vec<ArticleMeta>,
-    mut category_landings: Vec<CategoryLandingMeta>,
+    category_landings: Vec<CategoryLandingMeta>,
 ) -> SiteArtifacts {
     let article_index = build_article_index(&article_metas);
-    let mut category_indexes = build_category_indexes(&article_metas);
-    let mut site_metadata = build_site_metadata(&article_metas);
-
-    category_landings.sort_by(|a, b| a.category.as_str().cmp(b.category.as_str()));
-    for landing in &category_landings {
-        if category_indexes
-            .iter()
-            .all(|index| index.category != landing.category)
-        {
-            category_indexes.push(domain::CategoryIndex {
-                category: landing.category,
-                articles: vec![],
-            });
-        }
-
-        if site_metadata
-            .categories
-            .iter()
-            .all(|metadata| metadata.category != landing.category)
-        {
-            site_metadata.categories.push(domain::CategoryMetadata {
-                category: landing.category,
-                article_count: 0,
-            });
-        }
-    }
-
-    category_indexes.sort_by(|a, b| a.category.as_str().cmp(b.category.as_str()));
-    site_metadata
-        .categories
-        .sort_by(|a, b| a.category.as_str().cmp(b.category.as_str()));
+    let category_indexes = build_category_indexes(&article_metas, category_landings);
+    let site_metadata = build_site_metadata(&category_indexes);
 
     SiteArtifacts {
         article_index,
         category_indexes,
-        category_landings,
         site_metadata,
     }
 }

--- a/crates/publish/src/artifacts/writer.rs
+++ b/crates/publish/src/artifacts/writer.rs
@@ -7,7 +7,6 @@ use domain::{
 };
 use serde::Serialize;
 use std::{
-    collections::HashMap,
     fs::{self, File},
     io::BufWriter,
     path::{Path, PathBuf},
@@ -95,36 +94,17 @@ pub(crate) fn write_site_artifacts(
         &site_directories.articles_dir.join("index.json"),
         &ArticleIndexDocument::from(site_artifacts.article_index.as_slice()),
     )?;
-    let category_landings_by_category: HashMap<_, _> = site_artifacts
-        .category_landings
-        .iter()
-        .map(|landing| (landing.category, landing))
-        .collect();
-
     for category_index in &site_artifacts.category_indexes {
         let category_dir = site_directories
             .categories_dir
             .join(category_index.category.as_str());
         fs::create_dir_all(&category_dir)?;
-        let landing = category_landings_by_category
-            .get(&category_index.category)
-            .copied();
         write_json_pretty(
             &category_dir.join("index.json"),
-            &CategoryIndexDocument {
-                category: category_index.category.as_str().to_string(),
-                title: landing.map(|landing| landing.title.clone()),
-                description: landing.and_then(|landing| landing.description.clone()),
-                updated_at: landing.map(|landing| landing.updated_at.clone()),
-                articles: category_index
-                    .articles
-                    .iter()
-                    .map(domain::ArticleSummaryDocument::from)
-                    .collect(),
-            },
+            &CategoryIndexDocument::from(category_index),
         )?;
 
-        if landing.is_none() {
+        if category_index.landing.is_none() {
             fs::write(
                 category_dir.join("page.html"),
                 build_fallback_category_page_html(category_index),
@@ -157,10 +137,13 @@ fn build_fallback_category_page_html(category_index: &domain::CategoryIndex) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::super::builder::{CategoryLandingMeta, build_site_artifacts};
+    use super::super::builder::build_site_artifacts;
     use super::super::validator::validate_site_artifacts;
     use super::*;
-    use domain::{ArticleMeta, ArticleMetaInput, Category, PageKey, SectionPath, Title};
+    use domain::{
+        ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta, CategoryLandingMetaInput,
+        PageKey, SectionPath, Title,
+    };
     use tempfile::TempDir;
 
     fn build_article_meta(
@@ -180,6 +163,20 @@ mod tests {
             priority,
             created_at: created_at.to_string(),
             updated_at: created_at.to_string(),
+        })
+        .unwrap()
+    }
+
+    fn build_category_landing(
+        category: Category,
+        title: &str,
+        description: Option<&str>,
+    ) -> CategoryLandingMeta {
+        CategoryLandingMeta::new(CategoryLandingMetaInput {
+            category,
+            title: Title::new(title.to_string()).unwrap(),
+            description: description.map(str::to_string),
+            updated_at: "2025-01-01T00:00:00+09:00".to_string(),
         })
         .unwrap()
     }
@@ -208,7 +205,12 @@ mod tests {
 
         assert_eq!(artifacts.article_index.len(), 2);
         assert_eq!(artifacts.category_indexes.len(), 2);
-        assert!(artifacts.category_landings.is_empty());
+        assert!(
+            artifacts
+                .category_indexes
+                .iter()
+                .all(|index| index.landing.is_none())
+        );
         assert_eq!(artifacts.site_metadata.total_articles, 2);
         assert_eq!(artifacts.article_index[0].slug.as_str(), "second000002");
     }
@@ -226,12 +228,11 @@ mod tests {
         );
         let site_artifacts = build_site_artifacts(
             vec![article_meta.clone()],
-            vec![CategoryLandingMeta {
-                category: Category::Tech,
-                title: "Tech".to_string(),
-                description: Some("Tech landing".to_string()),
-                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
-            }],
+            vec![build_category_landing(
+                Category::Tech,
+                "Tech",
+                Some("Tech landing"),
+            )],
         );
 
         let article_path = write_article_page(
@@ -328,12 +329,7 @@ mod tests {
     fn test_build_site_artifacts_includes_landing_only_category_in_indexes_and_metadata() {
         let artifacts = build_site_artifacts(
             vec![],
-            vec![CategoryLandingMeta {
-                category: Category::Physics,
-                title: "Physics".to_string(),
-                description: None,
-                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
-            }],
+            vec![build_category_landing(Category::Physics, "Physics", None)],
         );
 
         assert_eq!(artifacts.category_indexes.len(), 1);

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -1,7 +1,6 @@
 use crate::artifacts::{
-    CategoryLandingMeta, SiteDirectories, build_site_artifacts, validate_site_artifacts,
-    write_article_page, write_category_page, write_home_fragment, write_page_document,
-    write_site_artifacts,
+    SiteDirectories, build_site_artifacts, validate_site_artifacts, write_article_page,
+    write_category_page, write_home_fragment, write_page_document, write_site_artifacts,
 };
 use crate::classify::{
     ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile, classify_obsidian_files,
@@ -207,18 +206,12 @@ async fn process_category(
     link_index: &links::Index,
     enrich: BookmarkEnricher,
     site_directories: SiteDirectories,
-) -> Result<CategoryLandingMeta> {
+) -> Result<domain::CategoryLandingMeta> {
     let rendered = render_category(parsed_file, link_index, enrich).await?;
     run_artifact_write(move || {
         let output_file_path =
-            write_category_page(&site_directories, rendered.category, &rendered.html)?;
-        let metadata = CategoryLandingMeta {
-            category: rendered.category,
-            title: rendered.title,
-            description: rendered.description,
-            updated_at: rendered.updated_at,
-        };
-        Ok((metadata, output_file_path))
+            write_category_page(&site_directories, rendered.meta.category, &rendered.html)?;
+        Ok((rendered.meta, output_file_path))
     })
     .await
 }

--- a/crates/publish/src/render/content.rs
+++ b/crates/publish/src/render/content.rs
@@ -3,8 +3,8 @@ use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, Par
 use crate::error::Result;
 use crate::links;
 use domain::{
-    ArticleBody, ArticleMeta, ArticleMetaInput, Category, HomeFragmentArtifactDocument,
-    PageArtifactDocument, Title,
+    ArticleBody, ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta,
+    CategoryLandingMetaInput, HomeFragmentArtifactDocument, PageArtifactDocument, Title,
 };
 use log::warn;
 
@@ -18,10 +18,7 @@ pub(crate) struct RenderedPage {
 }
 
 pub(crate) struct RenderedCategoryLanding {
-    pub(crate) category: Category,
-    pub(crate) title: String,
-    pub(crate) description: Option<String>,
-    pub(crate) updated_at: String,
+    pub(crate) meta: CategoryLandingMeta,
     pub(crate) html: String,
 }
 
@@ -108,13 +105,13 @@ pub(crate) async fn render_category(
     } else {
         html
     };
-    Ok(RenderedCategoryLanding {
+    let meta = CategoryLandingMeta::new(CategoryLandingMetaInput {
         category: parsed_file.category,
-        title,
+        title: Title::new(title)?,
         description,
         updated_at: parsed_file.front_matter.updated,
-        html,
-    })
+    })?;
+    Ok(RenderedCategoryLanding { meta, html })
 }
 
 fn normalize_category_title(category: Category, title: &str) -> String {

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -57,8 +57,9 @@ okawak_blog/
 各 crate の責務は次の通り。
 
 - `crates/domain`
-  - publisher と reader が共有する純粋契約
+  - 公開コンテンツの純粋なdomain model・ルールと、publisher / readerが共有する契約
   - `Category`、`Slug`、`PageKey`、`SectionPath`
+  - `ArticleMeta`、`CategoryLandingMeta`と記事・カテゴリ索引を構築する純粋ルール
   - artifact contract
   - site page contract
 - `crates/publish`
@@ -264,7 +265,8 @@ artifact の意味は次の通り。
   - 全記事の一覧
 - `categories/<category>/index.json`
   - そのカテゴリ配下の記事一覧
-  - `section_path` を含む
+  - landingがある場合はtitle / description / updated_atを含む
+  - 各記事に`section_path`を含む
 - `categories/<category>/page.html`
   - カテゴリ landing page 本文
   - landing Markdown が無い場合は fallback HTML を生成する
@@ -278,6 +280,8 @@ artifact の意味は次の通り。
   - 総記事数とカテゴリ集計
 
 `PageArtifactDocument` は固定ページを保持する。homeは完成したpageではなく実行時に記事一覧やmetadataと合成する一部分なので、`HomeFragmentArtifactDocument` として独立させる。
+
+publisherは描画済みカテゴリのmetadataを`CategoryLandingMeta`としてdomainへ渡す。domainはlandingだけが存在するカテゴリも含めて`CategoryIndex`へ統合し、カテゴリ順、記事順、`SiteMetadata`の集計を確定する。Markdown変換、HTML生成、filesystemへの書込みはpublisherに残す。
 
 ### S3 release 契約
 


### PR DESCRIPTION
## Summary

- add validated category landing metadata to the domain model
- move category landing integration, index ordering, and site metadata aggregation into domain rules
- simplify publisher artifact building and convert completed domain indexes directly into artifact documents
- update architecture documentation to describe the refined domain boundary

## Impact

Category landing metadata is now part of the completed domain model instead of a publisher-only parallel list. Artifact paths and JSON schema remain unchanged.

## Validation

- `mise run format`
- `mise run check`
- `mise run test`
- `mise run clippy`
- `mise run test-domain`

Closes #153