### PR TITLE
refactor: reorganize publisher rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 依存と配置の境界:
 
 - `crates/domain`: 公開コンテンツの純粋なdomain model・ルールと、publisher / readerが共有する契約。I/O、`async`、AWS SDK、Axum、Leptos を持ち込まない。WASM 互換を意識する
-- `crates/publish`: 単一のpublisher crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`render` moduleをcontent描画・Markdown変換・bookmark enrichmentの境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。publisher専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
+- `crates/publish`: 単一のpublisher crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`render` moduleをcontent描画の境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。`render`内ではcontent kind別の組み立て、共通本文処理、HTML変換、KaTeX処理、bookmark enrichmentを分離する。publisher専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
 - `crates/site/infra`: server が artifact を読む外部境界（local / S3、設定、将来のcache）。vault読取、Markdown変換、uploadを置かない
 - `crates/site/server`: Axum + Leptos SSR host、reader注入、API、health/readiness、release-aware conditional GET
 - `crates/site/web`: Leptos UI / route / metadata。SSR時もstorage実装へ直接依存しない

--- a/crates/publish/src/render.rs
+++ b/crates/publish/src/render.rs
@@ -1,10 +1,12 @@
+mod body;
 mod bookmark;
-mod content;
+mod document;
 mod html;
+mod katex;
 
 pub use bookmark::BookmarkEnricher;
 pub(crate) use bookmark::rich_bookmark_enricher;
