### PR TITLE
refactor: simplify table wikilink workaround

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - 常に日本語で簡潔に会話する
 - commit は署名付きで作る。commit 前に署名設定を確認する
 - ユーザーの既存差分を無断で破棄・上書きしない
+- GitHub PRのreview threadへ対応した場合は、修正をpushした後に該当threadをresolveする
 
 ## リポジトリの位置付け
 

--- a/crates/publish/src/render/html.rs
+++ b/crates/publish/src/render/html.rs
@@ -63,7 +63,7 @@ fn escape_table_wikilink_pipes(markdown: &str) -> Cow<'_, str> {
 }
 
 fn piped_wikilink_ranges(markdown: &str) -> Vec<Range<usize>> {
-    Parser::new_ext(markdown, Options::ENABLE_WIKILINKS)
+    let mut ranges = Parser::new_ext(markdown, Options::ENABLE_WIKILINKS)
         .into_offset_iter()
         .filter_map(|(event, range)| match event {
             Event::Start(
@@ -78,7 +78,22 @@ fn piped_wikilink_ranges(markdown: &str) -> Vec<Range<usize>> {
             ) => Some(range),
             _ => None,
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    ranges.sort_unstable_by_key(|range| range.start);
+
+    let mut disjoint_ranges: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        if let Some(previous) = disjoint_ranges.last_mut()
+            && range.start <= previous.end
+        {
+            previous.end = previous.end.max(range.end);
+        } else {
+            disjoint_ranges.push(range);
+        }
+    }
+
+    disjoint_ranges
 }
 
 fn replace_wikilink_pipes(
@@ -111,6 +126,7 @@ mod tests {
 
     #[rstest]
     #[case::link_outside_table("See [[Page|Label]].", "See [[Page|Label]].")]
+    #[case::nested_wikilinks_outside_table("![[image|[[page|text]]]]", "![[image|[[page|text]]]]")]
     #[case::link_inside_table(
         indoc! {r#"
             | Link |

--- a/crates/publish/src/render/html.rs
+++ b/crates/publish/src/render/html.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, ops::Range};
 
 /// Converts Markdown to sanitized HTML.
 pub(crate) fn convert_markdown_to_html(markdown_content: &str, link_index: &Index) -> String {
-    let markdown_content = escape_wikilink_pipes_for_table_parser(markdown_content);
+    let prepared_markdown = escape_table_wikilink_pipes(markdown_content);
 
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
@@ -16,23 +16,25 @@ pub(crate) fn convert_markdown_to_html(markdown_content: &str, link_index: &Inde
     options.insert(Options::ENABLE_MATH);
     options.insert(Options::ENABLE_WIKILINKS);
 
-    let parser = Parser::new_ext(&markdown_content, options);
+    let parser = Parser::new_ext(&prepared_markdown, options);
     let parser = links::resolve_wikilinks(parser, link_index);
-    let mut html_output = String::with_capacity(markdown_content.len() * 2);
+    let mut html_output = String::with_capacity(prepared_markdown.len() * 2);
     html::push_html(&mut html_output, sanitize::events(parser).into_iter());
 
     html_output
 }
 
-fn escape_wikilink_pipes_for_table_parser(markdown: &str) -> Cow<'_, str> {
-    let protected_ranges = wikilink_ranges(markdown);
+/// Escapes piped WikiLinks only where pulldown-cmark would treat their pipes as table separators.
+/// Remove this workaround once pulldown-cmark handles piped WikiLinks inside tables.
+fn escape_table_wikilink_pipes(markdown: &str) -> Cow<'_, str> {
+    let piped_wikilinks = piped_wikilink_ranges(markdown);
 
-    if protected_ranges.is_empty() {
+    if piped_wikilinks.is_empty() {
         return Cow::Borrowed(markdown);
     }
 
-    // A one-byte replacement keeps parser offsets aligned with the original Markdown.
-    let table_probe = replace_pipes_in_ranges(markdown, &protected_ranges, "/");
+    // Hide WikiLink pipes while detecting tables. `/` preserves the original byte offsets.
+    let table_probe = replace_wikilink_pipes(markdown, &piped_wikilinks, "/");
     let table_ranges = Parser::new_ext(
         &table_probe,
         Options::ENABLE_TABLES | Options::ENABLE_WIKILINKS,
@@ -44,28 +46,24 @@ fn escape_wikilink_pipes_for_table_parser(markdown: &str) -> Cow<'_, str> {
     })
     .collect::<Vec<_>>();
 
-    let table_ranges_to_escape = protected_ranges
+    let table_wikilinks = piped_wikilinks
         .into_iter()
-        .filter(|range| {
+        .filter(|wikilink| {
             table_ranges
                 .iter()
-                .any(|table_range| table_range.start <= range.start && range.end <= table_range.end)
+                .any(|table| table.start <= wikilink.start && wikilink.end <= table.end)
         })
         .collect::<Vec<_>>();
 
-    if table_ranges_to_escape.is_empty() {
+    if table_wikilinks.is_empty() {
         return Cow::Borrowed(markdown);
     }
 
-    Cow::Owned(replace_pipes_in_ranges(
-        markdown,
-        &table_ranges_to_escape,
-        r"\|",
-    ))
+    Cow::Owned(replace_wikilink_pipes(markdown, &table_wikilinks, r"\|"))
 }
 
-fn wikilink_ranges(markdown: &str) -> Vec<Range<usize>> {
-    let mut ranges = Parser::new_ext(markdown, Options::ENABLE_WIKILINKS)
+fn piped_wikilink_ranges(markdown: &str) -> Vec<Range<usize>> {
+    Parser::new_ext(markdown, Options::ENABLE_WIKILINKS)
         .into_offset_iter()
         .filter_map(|(event, range)| match event {
             Event::Start(
@@ -80,29 +78,18 @@ fn wikilink_ranges(markdown: &str) -> Vec<Range<usize>> {
             ) => Some(range),
             _ => None,
         })
-        .collect::<Vec<_>>();
-
-    ranges.sort_unstable_by_key(|range| range.start);
-    let mut merged_ranges: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
-
-    for range in ranges {
-        if let Some(previous) = merged_ranges.last_mut()
-            && range.start <= previous.end
-        {
-            previous.end = previous.end.max(range.end);
-            continue;
-        }
-        merged_ranges.push(range);
-    }
-
-    merged_ranges
+        .collect()
 }
 
-fn replace_pipes_in_ranges(markdown: &str, ranges: &[Range<usize>], replacement: &str) -> String {
+fn replace_wikilink_pipes(
+    markdown: &str,
+    wikilink_ranges: &[Range<usize>],
+    replacement: &str,
+) -> String {
     let mut replaced = String::with_capacity(markdown.len());
     let mut previous_end = 0;
 
-    for range in ranges {
+    for range in wikilink_ranges {
         replaced.push_str(&markdown[previous_end..range.start]);
         replaced.push_str(&markdown[range.clone()].replace('|', replacement));
         previous_end = range.end;
@@ -120,6 +107,36 @@ mod tests {
 
     fn convert_markdown_to_html(markdown: &str) -> String {
         super::convert_markdown_to_html(markdown, &Index::default())
+    }
+
+    #[rstest]
+    #[case::link_outside_table("See [[Page|Label]].", "See [[Page|Label]].")]
+    #[case::link_inside_table(
+        indoc! {r#"
+            | Link |
+            | --- |
+            | [[Page|Label]] |
+        "#},
+        indoc! {r#"
+            | Link |
+            | --- |
+            | [[Page\|Label]] |
+        "#}
+    )]
+    #[case::embed_inside_table(
+        indoc! {r#"
+            | Image |
+            | --- |
+            | ![[image.png|Alt]] |
+        "#},
+        indoc! {r#"
+            | Image |
+            | --- |
+            | ![[image.png\|Alt]] |
+        "#}
+    )]
+    fn test_escape_table_wikilink_pipes(#[case] markdown: &str, #[case] expected: &str) {
+        assert_eq!(escape_table_wikilink_pipes(markdown), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

- clarify the naming and flow of the temporary table WikiLink workaround
- remove unnecessary range sorting and merging
- add focused tests for links outside tables and link/embed syntax inside tables

## Validation

- `mise run format`
- `cargo test -p publish render::html`
- `mise run clippy`
- `mise run test`
- `git diff --check`

This keeps the workaround easy to identify and remove if pulldown-cmark gains native support.