### PR TITLE
refactor: resolve wikilinks as events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 依存と配置の境界:
 
 - `crates/domain`: 公開コンテンツの純粋なdomain model・ルールと、publisher / readerが共有する契約。I/O、`async`、AWS SDK、Axum、Leptos を持ち込まない。WASM 互換を意識する
-- `crates/publish`: 単一のpublisher crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`render` moduleをcontent描画の境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。`render`内ではcontent kind別の組み立て、共通本文処理、数式eventを含むHTML変換、bookmark enrichmentを分離する。publisher専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
+- `crates/publish`: 単一のpublisher crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`links` moduleを公開URL索引とWikiLink event解決の境界、`render` moduleをcontent描画の境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。`render`内ではcontent kind別の組み立て、共通本文処理、WikiLinkと数式を含む単一の`pulldown-cmark` event pipelineによるHTML変換、bookmark enrichmentを分離する。publisher専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
 - `crates/site/infra`: server が artifact を読む外部境界（local / S3、設定、将来のcache）。vault読取、Markdown変換、uploadを置かない
 - `crates/site/server`: Axum + Leptos SSR host、reader注入、API、health/readiness、release-aware conditional GET
 - `crates/site/web`: Leptos UI / route / metadataと、artifact内のmath spanに対するKaTeX描画。SSR時もstorage実装へ直接依存しない

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -61,24 +61,24 @@ pub(crate) fn resolve_wikilinks<'a>(
 ) -> impl Iterator<Item = Event<'a>> + 'a {
     events.map(move |event| match event {
         Event::Start(Tag::Link {
-            link_type: link_type @ LinkType::WikiLink { .. },
+            link_type: link_type @ LinkType::WikiLink { has_pothole },
             dest_url,
             title,
             id,
         }) => Event::Start(Tag::Link {
             link_type,
-            dest_url: resolve_wikilink_destination(dest_url.trim(), index),
+            dest_url: resolve_wikilink_destination(&dest_url, has_pothole, index),
             title,
             id,
         }),
         Event::Start(Tag::Image {
-            link_type: link_type @ LinkType::WikiLink { .. },
+            link_type: link_type @ LinkType::WikiLink { has_pothole },
             dest_url,
             title,
             id,
         }) => Event::Start(Tag::Image {
             link_type,
-            dest_url: resolve_wikilink_destination(dest_url.trim(), index),
+            dest_url: resolve_wikilink_destination(&dest_url, has_pothole, index),
             title,
             id,
         }),
@@ -86,7 +86,19 @@ pub(crate) fn resolve_wikilinks<'a>(
     })
 }
 