-pub(crate) use content::{render_article, render_category, render_home, render_page};
+pub(crate) use document::{render_article, render_category, render_home, render_page};
 
 #[cfg(test)]
 pub(crate) use html::convert_markdown_to_html;

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -1,0 +1,36 @@
+use super::{bookmark::BookmarkEnricher, html::convert_markdown_to_html};
+use crate::{error::Result, links};
+use log::warn;
+
+pub(super) async fn render(
+    markdown: &str,
+    link_index: &links::Index,
+    enrich: &BookmarkEnricher,
+) -> Result<String> {
+    let markdown = links::convert(markdown, link_index);
+    let html = convert_markdown_to_html(&markdown)?;
+    let fallback = html.clone();
+    Ok(enrich(html).await.unwrap_or_else(|error| {
+        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {error}");
+        fallback
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::PublishError;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_render_falls_back_to_html_when_bookmark_enrichment_fails() {
+        let link_index = links::Index::from_articles(&[]);
+        let enrich: BookmarkEnricher = Arc::new(|_html| {
+            Box::pin(async { Err(PublishError::Parse("enrichment failed".to_string())) })
+        });
+
+        let html = render("# Hello", &link_index, &enrich).await.unwrap();
+
+        assert_eq!(html, "<h1>Hello</h1>\n");
+    }
+}

--- a/crates/publish/src/render/document.rs
+++ b/crates/publish/src/render/document.rs
@@ -1,12 +1,13 @@
-use super::{bookmark::BookmarkEnricher, html::convert_markdown_to_html};
-use crate::classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile};
-use crate::error::Result;
-use crate::links;
+use super::{body, bookmark::BookmarkEnricher};
+use crate::{
+    classify::{ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile},
+    error::Result,
+    links,
+};
 use domain::{
     ArticleBody, ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta,
     CategoryLandingMetaInput, HomeFragmentArtifactDocument, PageArtifactDocument, Title,
 };
-use log::warn;
 
 pub(crate) struct RenderedArticle {
     pub(crate) meta: ArticleMeta,
@@ -22,27 +23,12 @@ pub(crate) struct RenderedCategoryLanding {
     pub(crate) html: String,
 }
 
-async fn render_html(
-    markdown_body: &str,
-    link_index: &links::Index,
-    enrich: &BookmarkEnricher,
-) -> Result<String> {
-    let markdown_with_links = links::convert(markdown_body, link_index);
-    let html_body = convert_markdown_to_html(&markdown_with_links)?;
-    let fallback = html_body.clone();
-    let html = enrich(html_body).await.unwrap_or_else(|e| {
-        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {e}");
-        fallback
-    });
-    Ok(html)
-}
-
 pub(crate) async fn render_article(
     parsed_file: ParsedArticleFile,
     link_index: &links::Index,
     enrich: BookmarkEnricher,
 ) -> Result<RenderedArticle> {
-    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
+    let html = body::render(&parsed_file.markdown_body, link_index, &enrich).await?;
     let meta = ArticleMeta::new(ArticleMetaInput {
         slug: parsed_file.slug,
         title: Title::new(parsed_file.front_matter.title)?,
@@ -61,47 +47,16 @@ pub(crate) async fn render_article(
     })
 }
 
-pub(crate) async fn render_page(
-    parsed_file: ParsedPageFile,
-    link_index: &links::Index,
-    enrich: BookmarkEnricher,
-) -> Result<RenderedPage> {
-    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
-    Ok(RenderedPage {
-        document: PageArtifactDocument {
-            page: parsed_file.page,
-            title: parsed_file.front_matter.title,
-            description: parsed_file.front_matter.summary,
-            html,
-            updated_at: parsed_file.front_matter.updated,
-        },
-    })
-}
-
-pub(crate) async fn render_home(
-    parsed_file: ParsedHomeFile,
-    link_index: &links::Index,
-    enrich: BookmarkEnricher,
-) -> Result<HomeFragmentArtifactDocument> {
-    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
-    Ok(HomeFragmentArtifactDocument {
-        title: parsed_file.front_matter.title,
-        description: parsed_file.front_matter.summary,
-        html,
-        updated_at: parsed_file.front_matter.updated,
-    })
-}
-
 pub(crate) async fn render_category(
     parsed_file: ParsedCategoryFile,
     link_index: &links::Index,
     enrich: BookmarkEnricher,
 ) -> Result<RenderedCategoryLanding> {
-    let html = render_html(&parsed_file.markdown_body, link_index, &enrich).await?;
+    let html = body::render(&parsed_file.markdown_body, link_index, &enrich).await?;
     let title = normalize_category_title(parsed_file.category, &parsed_file.front_matter.title);
     let description = normalize_category_description(parsed_file.front_matter.summary.as_deref());
     let html = if html.trim().is_empty() {
-        build_fallback_category_landing_html(parsed_file.category, &title, description.as_deref())
+        build_fallback_category_html(parsed_file.category, &title, description.as_deref())
     } else {
         html
     };
@@ -112,6 +67,37 @@ pub(crate) async fn render_category(
         updated_at: parsed_file.front_matter.updated,
     })?;
     Ok(RenderedCategoryLanding { meta, html })
+}
+
+pub(crate) async fn render_home(
+    parsed_file: ParsedHomeFile,
+    link_index: &links::Index,
+    enrich: BookmarkEnricher,
+) -> Result<HomeFragmentArtifactDocument> {
+    let html = body::render(&parsed_file.markdown_body, link_index, &enrich).await?;
+    Ok(HomeFragmentArtifactDocument {
+        title: parsed_file.front_matter.title,
+        description: parsed_file.front_matter.summary,
+        html,
+        updated_at: parsed_file.front_matter.updated,
+    })
+}
+
+pub(crate) async fn render_page(
+    parsed_file: ParsedPageFile,
+    link_index: &links::Index,
+    enrich: BookmarkEnricher,
+) -> Result<RenderedPage> {
+    let html = body::render(&parsed_file.markdown_body, link_index, &enrich).await?;
+    Ok(RenderedPage {
+        document: PageArtifactDocument {
+            page: parsed_file.page,
+            title: parsed_file.front_matter.title,
+            description: parsed_file.front_matter.summary,
+            html,
+            updated_at: parsed_file.front_matter.updated,
+        },
+    })
 }
 
 fn normalize_category_title(category: Category, title: &str) -> String {
@@ -130,7 +116,7 @@ fn normalize_category_description(description: Option<&str>) -> Option<String> {
         .map(str::to_owned)
 }
 
-fn build_fallback_category_landing_html(
+fn build_fallback_category_html(
     category: Category,
     title: &str,
     description: Option<&str>,
@@ -142,7 +128,7 @@ fn build_fallback_category_landing_html(
     };
 
     let body = description
-        .filter(|d| !d.trim().is_empty())
+        .filter(|description| !description.trim().is_empty())
         .map(str::trim)
         .map(str::to_owned)
         .unwrap_or_else(|| format!("{}カテゴリの記事一覧です。", category.display_name()));
@@ -164,28 +150,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_fallback_category_landing_html_uses_title_and_summary() {
-        let html = build_fallback_category_landing_html(
-            Category::Tech,
-            "Tech",
-            Some("Technology landing"),
-        );
+    fn test_build_fallback_category_html_uses_title_and_summary() {
+        let html = build_fallback_category_html(Category::Tech, "Tech", Some("Technology landing"));
 
         assert!(html.contains("<h1>Tech</h1>"));
         assert!(html.contains("<p>Technology landing</p>"));
     }
 
     #[test]
-    fn test_build_fallback_category_landing_html_falls_back_to_category_display_name() {
-        let html = build_fallback_category_landing_html(Category::Physics, "   ", None);
+    fn test_build_fallback_category_html_falls_back_to_category_display_name() {
+        let html = build_fallback_category_html(Category::Physics, "   ", None);
 
         assert!(html.contains("<h1>物理学</h1>"));
         assert!(html.contains("物理学カテゴリの記事一覧です。"));
     }
 
     #[test]
-    fn test_build_fallback_category_landing_html_escapes_frontmatter_text() {
-        let html = build_fallback_category_landing_html(
+    fn test_build_fallback_category_html_escapes_frontmatter_text() {
+        let html = build_fallback_category_html(
             Category::Tech,
             "<script>alert(1)</script>",
             Some("\"quoted\" & <tag>"),

--- a/crates/publish/src/render/html.rs
+++ b/crates/publish/src/render/html.rs
@@ -1,11 +1,8 @@
+use super::katex::ProtectedMarkdown;
 use crate::error::Result;
 use pulldown_cmark::{Event, Options, Parser, html};
 use regex::Regex;
-use std::{
-    collections::{HashMap, hash_map::DefaultHasher},
-    hash::{Hash, Hasher},
-    sync::LazyLock,
-};
+use std::sync::LazyLock;
 
 /// Allow-list regex for bookmark blocks; anything beyond `<a href="URL">TITLE</a>` is escaped.
 static SAFE_BOOKMARK_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -17,7 +14,7 @@ static HREF_ATTR_RE: LazyLock<Regex> =
 
 /// Converts Markdown to sanitized HTML.
 pub(crate) fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
-    let (markdown_content, katex_placeholders) = extract_katex_placeholders(markdown_content);
+    let protected_markdown = ProtectedMarkdown::new(markdown_content);
 
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
@@ -26,373 +23,12 @@ pub(crate) fn convert_markdown_to_html(markdown_content: &str) -> Result<String>
     options.insert(Options::ENABLE_TASKLISTS);
     options.insert(Options::ENABLE_SMART_PUNCTUATION);
 
-    let parser = Parser::new_ext(&markdown_content, options);
-    let mut html_output = String::with_capacity(markdown_content.len() * 2);
+    let parser = Parser::new_ext(protected_markdown.as_str(), options);
+    let mut html_output = String::with_capacity(protected_markdown.as_str().len() * 2);
     html::push_html(&mut html_output, sanitize_html(parser).into_iter());
     let html_output = sanitize_anchor_hrefs(&html_output);
-    let html_with_katex = replace_katex_placeholders(&html_output, &katex_placeholders);
-    let html_with_strong = repair_unparsed_strong_markers(&html_with_katex);
 
-    Ok(html_with_strong)
-}
-
-#[derive(Clone, Copy)]
-enum KatexMode {
-    Inline,
-    Display,
-}
-
-struct KatexPlaceholder {
-    token: String,
-    content: String,
-    mode: KatexMode,
-}
-
-#[derive(Clone, Copy)]
-enum CodeState {
-    Outside,
-    Inline(usize),
-    Fenced(usize),
-}
-
-#[derive(Clone, Copy)]
-enum LinkState {
-    Outside,
-    AfterClosingBracket,
-    Destination(usize),
-}
-
-fn extract_katex_placeholders(markdown: &str) -> (String, Vec<KatexPlaceholder>) {
-    let mut placeholders = Vec::new();
-    let mut output = String::with_capacity(markdown.len());
-    let mut chars = markdown.chars().peekable();
-    let mut code_state = CodeState::Outside;
-    let mut link_state = LinkState::Outside;
-    let mut line_prefix_is_whitespace = true;
-    let mut in_html_tag = false;
-
-    while let Some(ch) = chars.next() {
-        if in_html_tag {
-            output.push(ch);
-            if ch == '>' {
-                in_html_tag = false;
-            }
-            line_prefix_is_whitespace =
-                ch == '\n' || (line_prefix_is_whitespace && ch.is_whitespace());
-            continue;
-        }
-
-        if ch == '`' {
-            let mut tick_count = 1;
-            while chars.peek() == Some(&'`') {
-                chars.next();
-                tick_count += 1;
-            }
-
-            match code_state {
-                CodeState::Outside => {
-                    if tick_count >= 3 && line_prefix_is_whitespace {
-                        code_state = CodeState::Fenced(tick_count);
-                    } else {
-                        code_state = CodeState::Inline(tick_count);
-                    }
-                }
-                CodeState::Inline(delimiter_len) => {
-                    if tick_count == delimiter_len {
-                        code_state = CodeState::Outside;
-                    }
-                }
-                CodeState::Fenced(delimiter_len) => {
-                    if line_prefix_is_whitespace && tick_count >= delimiter_len {
-                        code_state = CodeState::Outside;
-                    }
-                }
-            }
-
-            for _ in 0..tick_count {
-                output.push('`');
-            }
-            line_prefix_is_whitespace = false;
-            continue;
-        }
-
-        if !matches!(code_state, CodeState::Outside) {
-            output.push(ch);
-            line_prefix_is_whitespace =
-                ch == '\n' || (line_prefix_is_whitespace && ch.is_whitespace());
-            continue;
-        }
-
-        if ch == '<' {
-            let starts_html_tag = matches!(
-                chars.peek(),
-                Some(next) if next.is_ascii_alphabetic() || matches!(next, '/' | '!' | '?')
-            );
-            if starts_html_tag {
-                in_html_tag = true;
-                output.push(ch);
-                line_prefix_is_whitespace = false;
-                continue;
-            }
-        }
-
-        match link_state {
-            LinkState::Outside => {
-                if ch == ']' {
-                    output.push(ch);
-                    link_state = LinkState::AfterClosingBracket;
-                    line_prefix_is_whitespace = false;
-                    continue;
-                }
-            }
-            LinkState::AfterClosingBracket => {
-                output.push(ch);
-                if ch == '(' {
-                    link_state = LinkState::Destination(1);
-                } else {
-                    link_state = LinkState::Outside;
-                }
-                line_prefix_is_whitespace = false;
-                continue;
-            }
-            LinkState::Destination(depth) => {
-                output.push(ch);
-                link_state = match ch {
-                    '(' => LinkState::Destination(depth + 1),
-                    ')' if depth == 1 => LinkState::Outside,
-                    ')' => LinkState::Destination(depth - 1),
-                    _ => LinkState::Destination(depth),
-                };
-                line_prefix_is_whitespace = false;
-                continue;
-            }
-        }
-
-        if ch != '$' {
-            output.push(ch);
-            line_prefix_is_whitespace =
-                ch == '\n' || (line_prefix_is_whitespace && ch.is_whitespace());
-            continue;
-        }
-
-        let preceding_backslash_count = output.chars().rev().take_while(|c| *c == '\\').count();
-        if preceding_backslash_count % 2 == 1 {
-            output.push(ch);
-            line_prefix_is_whitespace = false;
-            continue;
-        }
-
-        if chars.peek() == Some(&'$') {
-            chars.next();
-            if let Some(content) = take_until_delimiter(&mut chars, "$$") {
-                let token = build_katex_token(placeholders.len(), KatexMode::Display, &content);
-                placeholders.push(KatexPlaceholder {
-                    token: token.clone(),
-                    content,
-                    mode: KatexMode::Display,
-                });
-                output.push_str(&token);
-                line_prefix_is_whitespace = false;
-            } else {
-                output.push_str("$$");
-                line_prefix_is_whitespace = false;
-            }
-            continue;
-        }
-
-        if let Some(content) = take_until_delimiter(&mut chars, "$") {
-            let token = build_katex_token(placeholders.len(), KatexMode::Inline, &content);
-            placeholders.push(KatexPlaceholder {
-                token: token.clone(),
-                content,
-                mode: KatexMode::Inline,
-            });
-            output.push_str(&token);
-            line_prefix_is_whitespace = false;
-        } else {
-            output.push('$');
-            line_prefix_is_whitespace = false;
-        }
-    }
-
-    (output, placeholders)
-}
-
-fn build_katex_token(index: usize, mode: KatexMode, content: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    index.hash(&mut hasher);
-    match mode {
-        KatexMode::Inline => "inline".hash(&mut hasher),
-        KatexMode::Display => "display".hash(&mut hasher),
-    }
-    content.hash(&mut hasher);
-
-    format!("\u{E000}OKAWAKKATEX{:016x}\u{E001}", hasher.finish())
-}
-
-fn take_until_delimiter(
-    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
-    delimiter: &str,
-) -> Option<String> {
-    let mut content = String::new();
-
-    while let Some(ch) = chars.next() {
-        if delimiter == "$$" && ch == '$' && chars.peek() == Some(&'$') {
-            chars.next();
-            return Some(content);
-        }
-
-        if delimiter == "$" && ch == '$' {
-            return Some(content);
-        }
-
-        content.push(ch);
-    }
-
-    None
-}
-
-fn replace_katex_placeholders(html: &str, placeholders: &[KatexPlaceholder]) -> String {
-    if placeholders.is_empty() {
-        return html.to_string();
-    }
-
-    let replacements = placeholders
-        .iter()
-        .map(|placeholder| {
-            let content = html_escape(&normalize_katex_content(&placeholder.content));
-            let replacement = match placeholder.mode {
-                KatexMode::Inline => {
-                    format!(r#"<span class="okawak-katex-inline">{content}</span>"#)
-                }
-                KatexMode::Display => {
-                    format!(r#"<span class="okawak-katex-display">{content}</span>"#)
-                }
-            };
-
-            (placeholder.token.as_str(), replacement)
-        })
-        .collect::<HashMap<_, _>>();
-
-    let token_pattern = placeholders
-        .iter()
-        .map(|placeholder| regex::escape(&placeholder.token))
-        .collect::<Vec<_>>()
-        .join("|");
-    let token_re = Regex::new(&token_pattern).expect("Invalid KaTeX token regex");
-
-    token_re
-        .replace_all(html, |caps: &regex::Captures<'_>| {
-            let token = caps
-                .get(0)
-                .expect("Regex match should always contain the full match")
-                .as_str();
-            replacements
-                .get(token)
-                .cloned()
-                .unwrap_or_else(|| token.to_string())
-        })
-        .into_owned()
-}
-
-fn normalize_katex_content(content: &str) -> String {
-    content
-        .chars()
-        .filter(|ch| {
-            !matches!(
-                ch,
-                '\u{2009}'
-                    | '\u{200A}'
-                    | '\u{200B}'
-                    | '\u{200C}'
-                    | '\u{200D}'
-                    | '\u{2061}'
-                    | '\u{202F}'
-                    | '\u{2060}'
-                    | '\u{FEFF}'
-            )
-        })
-        .collect()
-}
-
-fn html_escape(text: &str) -> String {
-    text.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
-
-fn repair_unparsed_strong_markers(html: &str) -> String {
-    let mut result = String::with_capacity(html.len());
-    let mut remaining = html;
-
-    loop {
-        let code_start = [remaining.find("<pre"), remaining.find("<code")]
-            .into_iter()
-            .flatten()
-            .min();
-
-        match code_start {
-            None => {
-                result.push_str(&apply_unparsed_strong_markers(remaining));
-                break;
-            }
-            Some(start) => {
-                result.push_str(&apply_unparsed_strong_markers(&remaining[..start]));
-
-                let close_tag = if remaining[start..].starts_with("<pre") {
-                    "</pre>"
-                } else {
-                    "</code>"
-                };
-
-                match remaining[start..].find(close_tag) {
-                    Some(close_offset) => {
-                        let end = start + close_offset + close_tag.len();
-                        result.push_str(&remaining[start..end]);
-                        remaining = &remaining[end..];
-                    }
-                    None => {
-                        result.push_str(&remaining[start..]);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    repair_nested_adjacent_strong_tags(&result)
-}
-
-fn apply_unparsed_strong_markers(html: &str) -> String {
-    static STRONG_KATEX_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r#"(?s)\*\*((?:<span class="okawak-katex-(?:inline|display)">.*?</span>))\*\*"#)
-            .expect("Invalid KaTeX strong marker regex")
-    });
-
-    STRONG_KATEX_RE
-        .replace_all(html, "<strong>$1</strong>")
-        .into_owned()
-}
-
-fn repair_nested_adjacent_strong_tags(html: &str) -> String {
-    static NESTED_STRONG_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"<strong>([^<]+)<strong>([^<]+)</strong>([^<]+)</strong>")
-            .expect("Invalid nested strong regex")
-    });
-    static RAW_STRONG_SPLIT_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"\*\*([^*<]+)<strong>([^<]+)</strong>([^*<]+)\*\*")
-            .expect("Invalid raw strong split regex")
-    });
-
-    let html = RAW_STRONG_SPLIT_RE
-        .replace_all(html, "<strong>$1</strong>$2<strong>$3</strong>")
-        .into_owned();
-
-    NESTED_STRONG_RE
-        .replace_all(&html, "<strong>$1</strong>$2<strong>$3</strong>")
-        .into_owned()
+    Ok(protected_markdown.restore(&html_output))
 }
 
 fn sanitize_anchor_hrefs(html: &str) -> String {
@@ -491,10 +127,6 @@ mod tests {
     use indoc::indoc;
     use rstest::*;
 
-    fn generate_html_file(frontmatter_yaml: &str, html_body: &str) -> String {
-        format!("---\n{frontmatter_yaml}\n---\n{html_body}")
-    }
-
     #[rstest]
     #[case::basic_markdown(
         "# Hello World\n\nThis is a **bold** text and *italic* text.",
@@ -519,26 +151,6 @@ mod tests {
     fn test_markdown_to_html_conversion(#[case] markdown: &str, #[case] expected_html: &str) {
         let result = convert_markdown_to_html(markdown).unwrap();
         assert_eq!(result, expected_html);
-    }
-
-    #[rstest]
-    #[case::basic_html_file(
-        "title: Test Article\nslug: test123",
-        "<h1>Test Content</h1>\n<p>This is a paragraph.</p>",
-        "---\ntitle: Test Article\nslug: test123\n---\n<h1>Test Content</h1>\n<p>This is a paragraph.</p>"
-    )]
-    #[case::with_japanese_content(
-        "title: 日本語記事\nslug: japanese456",
-        "<h1>日本語のタイトル</h1>\n<p>日本語のコンテンツです。</p>",
-        "---\ntitle: 日本語記事\nslug: japanese456\n---\n<h1>日本語のタイトル</h1>\n<p>日本語のコンテンツです。</p>"
-    )]
-    fn test_html_file_generation(
-        #[case] frontmatter: &str,
-        #[case] html_body: &str,
-        #[case] expected: &str,
-    ) {
-        let result = generate_html_file(frontmatter, html_body);
-        assert_eq!(result, expected);
     }
 
     #[rstest]

--- a/crates/publish/src/render/katex.rs
+++ b/crates/publish/src/render/katex.rs
@@ -1,0 +1,389 @@
+use regex::Regex;
+use std::{
+    collections::{HashMap, hash_map::DefaultHasher},
+    hash::{Hash, Hasher},
+    sync::LazyLock,
+};
+
+pub(super) struct ProtectedMarkdown {
+    markdown: String,
+    placeholders: Vec<KatexPlaceholder>,
+}
+
+impl ProtectedMarkdown {
+    pub(super) fn new(markdown: &str) -> Self {
+        let (markdown, placeholders) = extract_placeholders(markdown);
+        Self {
+            markdown,
+            placeholders,
+        }
+    }
+
+    pub(super) fn as_str(&self) -> &str {
+        &self.markdown
+    }
+
+    pub(super) fn restore(self, html: &str) -> String {
+        let html = replace_placeholders(html, &self.placeholders);
+        repair_unparsed_strong_markers(&html)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum KatexMode {
+    Inline,
+    Display,
+}
+
+struct KatexPlaceholder {
+    token: String,
+    content: String,
+    mode: KatexMode,
+}
+
+#[derive(Clone, Copy)]
+enum CodeState {
+    Outside,
+    Inline(usize),
+    Fenced(usize),
+}
+
+#[derive(Clone, Copy)]
+enum LinkState {
+    Outside,
+    AfterClosingBracket,
+    Destination(usize),
+}
+
+fn extract_placeholders(markdown: &str) -> (String, Vec<KatexPlaceholder>) {
+    let mut placeholders = Vec::new();
+    let mut output = String::with_capacity(markdown.len());
+    let mut chars = markdown.chars().peekable();
+    let mut code_state = CodeState::Outside;
+    let mut link_state = LinkState::Outside;
+    let mut line_prefix_is_whitespace = true;
+    let mut in_html_tag = false;
+
+    while let Some(ch) = chars.next() {
+        if in_html_tag {
+            output.push(ch);
+            if ch == '>' {
+                in_html_tag = false;
+            }
+            line_prefix_is_whitespace =
+                ch == '\n' || (line_prefix_is_whitespace && ch.is_whitespace());
+            continue;
+        }
+
+        if ch == '`' {
+            let mut tick_count = 1;
+            while chars.peek() == Some(&'`') {
+                chars.next();
+                tick_count += 1;
+            }
+
+            match code_state {
+                CodeState::Outside => {
+                    if tick_count >= 3 && line_prefix_is_whitespace {
+                        code_state = CodeState::Fenced(tick_count);
+                    } else {
+                        code_state = CodeState::Inline(tick_count);
+                    }
+                }
+                CodeState::Inline(delimiter_len) => {
+                    if tick_count == delimiter_len {
+                        code_state = CodeState::Outside;
+                    }
+                }
+                CodeState::Fenced(delimiter_len) => {
+                    if line_prefix_is_whitespace && tick_count >= delimiter_len {
+                        code_state = CodeState::Outside;
+                    }
+                }
+            }
+
+            for _ in 0..tick_count {
+                output.push('`');
+            }
+            line_prefix_is_whitespace = false;
+            continue;
+        }
+
+        if !matches!(code_state, CodeState::Outside) {
+            output.push(ch);
+            line_prefix_is_whitespace =
+                ch == '\n' || (line_prefix_is_whitespace && ch.is_whitespace());
+            continue;
+        }
+
+        if ch == '<' {
+            let starts_html_tag = matches!(
+                chars.peek(),
+                Some(next) if next.is_ascii_alphabetic() || matches!(next, '/' | '!' | '?')
+            );
+            if starts_html_tag {
+                in_html_tag = true;
+                output.push(ch);
+                line_prefix_is_whitespace = false;
+                continue;
+            }
+        }
+
+        match link_state {
+            LinkState::Outside => {
+                if ch == ']' {
+                    output.push(ch);
+                    link_state = LinkState::AfterClosingBracket;
+                    line_prefix_is_whitespace = false;
+                    continue;
+                }
+            }
+            LinkState::AfterClosingBracket => {
+                output.push(ch);
+                if ch == '(' {
+                    link_state = LinkState::Destination(1);
+                } else {
+                    link_state = LinkState::Outside;
+                }
+                line_prefix_is_whitespace = false;
+                continue;
+            }
+            LinkState::Destination(depth) => {
+                output.push(ch);
+                link_state = match ch {
+                    '(' => LinkState::Destination(depth + 1),
+                    ')' if depth == 1 => LinkState::Outside,
+                    ')' => LinkState::Destination(depth - 1),
+                    _ => LinkState::Destination(depth),
+                };
+                line_prefix_is_whitespace = false;
+                continue;
+            }
+        }
+
+        if ch != '$' {
+            output.push(ch);
+            line_prefix_is_whitespace =
+                ch == '\n' || (line_prefix_is_whitespace && ch.is_whitespace());
+            continue;
+        }
+
+        let preceding_backslash_count = output.chars().rev().take_while(|c| *c == '\\').count();
+        if preceding_backslash_count % 2 == 1 {
+            output.push(ch);
+            line_prefix_is_whitespace = false;
+            continue;
+        }
+
+        if chars.peek() == Some(&'$') {
+            chars.next();
+            if let Some(content) = take_until_delimiter(&mut chars, "$$") {
+                let token = build_token(placeholders.len(), KatexMode::Display, &content);
+                placeholders.push(KatexPlaceholder {
+                    token: token.clone(),
+                    content,
+                    mode: KatexMode::Display,
+                });
+                output.push_str(&token);
+                line_prefix_is_whitespace = false;
+            } else {
+                output.push_str("$$");
+                line_prefix_is_whitespace = false;
+            }
+            continue;
+        }
+
+        if let Some(content) = take_until_delimiter(&mut chars, "$") {
+            let token = build_token(placeholders.len(), KatexMode::Inline, &content);
+            placeholders.push(KatexPlaceholder {
+                token: token.clone(),
+                content,
+                mode: KatexMode::Inline,
+            });
+            output.push_str(&token);
+            line_prefix_is_whitespace = false;
+        } else {
+            output.push('$');
+            line_prefix_is_whitespace = false;
+        }
+    }
+
+    (output, placeholders)
+}
+
+fn build_token(index: usize, mode: KatexMode, content: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    index.hash(&mut hasher);
+    match mode {
+        KatexMode::Inline => "inline".hash(&mut hasher),
+        KatexMode::Display => "display".hash(&mut hasher),
+    }
+    content.hash(&mut hasher);
+
+    format!("\u{E000}OKAWAKKATEX{:016x}\u{E001}", hasher.finish())
+}
+
+fn take_until_delimiter(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    delimiter: &str,
+) -> Option<String> {
+    let mut content = String::new();
+
+    while let Some(ch) = chars.next() {
+        if delimiter == "$$" && ch == '$' && chars.peek() == Some(&'$') {
+            chars.next();
+            return Some(content);
+        }
+
+        if delimiter == "$" && ch == '$' {
+            return Some(content);
+        }
+
+        content.push(ch);
+    }
+
+    None
+}
+
+fn replace_placeholders(html: &str, placeholders: &[KatexPlaceholder]) -> String {
+    if placeholders.is_empty() {
+        return html.to_string();
+    }
+
+    let replacements = placeholders
+        .iter()
+        .map(|placeholder| {
+            let content = html_escape(&normalize_content(&placeholder.content));
+            let replacement = match placeholder.mode {
+                KatexMode::Inline => {
+                    format!(r#"<span class="okawak-katex-inline">{content}</span>"#)
+                }
+                KatexMode::Display => {
+                    format!(r#"<span class="okawak-katex-display">{content}</span>"#)
+                }
+            };
+
+            (placeholder.token.as_str(), replacement)
+        })
+        .collect::<HashMap<_, _>>();
+
+    let token_pattern = placeholders
+        .iter()
+        .map(|placeholder| regex::escape(&placeholder.token))
+        .collect::<Vec<_>>()
+        .join("|");
+    let token_re = Regex::new(&token_pattern).expect("Invalid KaTeX token regex");
+
+    token_re
+        .replace_all(html, |captures: &regex::Captures<'_>| {
+            let token = captures
+                .get(0)
+                .expect("Regex match should always contain the full match")
+                .as_str();
+            replacements
+                .get(token)
+                .cloned()
+                .unwrap_or_else(|| token.to_string())
+        })
+        .into_owned()
+}
+
+fn normalize_content(content: &str) -> String {
+    content
+        .chars()
+        .filter(|ch| {
+            !matches!(
+                ch,
+                '\u{2009}'
+                    | '\u{200A}'
+                    | '\u{200B}'
+                    | '\u{200C}'
+                    | '\u{200D}'
+                    | '\u{2061}'
+                    | '\u{202F}'
+                    | '\u{2060}'
+                    | '\u{FEFF}'
+            )
+        })
+        .collect()
+}
+
+fn html_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn repair_unparsed_strong_markers(html: &str) -> String {
+    let mut result = String::with_capacity(html.len());
+    let mut remaining = html;
+
+    loop {
+        let code_start = [remaining.find("<pre"), remaining.find("<code")]
+            .into_iter()
+            .flatten()
+            .min();
+
+        match code_start {
+            None => {
+                result.push_str(&apply_unparsed_strong_markers(remaining));
+                break;
+            }
+            Some(start) => {
+                result.push_str(&apply_unparsed_strong_markers(&remaining[..start]));
+
+                let close_tag = if remaining[start..].starts_with("<pre") {
+                    "</pre>"
+                } else {
+                    "</code>"
+                };
+
+                match remaining[start..].find(close_tag) {
+                    Some(close_offset) => {
+                        let end = start + close_offset + close_tag.len();
+                        result.push_str(&remaining[start..end]);
+                        remaining = &remaining[end..];
+                    }
+                    None => {
+                        result.push_str(&remaining[start..]);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    repair_nested_adjacent_strong_tags(&result)
+}
+
+fn apply_unparsed_strong_markers(html: &str) -> String {
+    static STRONG_KATEX_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?s)\*\*((?:<span class="okawak-katex-(?:inline|display)">.*?</span>))\*\*"#)
+            .expect("Invalid KaTeX strong marker regex")
+    });
+
+    STRONG_KATEX_RE
+        .replace_all(html, "<strong>$1</strong>")
+        .into_owned()
+}
+
+fn repair_nested_adjacent_strong_tags(html: &str) -> String {
+    static NESTED_STRONG_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"<strong>([^<]+)<strong>([^<]+)</strong>([^<]+)</strong>")
+            .expect("Invalid nested strong regex")
+    });
+    static RAW_STRONG_SPLIT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\*\*([^*<]+)<strong>([^<]+)</strong>([^*<]+)\*\*")
+            .expect("Invalid raw strong split regex")
+    });
+
+    let html = RAW_STRONG_SPLIT_RE
+        .replace_all(html, "<strong>$1</strong>$2<strong>$3</strong>")
+        .into_owned();
+
+    NESTED_STRONG_RE
+        .replace_all(&html, "<strong>$1</strong>$2<strong>$3</strong>")
+        .into_owned()
+}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -69,7 +69,7 @@ okawak_blog/
   - path処理の対応環境はmacOSとLinuxとし、Windows形式のpathは対象外とする
   - vault moduleによるObsidian vault走査、Markdown読込、frontmatter parse
   - links moduleによる内部リンク索引の構築とObsidian link解決
-  - render moduleによるcontent kindごとの描画、MarkdownからHTMLへの変換、外部HTTPを伴うbookmark enrichment
+  - render moduleによるcontent kindごとの組み立て、共通本文処理、MarkdownからHTMLへの変換、KaTeX処理、外部HTTPを伴うbookmark enrichment
   - classify moduleによる公開種別の確定と`section_path`の導出
   - artifacts moduleによるartifact構築、`site/`配下への書込み、生成結果のvalidation
   - `ObsidianFrontMatter`と`ContentKind`はpublisher入力形式として内部に保持する


### PR DESCRIPTION
## Summary

- reorganize `publish::render` into document assembly, shared body processing, HTML conversion, KaTeX processing, and bookmark enrichment
- keep content-kind rendering together in `document.rs` instead of introducing multiple thin wrapper modules
- document the revised render boundary in the architecture guidance
- add coverage for bookmark-enrichment failure fallback and remove a test-only HTML helper that did not exercise production code

## Impact

This is a responsibility and file-layout refactor. It does not intentionally change the publisher API or artifact contract.

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `git diff --check`