### PR TITLE
refactor: align render test boundaries

### DIFF
--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -119,7 +119,6 @@ mod tests {
     use crate::classify::{
         ClassifiedFiles, ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile,
     };
-    use crate::render::convert_markdown_to_html;
     use crate::vault::{ContentKind, ObsidianFrontMatter};
     use domain::{Category, SectionPath, Slug};
     use rstest::rstest;
@@ -339,30 +338,5 @@ mod tests {
         let index = index(&[("article", "/tech/slug")]);
 
         assert_eq!(resolve_internal_links(markdown, &index), expected);
-    }
-
-    #[test]
-    fn converted_links_are_rendered_as_html() {
-        let markdown = r#"# My Article
-
-This is a test with [[Another Article|link]] and **bold** text.
-
-## Section Two
-
-- Item with [[Reference Note]]
-- Regular item"#;
-        let index = index(&[
-            ("Another Article", "/tech/def456"),
-            ("Reference Note", "/daily/ghi789"),
-        ]);
-
-        let markdown = resolve_internal_links(markdown, &index);
-        let html = convert_markdown_to_html(&markdown).unwrap();
-
-        assert!(html.contains("<h1>My Article</h1>"));
-        assert!(html.contains("<a href=\"/tech/def456\">link</a>"));
-        assert!(html.contains("<a href=\"/daily/ghi789\">Reference Note</a>"));
-        assert!(html.contains("<strong>bold</strong>"));
-        assert!(html.contains("<ul>"));
     }
 }

--- a/crates/publish/src/render.rs
+++ b/crates/publish/src/render.rs
@@ -7,6 +7,3 @@ mod katex;
 pub use bookmark::BookmarkEnricher;
 pub(crate) use bookmark::rich_bookmark_enricher;
 pub(crate) use document::{render_article, render_category, render_home, render_page};
-
-#[cfg(test)]
-pub(crate) use html::convert_markdown_to_html;

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -20,7 +20,32 @@ pub(super) async fn render(
 mod tests {
     use super::*;
     use crate::error::PublishError;
+    use indoc::indoc;
     use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_render_converts_internal_links_to_html() {
+        let link_index = links::Index::default();
+        let enrich: BookmarkEnricher = Arc::new(|html| Box::pin(async move { Ok(html) }));
+        let markdown = indoc! {r#"
+            # My Article
+
+            This is a test with [[article|link]] and **bold** text.
+
+            ## Section Two
+
+            - Item with [[reference]]
+            - Regular item
+        "#};
+
+        let html = render(markdown, &link_index, &enrich).await.unwrap();
+
+        assert!(html.contains("<h1>My Article</h1>"));
+        assert!(html.contains("<a href=\"/article\">link</a>"));
+        assert!(html.contains("<a href=\"/reference\">reference</a>"));
+        assert!(html.contains("<strong>bold</strong>"));
+        assert!(html.contains("<ul>"));
+    }
 
     #[tokio::test]
     async fn test_render_falls_back_to_html_when_bookmark_enrichment_fails() {

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -19,13 +19,25 @@ pub(super) async fn render(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::PublishError;
+    use crate::{
+        classify::{ClassifiedFiles, ParsedArticleFile},
+        error::PublishError,
+        vault::{ContentKind, ObsidianFrontMatter},
+    };
+    use domain::{Category, SectionPath, Slug};
     use indoc::indoc;
     use std::sync::Arc;
 
     #[tokio::test]
     async fn test_render_converts_internal_links_to_html() {
-        let link_index = links::Index::default();
+        let files = ClassifiedFiles {
+            articles: vec![
+                parsed_article("notes/article", Category::Tech, "def456"),
+                parsed_article("notes/reference", Category::Daily, "ghi789"),
+            ],
+            ..Default::default()
+        };
+        let link_index = links::Index::from_classified_files(&files);
         let enrich: BookmarkEnricher = Arc::new(|html| Box::pin(async move { Ok(html) }));
         let markdown = indoc! {r#"
             # My Article
@@ -41,8 +53,8 @@ mod tests {
         let html = render(markdown, &link_index, &enrich).await.unwrap();
 
         assert!(html.contains("<h1>My Article</h1>"));
-        assert!(html.contains("<a href=\"/article\">link</a>"));
-        assert!(html.contains("<a href=\"/reference\">reference</a>"));
+        assert!(html.contains("<a href=\"/tech/def456\">link</a>"));
+        assert!(html.contains("<a href=\"/daily/ghi789\">reference</a>"));
         assert!(html.contains("<strong>bold</strong>"));
         assert!(html.contains("<ul>"));
     }
@@ -57,5 +69,27 @@ mod tests {
         let html = render("# Hello", &link_index, &enrich).await.unwrap();
 
         assert_eq!(html, "<h1>Hello</h1>\n");
+    }
+
+    fn parsed_article(source_key: &str, category: Category, slug: &str) -> ParsedArticleFile {
+        ParsedArticleFile {
+            category,
+            slug: Slug::new(slug.to_string()).unwrap(),
+            source_key: source_key.to_string(),
+            section_path: SectionPath::default(),
+            markdown_body: String::new(),
+            front_matter: ObsidianFrontMatter {
+                title: "Article".to_string(),
+                kind: ContentKind::Article,
+                tags: None,
+                summary: None,
+                is_completed: true,
+                priority: None,
+                created: "2025-01-01T00:00:00+09:00".to_string(),
+                updated: "2025-01-01T00:00:00+09:00".to_string(),
+                category: Some(category.as_str().to_string()),
+                page: None,
+            },
+        }
     }
 }


### PR DESCRIPTION
## Summary

- move the internal-link-to-HTML integration coverage from `links` to `render::body`
- keep `links` tests focused on wikilink resolution
- remove the test-only re-export of `convert_markdown_to_html` from `render`
- use `indoc!` for the multiline Markdown fixture

## Why

The integration test exercises the shared body rendering pipeline rather than link resolution alone. Keeping it in `render::body` makes the module boundary explicit and avoids widening `render` solely for a sibling module's test.

## Impact

Production rendering behavior is unchanged. This PR only reorganizes test ownership and narrows the module surface before the separate `html.rs` refactor.

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