-fn resolve_wikilink_destination<'a>(target: &str, index: &'a Index) -> CowStr<'a> {
+fn resolve_wikilink_destination<'a>(
+    target: &str,
+    has_pothole: bool,
+    index: &'a Index,
+) -> CowStr<'a> {
+    let target = target.trim();
+    // The table prepass escapes a piped WikiLink delimiter, leaving this suffix on its target.
+    let target = if has_pothole {
+        target.strip_suffix('\\').unwrap_or(target)
+    } else {
+        target
+    };
+
     match index.resolve(target) {
         Some(href) => href.into(),
         None => {
@@ -296,6 +308,19 @@ mod tests {
                 ("image", "/daily/xyz789abc".to_string()),
                 ("image", "/daily/xyz789abc".to_string()),
                 ("link", "/missing".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_wikilinks_accepts_table_escaped_pipe_delimiters() {
+        let index = index(&[("article", "/tech/slug")]);
+
+        assert_eq!(
+            resolved_destinations(r"[[article\|Label]] ![[article\|Alt]]", &index),
+            vec![
+                ("link", "/tech/slug".to_string()),
+                ("image", "/tech/slug".to_string()),
             ]
         );
     }

--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -1,5 +1,5 @@
 use crate::classify::ClassifiedFiles;
-use pulldown_cmark::{Event, LinkType, Options, Parser, Tag};
+use pulldown_cmark::{CowStr, Event, LinkType, Tag};
 use std::collections::HashMap;
 
 const ROUTED_PAGE_KEYS: &[&str] = &["about"];
@@ -54,63 +54,46 @@ impl Index {
     }
 }
 
-/// Resolve Obsidian internal links to published Markdown links outside code.
-/// The vault is expected to contain valid Obsidian syntax; malformed links remain unchanged.
-pub(crate) fn resolve_internal_links(content: &str, index: &Index) -> String {
-    let mut resolved = String::with_capacity(content.len());
-    let mut copied_until = 0;
-
-    for (event, range) in Parser::new_ext(content, Options::ENABLE_WIKILINKS).into_offset_iter() {
-        if !matches!(
-            event,
-            Event::Start(Tag::Link {
-                link_type: LinkType::WikiLink { .. },
-                ..
-            })
-        ) {
-            continue;
-        }
-
-        resolved.push_str(&content[copied_until..range.start]);
-        resolved.push_str(&resolve_internal_link(&content[range.clone()], index));
-        copied_until = range.end;
-    }
-
-    resolved.push_str(&content[copied_until..]);
-    resolved
+/// Resolve Obsidian WikiLink events to published URLs.
+pub(crate) fn resolve_wikilinks<'a>(
+    events: impl Iterator<Item = Event<'a>> + 'a,
+    index: &'a Index,
+) -> impl Iterator<Item = Event<'a>> + 'a {
+    events.map(move |event| match event {
+        Event::Start(Tag::Link {
+            link_type: link_type @ LinkType::WikiLink { .. },
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Link {
+            link_type,
+            dest_url: resolve_wikilink_destination(dest_url.trim(), index),
+            title,
+            id,
+        }),
+        Event::Start(Tag::Image {
+            link_type: link_type @ LinkType::WikiLink { .. },
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Image {
+            link_type,
+            dest_url: resolve_wikilink_destination(dest_url.trim(), index),
+            title,
+            id,
+        }),
+        event => event,
+    })
 }
 
-fn resolve_internal_link(link: &str, index: &Index) -> String {
-    let link_content = link
-        .strip_prefix("[[")
-        .and_then(|link| link.strip_suffix("]]"))
-        .expect("pulldown-cmark should return the complete internal link range");
-    let (link_target, display_text) = link_content.split_once('|').map_or(
-        (link_content.trim(), link_content.trim()),
-        |(target, display)| (target.trim(), display.trim()),
-    );
-    let escaped_href = match index.resolve(link_target) {
-        Some(href) => escape_markdown_link_destination(href),
+fn resolve_wikilink_destination<'a>(target: &str, index: &'a Index) -> CowStr<'a> {
+    match index.resolve(target) {
+        Some(href) => href.into(),
         None => {
-            tracing::warn!(%link_target, "internal link target was not found");
-            escape_markdown_link_destination(&format!("/{link_target}"))
+            tracing::warn!(%target, "internal link target was not found");
+            format!("/{target}").into()
         }
-    };
-
-    format!(
-        "[{}]({escaped_href})",
-        escape_markdown_link_text(display_text),
-    )
-}
-
-fn escape_markdown_link_text(text: &str) -> String {
-    text.replace('\\', "\\\\")
-        .replace('[', "\\[")
-        .replace(']', "\\]")
-}
-
-fn escape_markdown_link_destination(destination: &str) -> String {
-    destination.replace(')', "\\)")
+    }
 }
 
 #[cfg(test)]
@@ -121,6 +104,7 @@ mod tests {
     };
     use crate::vault::{ContentKind, ObsidianFrontMatter};
     use domain::{Category, SectionPath, Slug};
+    use pulldown_cmark::{Options, Parser};
     use rstest::rstest;
 
     fn index(routes: &[(&str, &str)]) -> Index {
@@ -206,6 +190,25 @@ mod tests {
         }
     }
 
+    fn resolved_destinations(markdown: &str, index: &Index) -> Vec<(&'static str, String)> {
+        let parser = Parser::new_ext(markdown, Options::ENABLE_WIKILINKS);
+        resolve_wikilinks(parser, index)
+            .filter_map(|event| match event {
+                Event::Start(Tag::Link {
+                    link_type: LinkType::WikiLink { .. },
+                    dest_url,
+                    ..
+                }) => Some(("link", dest_url.to_string())),
+                Event::Start(Tag::Image {
+                    link_type: LinkType::WikiLink { .. },
+                    dest_url,
+                    ..
+                }) => Some(("image", dest_url.to_string())),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn index_is_built_from_all_published_content() {
         let files = ClassifiedFiles {
@@ -276,67 +279,38 @@ mod tests {
     }
 
     #[test]
-    fn resolve_internal_links_to_markdown() {
+    fn resolve_wikilinks_to_published_urls() {
         let index = index(&[
             ("notes/another-note", "/tech/abc123def"),
             ("filename", "/daily/xyz789abc"),
         ]);
 
         assert_eq!(
-            resolve_internal_links("Check out [[another-note]] for more info.", &index),
-            "Check out [another-note](/tech/abc123def) for more info."
-        );
-        assert_eq!(
-            resolve_internal_links("See [[filename|Custom Display Text]] here.", &index),
-            "See [Custom Display Text](/daily/xyz789abc) here."
-        );
-        assert_eq!(
-            resolve_internal_links("Link to [[nonexistent]] file.", &index),
-            "Link to [nonexistent](/nonexistent) file."
-        );
-        assert_eq!(
-            resolve_internal_links("This is normal text with no special links.", &index),
-            "This is normal text with no special links."
-        );
-    }
-
-    #[test]
-    fn resolve_internal_links_escapes_markdown_link_parts() {
-        let index = index(&[("File with <script>", "/tech/abc123")]);
-
-        assert_eq!(
-            resolve_internal_links("[[File with <script>|Display & test]]", &index),
-            "[Display & test](/tech/abc123)"
-        );
-        assert_eq!(
-            resolve_internal_links("[[File \"quoted\"|Text with 'quotes']]", &index),
-            "[Text with 'quotes'](/File \"quoted\")"
+            resolved_destinations(
+                "[[another-note]] [[filename|Label]] ![[filename]] ![[filename|Alt]] [[missing]]",
+                &index,
+            ),
+            vec![
+                ("link", "/tech/abc123def".to_string()),
+                ("link", "/daily/xyz789abc".to_string()),
+                ("image", "/daily/xyz789abc".to_string()),
+                ("image", "/daily/xyz789abc".to_string()),
+                ("link", "/missing".to_string()),
+            ]
         );
     }
 
     #[rstest]
-    #[case::inline_code(
-        "`[[article]]` and [[article]]",
-        "`[[article]]` and [article](/tech/slug)"
-    )]
-    #[case::fenced_code_block(
-        "```markdown\n[[article]]\n```\n\n[[article]]",
-        "```markdown\n[[article]]\n```\n\n[article](/tech/slug)"
-    )]
-    #[case::tilde_fenced_code_block(
-        "~~~markdown\n[[article]]\n~~~\n\n[[article]]",
-        "~~~markdown\n[[article]]\n~~~\n\n[article](/tech/slug)"
-    )]
-    #[case::indented_code_block(
-        "    [[article]]\n\n[[article]]",
-        "    [[article]]\n\n[article](/tech/slug)"
-    )]
-    fn resolve_internal_links_preserves_syntax_in_code(
-        #[case] markdown: &str,
-        #[case] expected: &str,
-    ) {
+    #[case::inline_code("`[[ignored]]` and [[article]]")]
+    #[case::fenced_code_block("```markdown\n[[ignored]]\n```\n\n[[article]]")]
+    #[case::tilde_fenced_code_block("~~~markdown\n[[ignored]]\n~~~\n\n[[article]]")]
+    #[case::indented_code_block("    [[ignored]]\n\n[[article]]")]
+    fn resolve_wikilinks_ignores_syntax_in_code(#[case] markdown: &str) {
         let index = index(&[("article", "/tech/slug")]);
 
-        assert_eq!(resolve_internal_links(markdown, &index), expected);
+        assert_eq!(
+            resolved_destinations(markdown, &index),
+            vec![("link", "/tech/slug".to_string())]
+        );
     }
 }

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -80,6 +80,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_render_preserves_piped_wikilinks_inside_table_cells() {
+        let files = ClassifiedFiles {
+            articles: vec![parsed_article("notes/article", Category::Tech, "def456")],
+            ..Default::default()
+        };
+        let link_index = links::Index::from_classified_files(&files);
+        let enrich: BookmarkEnricher = Arc::new(|html| Box::pin(async move { Ok(html) }));
+        let markdown = indoc! {r#"
+            | [[article|Header link]] | ![[article|Header embed]] |
+            | --- | --- |
+            | [[article|Cell link]] | ![[article|Cell embed]] |
+        "#};
+
+        let html = render(markdown, &link_index, &enrich).await.unwrap();
+
+        assert!(html.starts_with("<table>"), "unexpected html:\n{html}");
+        assert!(
+            html.contains(r#"<th><a href="/tech/def456">Header link</a></th>"#),
+            "unexpected html:\n{html}"
+        );
+        assert!(
+            html.contains(r#"<th><img src="/tech/def456" alt="Header embed" /></th>"#),
+            "unexpected html:\n{html}"
+        );
+        assert!(
+            html.contains(r#"<td><a href="/tech/def456">Cell link</a></td>"#),
+            "unexpected html:\n{html}"
+        );
+        assert!(
+            html.contains(r#"<td><img src="/tech/def456" alt="Cell embed" /></td>"#),
+            "unexpected html:\n{html}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_render_escapes_wikilink_text_and_destination() {
         let files = ClassifiedFiles {
             articles: vec![parsed_article("notes/article", Category::Tech, "def456")],

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -7,8 +7,7 @@ pub(super) async fn render(
     link_index: &links::Index,
     enrich: &BookmarkEnricher,
 ) -> Result<String> {
-    let markdown = links::resolve_internal_links(markdown, link_index);
-    let html = convert_markdown_to_html(&markdown)?;
+    let html = convert_markdown_to_html(markdown, link_index)?;
     let fallback = html.clone();
     Ok(enrich(html).await.unwrap_or_else(|error| {
         warn!(%error, "failed to enrich bookmarks");
@@ -57,6 +56,48 @@ mod tests {
         assert!(html.contains("<a href=\"/daily/ghi789\">reference</a>"));
         assert!(html.contains("<strong>bold</strong>"));
         assert!(html.contains("<ul>"));
+    }
+
+    #[tokio::test]
+    async fn test_render_converts_internal_embeds_to_images() {
+        let files = ClassifiedFiles {
+            articles: vec![parsed_article("notes/article", Category::Tech, "def456")],
+            ..Default::default()
+        };
+        let link_index = links::Index::from_classified_files(&files);
+        let enrich: BookmarkEnricher = Arc::new(|html| Box::pin(async move { Ok(html) }));
+
+        let html = render(
+            "Embed ![[article]] and ![[article|Alt text]].",
+            &link_index,
+            &enrich,
+        )
+        .await
+        .unwrap();
+
+        assert!(html.contains(r#"<img src="/tech/def456" alt="article" />"#));
+        assert!(html.contains(r#"<img src="/tech/def456" alt="Alt text" />"#));
+    }
+
+    #[tokio::test]
+    async fn test_render_escapes_wikilink_text_and_destination() {
+        let files = ClassifiedFiles {
+            articles: vec![parsed_article("notes/article", Category::Tech, "def456")],
+            ..Default::default()
+        };
+        let link_index = links::Index::from_classified_files(&files);
+        let enrich: BookmarkEnricher = Arc::new(|html| Box::pin(async move { Ok(html) }));
+
+        let html = render(
+            "[[article|Display & <script>]] and [[File \"quoted\"|missing]]",
+            &link_index,
+            &enrich,
+        )
+        .await
+        .unwrap();
+
+        assert!(html.contains(r#"<a href="/tech/def456">Display &amp; &lt;script&gt;</a>"#));
+        assert!(html.contains(r#"<a href="/File%20%22quoted%22">missing</a>"#));
     }
 
     #[tokio::test]

--- a/crates/publish/src/render/html.rs
+++ b/crates/publish/src/render/html.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Result,
     links::{self, Index},
 };
-use pulldown_cmark::{CowStr, Event, Options, Parser, Tag, html};
+use pulldown_cmark::{CowStr, Event, LinkType, Options, Parser, Tag, html};
 use regex::Regex;
 use std::{borrow::Cow, ops::Range, sync::LazyLock};
 
@@ -19,7 +19,7 @@ pub(crate) fn convert_markdown_to_html(
     markdown_content: &str,
     link_index: &Index,
 ) -> Result<String> {
-    let markdown_content = escape_math_pipes_for_table_parser(markdown_content);
+    let markdown_content = escape_pipes_for_table_parser(markdown_content);
 
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
@@ -51,8 +51,48 @@ fn add_legacy_math_classes(html: &str) -> String {
     )
 }
 
-fn escape_math_pipes_for_table_parser(markdown: &str) -> Cow<'_, str> {
-    let math_ranges = Parser::new_ext(markdown, Options::ENABLE_MATH)
+fn escape_pipes_for_table_parser(markdown: &str) -> Cow<'_, str> {
+    let protected_ranges = pipe_sensitive_ranges(markdown);
+
+    if protected_ranges.is_empty() {
+        return Cow::Borrowed(markdown);
+    }
+
+    // A one-byte replacement keeps parser offsets aligned with the original Markdown.
+    let table_probe = replace_pipes_in_ranges(markdown, &protected_ranges, "/");
+    let table_ranges = Parser::new_ext(
+        &table_probe,
+        Options::ENABLE_TABLES | Options::ENABLE_MATH | Options::ENABLE_WIKILINKS,
+    )
+    .into_offset_iter()
+    .filter_map(|(event, range)| match event {
+        Event::Start(Tag::Table(_)) => Some(range),
+        _ => None,
+    })
+    .collect::<Vec<_>>();
+
+    let table_ranges_to_escape = protected_ranges
+        .into_iter()
+        .filter(|range| {
+            table_ranges
+                .iter()
+                .any(|table_range| table_range.start <= range.start && range.end <= table_range.end)
+        })
+        .collect::<Vec<_>>();
+
+    if table_ranges_to_escape.is_empty() {
+        return Cow::Borrowed(markdown);
+    }
+
+    Cow::Owned(replace_pipes_in_ranges(
+        markdown,
+        &table_ranges_to_escape,
+        r"\|",
+    ))
+}
+
+fn pipe_sensitive_ranges(markdown: &str) -> Vec<Range<usize>> {
+    let mut ranges = Parser::new_ext(markdown, Options::ENABLE_MATH)
         .into_offset_iter()
         .filter_map(|(event, range)| match event {
             Event::InlineMath(_) | Event::DisplayMath(_)
@@ -64,34 +104,38 @@ fn escape_math_pipes_for_table_parser(markdown: &str) -> Cow<'_, str> {
         })
         .collect::<Vec<_>>();
 
-    if math_ranges.is_empty() {
-        return Cow::Borrowed(markdown);
+    ranges.extend(
+        Parser::new_ext(markdown, Options::ENABLE_WIKILINKS)
+            .into_offset_iter()
+            .filter_map(|(event, range)| match event {
+                Event::Start(
+                    Tag::Link {
+                        link_type: LinkType::WikiLink { has_pothole: true },
+                        ..
+                    }
+                    | Tag::Image {
+                        link_type: LinkType::WikiLink { has_pothole: true },
+                        ..
+                    },
+                ) => Some(range),
+                _ => None,
+            }),
+    );
+
+    ranges.sort_unstable_by_key(|range| range.start);
+    let mut merged_ranges: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+
+    for range in ranges {
+        if let Some(previous) = merged_ranges.last_mut()
+            && range.start <= previous.end
+        {
+            previous.end = previous.end.max(range.end);
+            continue;
+        }
+        merged_ranges.push(range);
     }
 
-    // A one-byte replacement keeps parser offsets aligned with the original Markdown.
-    let table_probe = replace_pipes_in_ranges(markdown, &math_ranges, "/");
-    let table_ranges = Parser::new_ext(&table_probe, Options::ENABLE_TABLES | Options::ENABLE_MATH)
-        .into_offset_iter()
-        .filter_map(|(event, range)| match event {
-            Event::Start(Tag::Table(_)) => Some(range),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    let table_math_ranges = math_ranges
-        .into_iter()
-        .filter(|range| {
-            table_ranges
-                .iter()
-                .any(|table_range| table_range.start <= range.start && range.end <= table_range.end)
-        })
-        .collect::<Vec<_>>();
-
-    if table_math_ranges.is_empty() {
-        return Cow::Borrowed(markdown);
-    }
-
-    Cow::Owned(replace_pipes_in_ranges(markdown, &table_math_ranges, r"\|"))
+    merged_ranges
 }
 
 fn replace_pipes_in_ranges(markdown: &str, ranges: &[Range<usize>], replacement: &str) -> String {

--- a/crates/publish/src/render/html.rs
+++ b/crates/publish/src/render/html.rs
@@ -1,5 +1,8 @@
-use crate::error::Result;
-use pulldown_cmark::{Event, Options, Parser, Tag, html};
+use crate::{
+    error::Result,
+    links::{self, Index},
+};
+use pulldown_cmark::{CowStr, Event, Options, Parser, Tag, html};
 use regex::Regex;
 use std::{borrow::Cow, ops::Range, sync::LazyLock};
 
@@ -12,7 +15,10 @@ static HREF_ATTR_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"href="([^"]*)""#).expect("Invalid href regex"));
 
 /// Converts Markdown to sanitized HTML.
-pub(crate) fn convert_markdown_to_html(markdown_content: &str) -> Result<String> {
+pub(crate) fn convert_markdown_to_html(
+    markdown_content: &str,
+    link_index: &Index,
+) -> Result<String> {
     let markdown_content = escape_math_pipes_for_table_parser(markdown_content);
 
     let mut options = Options::empty();
@@ -22,11 +28,12 @@ pub(crate) fn convert_markdown_to_html(markdown_content: &str) -> Result<String>
     options.insert(Options::ENABLE_TASKLISTS);
     options.insert(Options::ENABLE_SMART_PUNCTUATION);
     options.insert(Options::ENABLE_MATH);
+    options.insert(Options::ENABLE_WIKILINKS);
 
     let parser = Parser::new_ext(&markdown_content, options);
+    let parser = links::resolve_wikilinks(parser, link_index);
     let mut html_output = String::with_capacity(markdown_content.len() * 2);
-    html::push_html(&mut html_output, sanitize_html(parser).into_iter());
-    let html_output = sanitize_anchor_hrefs(&html_output);
+    html::push_html(&mut html_output, sanitize_events(parser).into_iter());
     let html_output = repair_unparsed_strong_markers(&html_output);
 
     Ok(add_legacy_math_classes(&html_output))
@@ -101,41 +108,79 @@ fn replace_pipes_in_ranges(markdown: &str, ranges: &[Range<usize>], replacement:
     replaced
 }
 
-fn sanitize_anchor_hrefs(html: &str) -> String {
+fn sanitize_bookmark_href(html: &str) -> String {
     HREF_ATTR_RE
         .replace_all(html, |caps: &regex::Captures| {
             let href = &caps[1];
-            let sanitized_href = if is_safe_href(href) { href } else { "#" };
+            let sanitized_href = if is_safe_destination(href) { href } else { "#" };
             format!("href=\"{sanitized_href}\"")
         })
         .to_string()
 }
 
-fn is_safe_href(href: &str) -> bool {
-    let href = href.trim();
+fn sanitize_destination(destination: CowStr<'_>) -> CowStr<'_> {
+    if is_safe_destination(&destination) {
+        destination
+    } else {
+        CowStr::Borrowed("#")
+    }
+}
 
-    if href.is_empty() {
+fn is_safe_destination(destination: &str) -> bool {
+    let destination = destination.trim();
+
+    if destination.is_empty() {
         return false;
     }
 
-    if href.starts_with('#') {
+    if destination.starts_with('#') {
         return true;
     }
 
-    if href.starts_with('/') {
-        return !href.starts_with("//");
+    if destination.starts_with('/') {
+        return !destination.starts_with("//");
     }
 
-    if href.starts_with("http://") || href.starts_with("https://") || href.starts_with("mailto:") {
+    if destination.starts_with("http://")
+        || destination.starts_with("https://")
+        || destination.starts_with("mailto:")
+    {
         return true;
     }
 
-    !href.contains(':') && !href.contains('\\') && !href.starts_with('.')
+    !destination.contains(':') && !destination.contains('\\') && !destination.starts_with('.')
 }
 
-/// Escapes all raw HTML events except valid `<div class="bookmark">` blocks.
-/// Accumulates each potential bookmark block and validates with SAFE_BOOKMARK_RE before passing through.
-fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> {
+fn sanitize_destination_event(event: Event<'_>) -> Event<'_> {
+    match event {
+        Event::Start(Tag::Link {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Link {
+            link_type,
+            dest_url: sanitize_destination(dest_url),
+            title,
+            id,
+        }),
+        Event::Start(Tag::Image {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Image {
+            link_type,
+            dest_url: sanitize_destination(dest_url),
+            title,
+            id,
+        }),
+        event => event,
+    }
+}
+
+/// Sanitizes link destinations and raw HTML before HTML generation.
+fn sanitize_events<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> {
     let mut result: Vec<Event<'a>> = Vec::new();
     let mut in_bookmark = false;
     let mut bookmark_buffer = String::new();
@@ -159,7 +204,7 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
                         bookmark_buffer.clear();
 
                         if SAFE_BOOKMARK_RE.is_match(&bookmark_part) {
-                            result.push(Event::Html(bookmark_part.into()));
+                            result.push(Event::Html(sanitize_bookmark_href(&bookmark_part).into()));
                         } else {
                             result.push(Event::Text(bookmark_part.into()));
                         }
@@ -178,7 +223,7 @@ fn sanitize_html<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Event<'a>> 
                         result.push(Event::Text(buffer.into()));
                     }
                 }
-                result.push(other);
+                result.push(sanitize_destination_event(other));
             }
         }
     }
@@ -268,6 +313,10 @@ mod tests {
     use super::*;
     use indoc::indoc;
     use rstest::*;
+
+    fn convert_markdown_to_html(markdown: &str) -> Result<String> {
+        super::convert_markdown_to_html(markdown, &Index::default())
+    }
 
     #[rstest]
     #[case::basic_markdown(
@@ -463,6 +512,16 @@ mod tests {
             result.contains("href=\"#\""),
             "unsafe href should be neutralized"
         );
+        assert!(!result.contains("javascript:alert"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_sanitizes_javascript_image_source() {
+        let markdown = "![image](javascript:alert('xss'))";
+
+        let result = convert_markdown_to_html(markdown).unwrap();
+
+        assert!(result.contains("src=\"#\""));
         assert!(!result.contains("javascript:alert"));
     }
 

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -143,6 +143,7 @@ async fn test_publish_resolves_links_to_all_content_kinds() {
             [[about|About]]
             [[home|Home]]
             [[tech/index|Tech]]
+            ![[about|About image]]
         "#},
     )
     .unwrap();
@@ -186,6 +187,7 @@ async fn test_publish_resolves_links_to_all_content_kinds() {
     assert!(html.contains(r#"href="/about">About</a>"#));
     assert!(html.contains(r#"href="/">Home</a>"#));
     assert!(html.contains(r#"href="/tech">Tech</a>"#));
+    assert!(html.contains(r#"src="/about" alt="About image""#));
 }
 
 #[tokio::test]

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -12,8 +12,8 @@
 
 1. private な Obsidian リポジトリを git submodule として取得する
 2. `crates/publish` の vault module が Markdown を走査し、frontmatter と本文を読み取る
-3. classify / links module が公開種別を確定し、Obsidian link を解決する
-4. render module が Markdown の HTML 変換と bookmark enrichment を行う
+3. classify module が公開種別を確定し、links module が公開URLの索引を構築する
+4. render module が単一の`pulldown-cmark` event pipeline内でObsidian link / embedを解決し、MarkdownのHTML変換とbookmark enrichmentを行う
 5. artifacts module が `site/` 配下の HTML / JSON を組み立てる
 6. GitHub Actions が artifact を immutable release として S3 に配置し、`current.json` を最後に切り替える
 7. `crates/site/server` と `crates/site/web` が `crates/site/infra` 経由で release snapshot を読んで SSR する
@@ -68,8 +68,8 @@ okawak_blog/
   - crate外向けAPIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に限定する
   - path処理の対応環境はmacOSとLinuxとし、Windows形式のpathは対象外とする
   - vault moduleによるObsidian vault走査、Markdown読込、frontmatter parse
-  - links moduleによる全公開contentのvault相対source keyと公開URLの索引構築、およびObsidian link解決
-  - render moduleによるcontent kindごとの組み立て、共通本文処理、`pulldown-cmark`の数式eventを含むMarkdownからHTMLへの変換、外部HTTPを伴うbookmark enrichment。数式spanはruntime移行中の互換性のため`.math-*`と`.okawak-katex-*`を併記する
+  - links moduleによる全公開contentのvault相対source keyと公開URLの索引構築、およびWikiLink link / image eventの公開URL解決
+  - render moduleによるcontent kindごとの組み立て、共通本文処理、WikiLinkと数式を含む単一の`pulldown-cmark` event pipelineによるMarkdownからHTMLへの変換、外部HTTPを伴うbookmark enrichment。数式spanはruntime移行中の互換性のため`.math-*`と`.okawak-katex-*`を併記する
   - classify moduleによる公開種別の確定と`section_path`の導出
   - artifacts moduleによるartifact構築、`site/`配下への書込み、生成結果のvalidation
   - `ObsidianFrontMatter`と`ContentKind`はpublisher入力形式として内部に保持する


### PR DESCRIPTION
## Summary

- resolve WikiLink link and image events directly in the `pulldown-cmark` event pipeline
- remove the intermediate Markdown rewrite and manual link escaping
- render `![[target]]` and piped embeds as images with resolved public URLs
- validate link and image destinations before HTML generation while preserving bookmark href validation
- document the revised `links` / `render` responsibility boundary

## Why

WikiLinks were previously parsed, rewritten into Markdown links, and parsed again for HTML generation. Resolving the parser events directly lets `pulldown-cmark` own WikiLink parsing, code-block exclusion, display text handling, and HTML escaping while keeping route lookup in the `links` module.

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `git diff --check`

Closes #172
