### PR TITLE
refactor: migrate publisher logging to tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,56 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "any_spawner"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,12 +617,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
@@ -813,12 +757,6 @@ name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1109,37 +1047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "defmt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
-dependencies = [
- "defmt-parser",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,29 +1187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,7 +1205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2027,12 +1911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,42 +1924,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc43d6fb25860892c78ef7ce2ffed572087a6853ecb60f587f499329717ed7da"
-dependencies = [
- "defmt",
- "jiff-core",
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
-dependencies = [
- "defmt",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fb828bff41eeb269a9665f950cb359e8018f7288b8f34db24937ff54ed8fc5"
-dependencies = [
- "jiff-core",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "jni"
@@ -2167,6 +2009,12 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leptos"
@@ -2578,6 +2426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,12 +2473,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -2780,21 +2631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "portable-atomic"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,11 +2740,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "domain",
- "env_logger",
  "futures",
  "ignore",
  "indoc",
- "log",
  "pulldown-cmark",
  "regex",
  "reqwest",
@@ -2921,6 +2755,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -2930,7 +2766,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -2997,7 +2833,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3158,7 +2994,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3321,11 +3157,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3382,7 +3218,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3460,7 +3296,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3483,7 +3319,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "cssparser",
  "derive_more",
  "log",
@@ -3760,6 +3596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,7 +3787,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3999,7 +3844,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4049,6 +3894,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4243,7 +4097,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4270,7 +4124,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4331,6 +4185,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4470,12 +4350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4485,6 +4359,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -4693,7 +4573,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ aws-sdk-s3 = { version = "1", default-features = false }
 axum = "0.8"
 chrono = "0.4"
 console_error_panic_hook = "0.1"
-env_logger = "0.11"
 futures = "0.3"
 httpdate = "1"
 ignore = "0.4"

--- a/crates/publish/Cargo.toml
+++ b/crates/publish/Cargo.toml
@@ -9,10 +9,8 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 domain = { path = "../domain" }
-env_logger.workspace = true
 futures.workspace = true
 ignore.workspace = true
-log.workspace = true
 pulldown-cmark.workspace = true
 regex.workspace = true
 reqwest = { workspace = true, features = ["json"] }
@@ -23,6 +21,8 @@ serde_yaml.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -1,9 +1,9 @@
 use crate::error::{PublishError, Result};
 use crate::vault::{ContentKind, ObsidianFrontMatter, ParsedObsidianFile, parse_obsidian_file};
 use domain::{Category, PageKey, SectionPath, Slug};
-use log::{error, warn};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use tracing::{error, warn};
 
 pub(crate) struct ParsedArticleFile {
     pub(crate) category: Category,
@@ -106,18 +106,18 @@ pub(crate) fn classify_obsidian_files(
                             });
                         }),
                     });
-                if let Err(e) = result {
+                if let Err(error) = result {
                     errors += 1;
-                    error!("Error processing {}: {}", file_path.display(), e);
+                    error!(file_path = %file_path.display(), %error, "failed to process file");
                 }
             }
             Ok(_) => {
                 skipped += 1;
-                warn!("Skipped (not completed): {}", file_path.display());
+                warn!(file_path = %file_path.display(), "skipped incomplete file");
             }
