### PR TITLE
refactor: expand internal link index

### DIFF
--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -18,17 +18,23 @@ pub(crate) struct ParsedArticleFile {
 
 pub(crate) struct ParsedPageFile {
     pub(crate) page: PageKey,
+    /// Extensionless vault-relative key used to resolve Obsidian internal links.
+    pub(crate) source_key: String,
     pub(crate) markdown_body: String,
     pub(crate) front_matter: ObsidianFrontMatter,
 }
 
 pub(crate) struct ParsedHomeFile {
+    /// Extensionless vault-relative key used to resolve Obsidian internal links.
+    pub(crate) source_key: String,
     pub(crate) markdown_body: String,
     pub(crate) front_matter: ObsidianFrontMatter,
 }
 
 pub(crate) struct ParsedCategoryFile {
     pub(crate) category: Category,
+    /// Extensionless vault-relative key used to resolve Obsidian internal links.
+    pub(crate) source_key: String,
     pub(crate) markdown_body: String,
     pub(crate) front_matter: ObsidianFrontMatter,
 }
@@ -56,41 +62,50 @@ pub(crate) fn classify_obsidian_files(
     for file_path in markdown_files {
         match parse_obsidian_file(&file_path) {
             Ok(Some(parsed)) if parsed.front_matter.is_completed => {
-                let result: Result<()> = match parsed.front_matter.kind {
-                    ContentKind::Article => process_article_file(&file_path, parsed, obsidian_dir)
-                        .map(|f| articles.push(f)),
-                    ContentKind::Page => {
-                        parse_page_key(parsed.front_matter.page.as_deref()).map(|page| {
-                            pages.push(ParsedPageFile {
-                                page,
-                                markdown_body: parsed.markdown_body,
-                                front_matter: parsed.front_matter,
-                            });
-                        })
-                    }
-                    ContentKind::Home => {
-                        if home.is_some() {
-                            Err(PublishError::Parse(
-                                "Duplicate home content detected".to_string(),
-                            ))
-                        } else {
-                            home = Some(ParsedHomeFile {
-                                markdown_body: parsed.markdown_body,
-                                front_matter: parsed.front_matter,
-                            });
-                            Ok(())
+                let result =
+                    derive_source_key(&file_path, obsidian_dir).and_then(|source_key| match parsed
+                        .front_matter
+                        .kind
+                    {
+                        ContentKind::Article => {
+                            process_article_file(&file_path, parsed, obsidian_dir, source_key)
+                                .map(|file| articles.push(file))
                         }
-                    }
-                    ContentKind::Category => {
-                        parse_category(parsed.front_matter.category.as_deref()).map(|category| {
+                        ContentKind::Page => parse_page_key(parsed.front_matter.page.as_deref())
+                            .map(|page| {
+                                pages.push(ParsedPageFile {
+                                    page,
+                                    source_key,
+                                    markdown_body: parsed.markdown_body,
+                                    front_matter: parsed.front_matter,
+                                });
+                            }),
+                        ContentKind::Home => {
+                            if home.is_some() {
+                                Err(PublishError::Parse(
+                                    "Duplicate home content detected".to_string(),
+                                ))
+                            } else {
+                                home = Some(ParsedHomeFile {
+                                    source_key,
+                                    markdown_body: parsed.markdown_body,
+                                    front_matter: parsed.front_matter,
+                                });
+                                Ok(())
+                            }
+                        }
+                        ContentKind::Category => parse_category(
+                            parsed.front_matter.category.as_deref(),
+                        )
+                        .map(|category| {
                             categories.push(ParsedCategoryFile {
                                 category,
+                                source_key,
                                 markdown_body: parsed.markdown_body,
                                 front_matter: parsed.front_matter,
                             });
-                        })
-                    }
-                };
+                        }),
+                    });
                 if let Err(e) = result {
                     errors += 1;
                     error!("Error processing {}: {}", file_path.display(), e);
@@ -121,6 +136,7 @@ fn process_article_file(
     file_path: &Path,
     parsed_file: ParsedObsidianFile,
     obsidian_dir: &Path,
+    source_key: String,
 ) -> Result<ParsedArticleFile> {
     let relative_path = file_path.strip_prefix(obsidian_dir)?;
     let category = parse_category(parsed_file.front_matter.category.as_deref())?;
@@ -130,10 +146,6 @@ fn process_article_file(
         relative_path,
         &parsed_file.front_matter.created,
     )?;
-    let source_key = relative_path
-        .with_extension("")
-        .to_string_lossy()
-        .into_owned();
     let section_path = derive_section_path(category_relative_path);
 
     Ok(ParsedArticleFile {
@@ -144,6 +156,14 @@ fn process_article_file(
         markdown_body: parsed_file.markdown_body,
         front_matter: parsed_file.front_matter,
     })
+}
+
+fn derive_source_key(file_path: &Path, obsidian_dir: &Path) -> Result<String> {
+    Ok(file_path
+        .strip_prefix(obsidian_dir)?
+        .with_extension("")
+        .to_string_lossy()
+        .into_owned())
 }
 
 fn derive_section_path(category_relative_path: &Path) -> SectionPath {
@@ -233,6 +253,7 @@ mod tests {
         front_matter.category = Some(category.as_str().to_string());
         ParsedCategoryFile {
             category,
+            source_key: format!("{}/index", category.as_str()),
             markdown_body: String::new(),
             front_matter,
         }
@@ -243,6 +264,7 @@ mod tests {
         front_matter.page = Some(page.to_string());
         ParsedPageFile {
             page: PageKey::new(page.to_string()).unwrap(),
+            source_key: format!("pages/{page}"),
             markdown_body: String::new(),
             front_matter,
         }
@@ -271,9 +293,18 @@ mod tests {
             Path::new("/vault/daily/article.md"),
             parsed_file,
             obsidian_dir,
+            "daily/article".to_string(),
         );
 
         assert!(matches!(result, Err(PublishError::StripPrefix(_))));
+    }
+
+    #[test]
+    fn test_derive_source_key_uses_extensionless_vault_relative_path() {
+        let source_key =
+            derive_source_key(Path::new("/vault/pages/about.md"), Path::new("/vault")).unwrap();
+
+        assert_eq!(source_key, "pages/about");
     }
 
     #[rstest]

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -1,23 +1,46 @@
-use crate::classify::ParsedArticleFile;
+use crate::classify::ClassifiedFiles;
 use pulldown_cmark::{Event, LinkType, Options, Parser, Tag};
 use std::collections::HashMap;
 
-/// Published article hrefs indexed by extensionless source keys.
+/// Published content hrefs indexed by extensionless source keys.
+#[derive(Default)]
 pub(crate) struct Index {
     routes: HashMap<String, String>,
 }
 
 impl Index {
-    pub(crate) fn from_articles(articles: &[ParsedArticleFile]) -> Self {
-        let routes = articles
-            .iter()
-            .map(|article| {
-                (
-                    article.source_key.clone(),
-                    format!("/{}/{}", article.category.as_str(), article.slug),
-                )
-            })
-            .collect();
+    pub(crate) fn from_classified_files(files: &ClassifiedFiles) -> Self {
+        let capacity = files.articles.len()
+            + files.pages.len()
+            + usize::from(files.home.is_some())
+            + files.categories.len();
+        let mut routes = HashMap::with_capacity(capacity);
+
+        routes.extend(files.articles.iter().map(|article| {
+            (
+                article.source_key.clone(),
+                format!("/{}/{}", article.category.as_str(), article.slug),
+            )
+        }));
+        routes.extend(
+            files
+                .pages
+                .iter()
+                .map(|page| (page.source_key.clone(), format!("/{}", page.page.as_str()))),
+        );
+        routes.extend(
+            files
+                .home
+                .iter()
+                .map(|home| (home.source_key.clone(), "/".to_string())),
+        );
+        routes.extend(files.categories.iter().map(|category| {
+            (
+                category.source_key.clone(),
+                format!("/{}", category.category.as_str()),
+            )
+        }));
+
         Self { routes }
     }
 
@@ -94,6 +117,9 @@ fn escape_markdown_link_destination(destination: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::classify::{
+        ClassifiedFiles, ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile,
+    };
     use crate::render::convert_markdown_to_html;
     use crate::vault::{ContentKind, ObsidianFrontMatter};
     use domain::{Category, SectionPath, Slug};
@@ -130,30 +156,92 @@ mod tests {
         }
     }
 
-    #[test]
-    fn index_is_built_from_articles() {
-        let articles = vec![article("sub/dir/test", Category::Tech, "slug")];
+    fn page(source_key: &str, page: &str) -> ParsedPageFile {
+        ParsedPageFile {
+            page: domain::PageKey::new(page.to_string()).unwrap(),
+            source_key: source_key.to_string(),
+            markdown_body: "# Page".to_string(),
+            front_matter: front_matter(ContentKind::Page),
+        }
+    }
 
-        let index = Index::from_articles(&articles);
+    fn home(source_key: &str) -> ParsedHomeFile {
+        ParsedHomeFile {
+            source_key: source_key.to_string(),
+            markdown_body: "# Home".to_string(),
+            front_matter: front_matter(ContentKind::Home),
+        }
+    }
 
-        assert_eq!(index.resolve("sub/dir/test"), Some("/tech/slug"));
+    fn category(source_key: &str, category: Category) -> ParsedCategoryFile {
+        ParsedCategoryFile {
+            category,
+            source_key: source_key.to_string(),
+            markdown_body: "# Category".to_string(),
+            front_matter: front_matter(ContentKind::Category),
+        }
+    }
+
+    fn front_matter(kind: ContentKind) -> ObsidianFrontMatter {
+        ObsidianFrontMatter {
+            title: "Content".to_string(),
+            kind,
+            tags: None,
+            summary: None,
+            priority: None,
+            created: "2025-01-01T00:00:00+09:00".to_string(),
+            updated: "2025-01-01T00:00:00+09:00".to_string(),
+            is_completed: true,
+            category: None,
+            page: None,
+        }
+    }
+
+    fn classified_files(articles: Vec<ParsedArticleFile>) -> ClassifiedFiles {
+        ClassifiedFiles {
+            articles,
+            pages: Vec::new(),
+            home: None,
+            categories: Vec::new(),
+            skipped: 0,
+            errors: 0,
+        }
     }
 
     #[test]
-    fn index_is_empty_when_there_are_no_articles() {
-        let index = Index::from_articles(&[]);
+    fn index_is_built_from_all_published_content() {
+        let files = ClassifiedFiles {
+            articles: vec![article("tech/article", Category::Tech, "slug")],
+            pages: vec![page("pages/about", "about")],
+            home: Some(home("home")),
+            categories: vec![category("tech/index", Category::Tech)],
+            skipped: 0,
+            errors: 0,
+        };
+
+        let index = Index::from_classified_files(&files);
+
+        assert_eq!(index.resolve("tech/article"), Some("/tech/slug"));
+        assert_eq!(index.resolve("pages/about"), Some("/about"));
+        assert_eq!(index.resolve("home"), Some("/"));
+        assert_eq!(index.resolve("tech/index"), Some("/tech"));
+    }
+
+    #[test]
+    fn index_is_empty_when_there_is_no_published_content() {
+        let index = Index::from_classified_files(&classified_files(Vec::new()));
 
         assert_eq!(index.resolve("test"), None);
     }
 
     #[test]
     fn index_preserves_distinct_source_keys() {
-        let articles = vec![
+        let files = classified_files(vec![
             article("dir1/test", Category::Tech, "slug1"),
             article("dir2/test", Category::Daily, "slug2"),
-        ];
+        ]);
 
-        let index = Index::from_articles(&articles);
+        let index = Index::from_classified_files(&files);
 
         assert_eq!(index.resolve("dir1/test"), Some("/tech/slug1"));
         assert_eq!(index.resolve("dir2/test"), Some("/daily/slug2"));

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -2,6 +2,8 @@ use crate::classify::ClassifiedFiles;
 use pulldown_cmark::{Event, LinkType, Options, Parser, Tag};
 use std::collections::HashMap;
 
+const ROUTED_PAGE_KEYS: &[&str] = &["about"];
+
 /// Published content hrefs indexed by extensionless source keys.
 #[derive(Default)]
 pub(crate) struct Index {
@@ -10,8 +12,13 @@ pub(crate) struct Index {
 
 impl Index {
     pub(crate) fn from_classified_files(files: &ClassifiedFiles) -> Self {
+        let routed_page_count = files
+            .pages
+            .iter()
+            .filter(|page| is_routed_page(page.page.as_str()))
+            .count();
         let capacity = files.articles.len()
-            + files.pages.len()
+            + routed_page_count
             + usize::from(files.home.is_some())
             + files.categories.len();
         let mut routes = HashMap::with_capacity(capacity);
@@ -26,6 +33,7 @@ impl Index {
             files
                 .pages
                 .iter()
+                .filter(|page| is_routed_page(page.page.as_str()))
                 .map(|page| (page.source_key.clone(), format!("/{}", page.page.as_str()))),
         );
         routes.extend(
@@ -52,6 +60,10 @@ impl Index {
             })
         })
     }
+}
+
+fn is_routed_page(page_key: &str) -> bool {
+    ROUTED_PAGE_KEYS.contains(&page_key)
 }
 
 /// Resolve Obsidian internal links to published Markdown links outside code.
@@ -225,6 +237,23 @@ mod tests {
         assert_eq!(index.resolve("pages/about"), Some("/about"));
         assert_eq!(index.resolve("home"), Some("/"));
         assert_eq!(index.resolve("tech/index"), Some("/tech"));
+    }
+
+    #[test]
+    fn index_excludes_pages_without_a_published_route() {
+        let files = ClassifiedFiles {
+            articles: Vec::new(),
+            pages: vec![page("pages/contact", "contact")],
+            home: None,
+            categories: Vec::new(),
+            skipped: 0,
+            errors: 0,
+        };
+
+        let index = Index::from_classified_files(&files);
+
+        assert_eq!(index.resolve("pages/contact"), None);
+        assert_eq!(index.resolve("contact"), None);
     }
 
     #[test]

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -39,28 +39,38 @@ pub async fn publish_with_bookmark_enricher(
     let markdown_files = scan_markdown_files(obsidian_dir)?;
     info!("Found {} markdown files", markdown_files.len());
 
+    let classified_files = classify_obsidian_files(markdown_files, obsidian_dir);
+
+    info!("Valid article files: {}", classified_files.articles.len());
+    info!("Valid page files: {}", classified_files.pages.len());
+    info!(
+        "Valid home file: {}",
+        usize::from(classified_files.home.is_some())
+    );
+    info!(
+        "Valid category files: {}",
+        classified_files.categories.len()
+    );
+    info!("Skipped files: {}", classified_files.skipped);
+    if classified_files.errors > 0 {
+        return Err(PublishError::ContentErrors {
+            count: classified_files.errors,
+        });
+    }
+
+    ensure_unique_page_keys(&classified_files.pages)?;
+    ensure_unique_category_landings(&classified_files.categories)?;
+
+    let link_index = links::Index::from_classified_files(&classified_files);
     let classify::ClassifiedFiles {
         articles,
         pages,
         home,
         categories,
         skipped,
-        errors,
-    } = classify_obsidian_files(markdown_files, obsidian_dir);
+        ..
+    } = classified_files;
 
-    info!("Valid article files: {}", articles.len());
-    info!("Valid page files: {}", pages.len());
-    info!("Valid home file: {}", usize::from(home.is_some()));
-    info!("Valid category files: {}", categories.len());
-    info!("Skipped files: {skipped}");
-    if errors > 0 {
-        return Err(PublishError::ContentErrors { count: errors });
-    }
-
-    ensure_unique_page_keys(&pages)?;
-    ensure_unique_category_landings(&categories)?;
-
-    let link_index = links::Index::from_articles(&articles);
     let site_directories = SiteDirectories::prepare(output_dir)?;
 
     const CONCURRENT_LIMIT: usize = 4;

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -24,7 +24,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_render_falls_back_to_html_when_bookmark_enrichment_fails() {
-        let link_index = links::Index::from_articles(&[]);
+        let link_index = links::Index::default();
         let enrich: BookmarkEnricher = Arc::new(|_html| {
             Box::pin(async { Err(PublishError::Parse("enrichment failed".to_string())) })
         });

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -123,6 +123,72 @@ async fn test_publish_with_sample_file() {
 }
 
 #[tokio::test]
+async fn test_publish_resolves_links_to_all_content_kinds() {
+    let temp_dir = TempDir::new().unwrap();
+    let obsidian_dir = temp_dir.path().join("obsidian");
+    let output_dir = temp_dir.path().join("dist");
+
+    fs::create_dir_all(obsidian_dir.join("tech")).unwrap();
+    fs::write(
+        obsidian_dir.join("tech/links.md"),
+        indoc! {r#"
+            ---
+            title: "Links"
+            created: "2025-01-01T00:00:00+09:00"
+            updated: "2025-01-01T00:00:00+09:00"
+            is_completed: true
+            category: "tech"
+            ---
+
+            [[about|About]]
+            [[home|Home]]
+            [[tech/index|Tech]]
+        "#},
+    )
+    .unwrap();
+    fs::write(
+        obsidian_dir.join("home.md"),
+        indoc! {r#"
+            ---
+            title: "Home"
+            kind: home
+            created: "2025-01-01T00:00:00+09:00"
+            updated: "2025-01-01T00:00:00+09:00"
+            is_completed: true
+            ---
+
+            # Home
+        "#},
+    )
+    .unwrap();
+    fs::write(
+        obsidian_dir.join("tech/index.md"),
+        indoc! {r#"
+            ---
+            title: "Tech"
+            kind: category
+            category: tech
+            created: "2025-01-01T00:00:00+09:00"
+            updated: "2025-01-01T00:00:00+09:00"
+            is_completed: true
+            ---
+
+            # Tech
+        "#},
+    )
+    .unwrap();
+    write_about_page(&obsidian_dir);
+
+    publish(&obsidian_dir, &output_dir).await.unwrap();
+
+    let html_files = collect_html_files(&output_dir.join("site/articles"));
+    let html = fs::read_to_string(&html_files[0]).unwrap();
+    assert!(html.contains(r#"href="/about">About</a>"#));
+    assert!(html.contains(r#"href="/">Home</a>"#));
+    assert!(html.contains(r#"href="/tech">Tech</a>"#));
+}
+
+#[tokio::test]
 async fn test_publish_skips_incomplete_file() {
     let temp_dir = TempDir::new().unwrap();
     let obsidian_dir = temp_dir.path().join("obsidian");

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -68,7 +68,7 @@ okawak_blog/
   - crate外向けAPIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に限定する
   - path処理の対応環境はmacOSとLinuxとし、Windows形式のpathは対象外とする
   - vault moduleによるObsidian vault走査、Markdown読込、frontmatter parse
-  - links moduleによる内部リンク索引の構築とObsidian link解決
+  - links moduleによる全公開contentのvault相対source keyと公開URLの索引構築、およびObsidian link解決
   - render moduleによるcontent kindごとの組み立て、共通本文処理、MarkdownからHTMLへの変換、KaTeX処理、外部HTTPを伴うbookmark enrichment
   - classify moduleによる公開種別の確定と`section_path`の導出
   - artifacts moduleによるartifact構築、`site/`配下への書込み、生成結果のvalidation


### PR DESCRIPTION
## Summary

- derive an extensionless vault-relative `source_key` for every classified content kind
- build the internal link index from articles, pages, home content, and category landings
- register each content kind's published route before classified values are moved into the publishing pipeline
- add unit and integration coverage for links to every published content kind
- update the architecture documentation to describe the expanded index

## Why

The link resolver ran for every rendered document, but its index contained articles only. Links targeting pages, home content, or category landings therefore fell back to paths inferred from their raw Obsidian targets instead of resolving through the publisher's route contract.

## Impact

Published Markdown can now resolve links to:

- articles: `/{category}/{slug}`
- pages: `/{page}`
- home: `/`
- category landings: `/{category}`

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `git diff --check`