-            Err(e) => {
+            Err(error) => {
                 errors += 1;
-                error!("Error processing {}: {}", file_path.display(), e);
+                error!(file_path = %file_path.display(), %error, "failed to process file");
             }
         }
     }

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -105,7 +105,7 @@ fn resolve_internal_link(link: &str, index: &Index) -> String {
         .resolve(link_target)
         .map(str::to_owned)
         .unwrap_or_else(|| {
-            log::warn!("Internal link target '{link_target}' was not found");
+            tracing::warn!(%link_target, "internal link target was not found");
             format!("/{link_target}")
         });
 

--- a/crates/publish/src/main.rs
+++ b/crates/publish/src/main.rs
@@ -7,10 +7,10 @@ const OUTPUT_DIR: &str = "crates/publish/dist";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let env = env_logger::Env::default()
-        .filter_or("RUST_LOG", "info")
-        .write_style_or("LOG_STYLE", "auto");
-    env_logger::init_from_env(env);
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .try_init()
+        .map_err(anyhow::Error::from_boxed)?;
 
     publish(Path::new(OBSIDIAN_DIR), Path::new(OUTPUT_DIR)).await?;
 

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -14,16 +14,22 @@ use crate::render::{
 use crate::vault::{scan_markdown_files, validate_obsidian_dir};
 use crate::{classify, links};
 use futures::{StreamExt, stream};
-use log::info;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use tracing::info;
 
 pub async fn publish(obsidian_dir: &Path, output_dir: &Path) -> Result<()> {
     publish_with_bookmark_enricher(obsidian_dir, output_dir, rich_bookmark_enricher()).await
 }
 
+#[tracing::instrument(
+    name = "publish",
+    skip_all,
+    fields(input_dir = %obsidian_dir.display(), output_dir = %output_dir.display()),
+    err
+)]
 pub async fn publish_with_bookmark_enricher(
     obsidian_dir: &Path,
     output_dir: &Path,
@@ -32,26 +38,22 @@ pub async fn publish_with_bookmark_enricher(
     validate_obsidian_dir(obsidian_dir)?;
 
     let start_time = std::time::Instant::now();
-    info!("=== Publisher Started ===");
-    info!("Input directory: {}", obsidian_dir.display());
-    info!("Output directory: {}", output_dir.display());
+    info!("publisher started");
 
     let markdown_files = scan_markdown_files(obsidian_dir)?;
-    info!("Found {} markdown files", markdown_files.len());
+    info!(file_count = markdown_files.len(), "scanned markdown files");
 
     let classified_files = classify_obsidian_files(markdown_files, obsidian_dir);
 
-    info!("Valid article files: {}", classified_files.articles.len());
-    info!("Valid page files: {}", classified_files.pages.len());
     info!(
-        "Valid home file: {}",
-        usize::from(classified_files.home.is_some())
+        article_count = classified_files.articles.len(),
+        page_count = classified_files.pages.len(),
+        home_count = usize::from(classified_files.home.is_some()),
+        category_count = classified_files.categories.len(),
+        skipped_count = classified_files.skipped,
+        error_count = classified_files.errors,
+        "classified markdown files"
     );
-    info!(
-        "Valid category files: {}",
-        classified_files.categories.len()
-    );
-    info!("Skipped files: {}", classified_files.skipped);
     if classified_files.errors > 0 {
         return Err(PublishError::ContentErrors {
             count: classified_files.errors,
@@ -140,30 +142,35 @@ pub async fn publish_with_bookmark_enricher(
     let validation =
         tokio::task::spawn_blocking(move || validate_site_artifacts(site_root)).await??;
     info!(
-        "Validated {} articles across {} categories",
-        validation.article_count, validation.category_count
+        article_count = validation.article_count,
+        category_count = validation.category_count,
+        "validated site artifacts"
     );
 
     let processed_count = site_artifacts.article_index.len();
     let duration = start_time.elapsed();
 
-    info!("=== Processing Summary ===");
-    info!("Successfully processed: {processed_count} files");
-    info!("  Skipped: {skipped} files");
-    info!("  Processing time: {duration:.2?}");
-    info!("Output directory: {}", output_dir.display());
+    info!(
+        processed_count,
+        skipped_count = skipped,
+        processing_time_ms = duration.as_millis(),
+        "publisher completed"
+    );
 
     if !site_artifacts.article_index.is_empty() {
-        info!("Processed files:");
         for article in &site_artifacts.article_index {
-            info!("  • {} ({})", article.title.as_str(), article.slug.as_str());
+            info!(
+                title = article.title.as_str(),
+                slug = article.slug.as_str(),
+                "processed article"
+            );
         }
     }
 
-    info!("=== Publisher Completed ===");
     Ok(())
 }
 
+#[tracing::instrument(skip_all, fields(source_key = %parsed_file.source_key), err)]
 async fn process_article(
     parsed_file: ParsedArticleFile,
     link_index: &links::Index,
@@ -183,6 +190,7 @@ async fn process_article(
     .await
 }
 
+#[tracing::instrument(skip_all, fields(source_key = %parsed_file.source_key), err)]
 async fn process_page(
     parsed_file: ParsedPageFile,
     link_index: &links::Index,
@@ -197,6 +205,7 @@ async fn process_page(
     .await
 }
 
+#[tracing::instrument(skip_all, fields(source_key = %parsed_file.source_key), err)]
 async fn process_home(
     parsed_file: ParsedHomeFile,
     link_index: &links::Index,
@@ -211,6 +220,7 @@ async fn process_home(
     .await
 }
 
+#[tracing::instrument(skip_all, fields(source_key = %parsed_file.source_key), err)]
 async fn process_category(
     parsed_file: ParsedCategoryFile,
     link_index: &links::Index,
@@ -233,6 +243,6 @@ where
     T: Send + 'static,
 {
     let (result, output_file_path) = tokio::task::spawn_blocking(write).await??;
-    info!("...processed {}", output_file_path.display());
+    info!(output_file = %output_file_path.display(), "wrote artifact");
     Ok(result)
 }

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -1,6 +1,6 @@
 use super::{bookmark::BookmarkEnricher, html::convert_markdown_to_html};
 use crate::{error::Result, links};
-use log::warn;
+use tracing::warn;
 
 pub(super) async fn render(
     markdown: &str,
@@ -11,7 +11,7 @@ pub(super) async fn render(
     let html = convert_markdown_to_html(&markdown)?;
     let fallback = html.clone();
     Ok(enrich(html).await.unwrap_or_else(|error| {
-        warn!("Warning: Failed to convert simple bookmarks to rich bookmarks: {error}");
+        warn!(%error, "failed to enrich bookmarks");
         fallback
     }))
 }

--- a/crates/publish/src/render/bookmark.rs
+++ b/crates/publish/src/render/bookmark.rs
@@ -294,8 +294,8 @@ where
 /// Replaces simple bookmark markup with rich bookmark cards fetched from OGP metadata.
 async fn convert_simple_bookmarks_to_rich(html_content: &str) -> Result<String> {
     convert_simple_bookmarks_with(html_content, |url, original_title| async move {
-        fetch_ogp_metadata(&url).await.unwrap_or_else(|e| {
-            log::warn!("Warning: Failed to fetch OGP metadata for '{url}': {e}");
+        fetch_ogp_metadata(&url).await.unwrap_or_else(|error| {
+            tracing::warn!(%url, %error, "failed to fetch OGP metadata");
             create_fallback_bookmark_data(&url, &original_title)
         })
     })


### PR DESCRIPTION
## Summary

- replace publisher's `env_logger` / `log` usage with `tracing` and `tracing-subscriber`
- emit structured fields for publisher events
- instrument the publish pipeline and concurrent content processing with spans containing `source_key`
- use a fixed `INFO` maximum level instead of runtime `EnvFilter` configuration
- remove obsolete direct dependencies and update the lockfile

## Why

The publisher processes content concurrently. Tracing spans preserve the publish and content context across asynchronous polling, making interleaved logs attributable to the relevant source file.

Closes #158

## Impact

Publisher logs now use structured tracing output and always emit `INFO` or higher. `RUST_LOG` and `LOG_STYLE` no longer configure the publisher. The site/web logging implementation is unchanged.

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `cargo test -p publisher`
- `cargo clippy -p publisher --all-targets -- -D warnings`