### PR TITLE
refactor: model publishable content with value objects

### DIFF
--- a/crates/domain/src/artifact_document.rs
+++ b/crates/domain/src/artifact_document.rs
@@ -95,8 +95,8 @@ impl From<&PublishedArticleSummary> for ArticleSummaryDocument {
             description: summary.description.clone(),
             tags: summary.tags.clone(),
             priority: summary.priority,
-            created_at: summary.created_at.clone(),
-            updated_at: summary.updated_at.clone(),
+            created_at: summary.created_at.to_string(),
+            updated_at: summary.updated_at.to_string(),
         }
     }
 }
@@ -133,7 +133,7 @@ impl From<&CategoryIndex> for CategoryIndexDocument {
             category: index.category.as_str().to_string(),
             title: landing.map(|landing| landing.title.as_str().to_string()),
             description: landing.and_then(|landing| landing.description.clone()),
-            updated_at: landing.map(|landing| landing.updated_at.clone()),
+            updated_at: landing.map(|landing| landing.updated_at.to_string()),
             articles: index
                 .articles
                 .iter()
@@ -193,7 +193,7 @@ impl From<&SiteMetadata> for SiteMetadataDocument {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Category, CategoryLandingMeta, CategoryLandingMetaInput, PageKey, Slug, Title};
+    use crate::{Category, CategoryLandingMeta, PageKey, Slug, Timestamp, Title};
 
     fn release_pointer(prefix: &str) -> ArtifactReleasePointerDocument {
         ArtifactReleasePointerDocument {
@@ -267,8 +267,8 @@ mod tests {
             description: Some("Test description".to_string()),
             tags: vec!["test".to_string()],
             priority: Some(1),
-            created_at: "2025-01-01T00:00:00+09:00".to_string(),
-            updated_at: "2025-01-02T00:00:00+09:00".to_string(),
+            created_at: Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap(),
+            updated_at: Timestamp::new("2025-01-02T00:00:00+09:00".to_string()).unwrap(),
         };
 
         let json = serde_json::to_string(&ArticleSummaryDocument::from(&summary)).unwrap();
@@ -289,8 +289,8 @@ mod tests {
             description: None,
             tags: vec![],
             priority: None,
-            created_at: "2025-01-01T00:00:00+09:00".to_string(),
-            updated_at: "2025-01-02T00:00:00+09:00".to_string(),
+            created_at: Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap(),
+            updated_at: Timestamp::new("2025-01-02T00:00:00+09:00".to_string()).unwrap(),
         };
 
         let json = serde_json::to_string(&ArticleSummaryDocument::from(&summary)).unwrap();
@@ -365,13 +365,12 @@ mod tests {
 
     #[test]
     fn test_category_index_document_uses_landing_metadata() {
-        let landing = CategoryLandingMeta::new(CategoryLandingMetaInput {
+        let landing = CategoryLandingMeta {
             category: Category::Tech,
             title: Title::new("Technology".to_string()).unwrap(),
             description: Some("Technology landing".to_string()),
-            updated_at: "2025-01-02T00:00:00+09:00".to_string(),
-        })
-        .unwrap();
+            updated_at: Timestamp::new("2025-01-02T00:00:00+09:00".to_string()).unwrap(),
+        };
         let index = CategoryIndex {
             category: Category::Tech,
             landing: Some(landing),

--- a/crates/domain/src/entities.rs
+++ b/crates/domain/src/entities.rs
@@ -6,7 +6,7 @@ mod attributes;
 mod identifiers;
 
 use crate::error::DomainError;
-pub use attributes::{Category, SectionPath, Title};
+pub use attributes::{Category, SectionPath, Timestamp, Title};
 pub use identifiers::{PageKey, Slug};
 use serde::{Deserialize, Deserializer, de::Error as DeError};
 use std::str::FromStr;

--- a/crates/domain/src/entities/attributes.rs
+++ b/crates/domain/src/entities/attributes.rs
@@ -74,6 +74,48 @@ impl<'de> Deserialize<'de> for Title {
     }
 }
 
+/// RFC 3339 timestamp used by publishable content.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct Timestamp(String);
+
+impl Timestamp {
+    pub fn new(value: String) -> Result<Self> {
+        let value = value.trim();
+        chrono::DateTime::parse_from_rfc3339(value).map_err(|_| DomainError::InvalidTimestamp {
+            value: value.to_string(),
+        })?;
+
+        Ok(Self(value.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for Timestamp {
+    type Err = DomainError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::new(s.to_string())
+    }
+}
+
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Timestamp {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        super::deserialize_validated_string(deserializer)
+    }
+}
+
 /// Category constrained by an enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub enum Category {
@@ -136,7 +178,7 @@ impl<'de> Deserialize<'de> for Category {
 
 #[cfg(test)]
 mod tests {
-    use super::{Category, SectionPath, Title};
+    use super::{Category, SectionPath, Timestamp, Title};
 
     #[test]
     fn test_section_path_exposes_ordered_segments() {
@@ -168,6 +210,20 @@ mod tests {
     fn test_title_validates_unicode_character_count() {
         assert!(Title::new("あ".repeat(200)).is_ok());
         assert!(Title::new("あ".repeat(201)).is_err());
+    }
+
+    #[test]
+    fn test_timestamp_accepts_rfc3339_and_trims_whitespace() {
+        let timestamp = Timestamp::new("  2025-01-01T00:00:00+09:00  ".to_string()).unwrap();
+
+        assert_eq!(timestamp.as_str(), "2025-01-01T00:00:00+09:00");
+    }
+
+    #[test]
+    fn test_timestamp_rejects_invalid_values() {
+        for value in ["", "   ", "2025-01-01", "not-a-timestamp"] {
+            assert!(Timestamp::new(value.to_string()).is_err());
+        }
     }
 
     #[test]

--- a/crates/domain/src/error.rs
+++ b/crates/domain/src/error.rs
@@ -17,6 +17,9 @@ pub enum DomainError {
     #[error("無効なパスです: {path}")]
     InvalidPath { path: String },
 
+    #[error("invalid RFC 3339 timestamp: {value}")]
+    InvalidTimestamp { value: String },
+
     #[error("バリデーションエラー: {field}")]
     ValidationError { field: String },
 }

--- a/crates/domain/src/publishable.rs
+++ b/crates/domain/src/publishable.rs
@@ -71,6 +71,37 @@ pub struct CategoryLandingMeta {
     pub updated_at: Timestamp,
 }
 
+/// Rendered HTML body for a publishable category landing page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryLandingBody(String);
+
+impl CategoryLandingBody {
+    pub fn new(html: String) -> Result<Self> {
+        if html.trim().is_empty() {
+            return Err(DomainError::validation("html"));
+        }
+
+        Ok(Self(html))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Fully publishable category landing page used by the artifact pipeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishableCategoryLanding {
+    pub meta: CategoryLandingMeta,
+    pub body: CategoryLandingBody,
+}
+
+impl PublishableCategoryLanding {
+    pub fn new(meta: CategoryLandingMeta, body: CategoryLandingBody) -> Self {
+        Self { meta, body }
+    }
+}
+
 /// Category-specific index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CategoryIndex {
@@ -231,6 +262,14 @@ mod tests {
         let body = ArticleBody::new("<p>body</p>".to_string()).unwrap();
 
         assert_eq!(body.as_str(), "<p>body</p>");
+    }
+
+    #[test]
+    fn test_category_landing_body_validation() {
+        assert!(CategoryLandingBody::new("   ".to_string()).is_err());
+        let body = CategoryLandingBody::new("<p>category</p>".to_string()).unwrap();
+
+        assert_eq!(body.as_str(), "<p>category</p>");
     }
 
     #[test]

--- a/crates/domain/src/publishable.rs
+++ b/crates/domain/src/publishable.rs
@@ -1,6 +1,6 @@
 //! Domain models and pure functions for publishable site artifacts.
 
-use crate::{Category, DomainError, Result, SectionPath, Slug, Title};
+use crate::{Category, DomainError, Result, SectionPath, Slug, Timestamp, Title};
 use std::cmp::Ordering;
 
 /// Metadata for a publishable article.
@@ -13,51 +13,13 @@ pub struct ArticleMeta {
     pub description: Option<String>,
     pub tags: Vec<String>,
     pub priority: Option<i32>,
-    pub created_at: String,
-    pub updated_at: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ArticleMetaInput {
-    pub slug: Slug,
-    pub title: Title,
-    pub category: Category,
-    pub section_path: SectionPath,
-    pub description: Option<String>,
-    pub tags: Vec<String>,
-    pub priority: Option<i32>,
-    pub created_at: String,
-    pub updated_at: String,
-}
-
-impl ArticleMeta {
-    pub fn new(input: ArticleMetaInput) -> Result<Self> {
-        if input.created_at.trim().is_empty() {
-            return Err(DomainError::validation("created_at"));
-        }
-        if input.updated_at.trim().is_empty() {
-            return Err(DomainError::validation("updated_at"));
-        }
-
-        Ok(Self {
-            slug: input.slug,
-            title: input.title,
-            category: input.category,
-            section_path: input.section_path,
-            description: input.description,
-            tags: input.tags,
-            priority: input.priority,
-            created_at: input.created_at,
-            updated_at: input.updated_at,
-        })
-    }
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 /// Rendered HTML body for a publishable article.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ArticleBody {
-    pub html: String,
-}
+pub struct ArticleBody(String);
 
 impl ArticleBody {
     pub fn new(html: String) -> Result<Self> {
@@ -65,7 +27,11 @@ impl ArticleBody {
             return Err(DomainError::validation("html"));
         }
 
-        Ok(Self { html })
+        Ok(Self(html))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -92,8 +58,8 @@ pub struct PublishedArticleSummary {
     pub description: Option<String>,
     pub tags: Vec<String>,
     pub priority: Option<i32>,
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 /// Metadata for a rendered category landing page.
@@ -102,30 +68,7 @@ pub struct CategoryLandingMeta {
     pub category: Category,
     pub title: Title,
     pub description: Option<String>,
-    pub updated_at: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CategoryLandingMetaInput {
-    pub category: Category,
-    pub title: Title,
-    pub description: Option<String>,
-    pub updated_at: String,
-}
-
-impl CategoryLandingMeta {
-    pub fn new(input: CategoryLandingMetaInput) -> Result<Self> {
-        if input.updated_at.trim().is_empty() {
-            return Err(DomainError::validation("updated_at"));
-        }
-
-        Ok(Self {
-            category: input.category,
-            title: input.title,
-            description: input.description,
-            updated_at: input.updated_at,
-        })
-    }
+    pub updated_at: Timestamp,
 }
 
 /// Category-specific index.
@@ -252,13 +195,12 @@ mod tests {
     use super::*;
 
     fn build_category_landing(category: Category, title: &str) -> CategoryLandingMeta {
-        CategoryLandingMeta::new(CategoryLandingMetaInput {
+        CategoryLandingMeta {
             category,
             title: Title::new(title.to_string()).unwrap(),
             description: Some(format!("{title} landing")),
-            updated_at: "2025-01-03T00:00:00+09:00".to_string(),
-        })
-        .unwrap()
+            updated_at: Timestamp::new("2025-01-03T00:00:00+09:00".to_string()).unwrap(),
+        }
     }
 
     fn build_article(
@@ -268,7 +210,7 @@ mod tests {
         priority: Option<i32>,
         created_at: &str,
     ) -> PublishableArticle {
-        let meta = ArticleMeta::new(ArticleMetaInput {
+        let meta = ArticleMeta {
             slug: Slug::new(slug.to_string()).unwrap(),
             title: Title::new(title.to_string()).unwrap(),
             category,
@@ -276,10 +218,9 @@ mod tests {
             description: Some(format!("{title} summary")),
             tags: vec!["tag".to_string()],
             priority,
-            created_at: created_at.to_string(),
-            updated_at: created_at.to_string(),
-        })
-        .unwrap();
+            created_at: Timestamp::new(created_at.to_string()).unwrap(),
+            updated_at: Timestamp::new(created_at.to_string()).unwrap(),
+        };
         let body = ArticleBody::new(format!("<p>{title}</p>")).unwrap();
         PublishableArticle::new(meta, body)
     }
@@ -287,48 +228,9 @@ mod tests {
     #[test]
     fn test_article_body_validation() {
         assert!(ArticleBody::new("   ".to_string()).is_err());
-        assert!(ArticleBody::new("<p>body</p>".to_string()).is_ok());
-    }
+        let body = ArticleBody::new("<p>body</p>".to_string()).unwrap();
 
-    #[test]
-    fn test_article_meta_validation() {
-        let valid_input = ArticleMetaInput {
-            slug: Slug::new("valid00000001".to_string()).unwrap(),
-            title: Title::new("Valid".to_string()).unwrap(),
-            category: Category::Tech,
-            section_path: SectionPath::new(vec!["block".to_string()]),
-            description: Some("summary".to_string()),
-            tags: vec!["tag".to_string()],
-            priority: Some(1),
-            created_at: "2025-01-01T00:00:00+09:00".to_string(),
-            updated_at: "2025-01-02T00:00:00+09:00".to_string(),
-        };
-
-        assert!(ArticleMeta::new(valid_input.clone()).is_ok());
-
-        let missing_created_at = ArticleMetaInput {
-            created_at: "   ".to_string(),
-            ..valid_input.clone()
-        };
-        assert!(ArticleMeta::new(missing_created_at).is_err());
-
-        let missing_updated_at = ArticleMetaInput {
-            updated_at: "".to_string(),
-            ..valid_input
-        };
-        assert!(ArticleMeta::new(missing_updated_at).is_err());
-    }
-
-    #[test]
-    fn test_category_landing_meta_requires_updated_at() {
-        let input = CategoryLandingMetaInput {
-            category: Category::Tech,
-            title: Title::new("Tech".to_string()).unwrap(),
-            description: None,
-            updated_at: "   ".to_string(),
-        };
-
-        assert!(CategoryLandingMeta::new(input).is_err());
+        assert_eq!(body.as_str(), "<p>body</p>");
     }
 
     #[test]

--- a/crates/publish/src/artifacts/writer.rs
+++ b/crates/publish/src/artifacts/writer.rs
@@ -141,8 +141,7 @@ mod tests {
     use super::super::validator::validate_site_artifacts;
     use super::*;
     use domain::{
-        ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta, CategoryLandingMetaInput,
-        PageKey, SectionPath, Title,
+        ArticleMeta, Category, CategoryLandingMeta, PageKey, SectionPath, Timestamp, Title,
     };
     use tempfile::TempDir;
 
@@ -153,7 +152,7 @@ mod tests {
         priority: Option<i32>,
         created_at: &str,
     ) -> ArticleMeta {
-        ArticleMeta::new(ArticleMetaInput {
+        ArticleMeta {
             slug: Slug::new(slug.to_string()).unwrap(),
             title: Title::new(title.to_string()).unwrap(),
             category,
@@ -161,10 +160,9 @@ mod tests {
             description: Some(format!("{title} summary")),
             tags: vec!["rust".to_string()],
             priority,
-            created_at: created_at.to_string(),
-            updated_at: created_at.to_string(),
-        })
-        .unwrap()
+            created_at: Timestamp::new(created_at.to_string()).unwrap(),
+            updated_at: Timestamp::new(created_at.to_string()).unwrap(),
+        }
     }
 
     fn build_category_landing(
@@ -172,13 +170,12 @@ mod tests {
         title: &str,
         description: Option<&str>,
     ) -> CategoryLandingMeta {
-        CategoryLandingMeta::new(CategoryLandingMetaInput {
+        CategoryLandingMeta {
             category,
             title: Title::new(title.to_string()).unwrap(),
             description: description.map(str::to_string),
-            updated_at: "2025-01-01T00:00:00+09:00".to_string(),
-        })
-        .unwrap()
+            updated_at: Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap(),
+        }
     }
 
     #[test]

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -229,8 +229,11 @@ async fn process_category(
 ) -> Result<domain::CategoryLandingMeta> {
     let rendered = render_category(parsed_file, link_index, enrich).await?;
     run_artifact_write(move || {
-        let output_file_path =
-            write_category_page(&site_directories, rendered.meta.category, &rendered.html)?;
+        let output_file_path = write_category_page(
+            &site_directories,
+            rendered.meta.category,
+            rendered.body.as_str(),
+        )?;
         Ok((rendered.meta, output_file_path))
     })
     .await

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -177,15 +177,15 @@ async fn process_article(
     enrich: BookmarkEnricher,
     site_directories: SiteDirectories,
 ) -> Result<domain::ArticleMeta> {
-    let rendered = render_article(parsed_file, link_index, enrich).await?;
+    let article = render_article(parsed_file, link_index, enrich).await?;
     run_artifact_write(move || {
         let output_file_path = write_article_page(
             &site_directories,
-            rendered.meta.category,
-            &rendered.meta.slug,
-            &rendered.html,
+            article.meta.category,
+            &article.meta.slug,
+            article.body.as_str(),
         )?;
-        Ok((rendered.meta, output_file_path))
+        Ok((article.meta, output_file_path))
     })
     .await
 }

--- a/crates/publish/src/render/document.rs
+++ b/crates/publish/src/render/document.rs
@@ -5,15 +5,10 @@ use crate::{
     links,
 };
 use domain::{
-    ArticleBody, ArticleMeta, Category, CategoryLandingMeta, HomeFragmentArtifactDocument,
-    PageArtifactDocument, PublishableArticle, Timestamp, Title,
+    ArticleBody, ArticleMeta, CategoryLandingBody, CategoryLandingMeta,
+    HomeFragmentArtifactDocument, PageArtifactDocument, PublishableArticle,
+    PublishableCategoryLanding, Timestamp, Title,
 };
-use html_escape::encode_text;
-
-pub(crate) struct RenderedCategoryLanding {
-    pub(crate) meta: CategoryLandingMeta,
-    pub(crate) html: String,
-}
 
 pub(crate) async fn render_article(
     parsed_file: ParsedArticleFile,
@@ -40,22 +35,16 @@ pub(crate) async fn render_category(
     parsed_file: ParsedCategoryFile,
     link_index: &links::Index,
     enrich: BookmarkEnricher,
-) -> Result<RenderedCategoryLanding> {
+) -> Result<PublishableCategoryLanding> {
     let html = body::render(&parsed_file.markdown_body, link_index, &enrich).await;
-    let title = normalize_category_title(parsed_file.category, &parsed_file.front_matter.title);
-    let description = normalize_category_description(parsed_file.front_matter.summary.as_deref());
-    let html = if html.trim().is_empty() {
-        build_fallback_category_html(parsed_file.category, &title, description.as_deref())
-    } else {
-        html
-    };
     let meta = CategoryLandingMeta {
         category: parsed_file.category,
-        title: Title::new(title)?,
-        description,
+        title: Title::new(parsed_file.front_matter.title)?,
+        description: parsed_file.front_matter.summary,
         updated_at: Timestamp::new(parsed_file.front_matter.updated)?,
     };
-    Ok(RenderedCategoryLanding { meta, html })
+    let body = CategoryLandingBody::new(html)?;
+    Ok(PublishableCategoryLanding::new(meta, body))
 }
 
 pub(crate) async fn render_home(
@@ -84,87 +73,5 @@ pub(crate) async fn render_page(
         description: parsed_file.front_matter.summary,
         html,
         updated_at: parsed_file.front_matter.updated,
-    }
-}
-
-fn normalize_category_title(category: Category, title: &str) -> String {
-    let title = title.trim();
-    if title.is_empty() {
-        category.display_name().to_owned()
-    } else {
-        title.to_owned()
-    }
-}
-
-fn normalize_category_description(description: Option<&str>) -> Option<String> {
-    description
-        .map(str::trim)
-        .filter(|description| !description.is_empty())
-        .map(str::to_owned)
-}
-
-fn build_fallback_category_html(
-    category: Category,
-    title: &str,
-    description: Option<&str>,
-) -> String {
-    let heading = if title.trim().is_empty() {
-        category.display_name()
-    } else {
-        title.trim()
-    };
-
-    let body = description
-        .filter(|description| !description.trim().is_empty())
-        .map(str::trim)
-        .map(str::to_owned)
-        .unwrap_or_else(|| format!("{}カテゴリの記事一覧です。", category.display_name()));
-    let heading = encode_text(heading);
-    let body = encode_text(&body);
-    format!("<article><h1>{heading}</h1><p>{body}</p></article>")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_build_fallback_category_html_uses_title_and_summary() {
-        let html = build_fallback_category_html(Category::Tech, "Tech", Some("Technology landing"));
-
-        assert!(html.contains("<h1>Tech</h1>"));
-        assert!(html.contains("<p>Technology landing</p>"));
-    }
-
-    #[test]
-    fn test_build_fallback_category_html_falls_back_to_category_display_name() {
-        let html = build_fallback_category_html(Category::Physics, "   ", None);
-
-        assert!(html.contains("<h1>物理学</h1>"));
-        assert!(html.contains("物理学カテゴリの記事一覧です。"));
-    }
-
-    #[test]
-    fn test_build_fallback_category_html_escapes_frontmatter_text() {
-        let html = build_fallback_category_html(
-            Category::Tech,
-            "<script>alert(1)</script>",
-            Some("\"quoted\" & <tag>"),
-        );
-
-        assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
-        assert!(html.contains("\"quoted\" &amp; &lt;tag&gt;"));
-        assert!(!html.contains("<script>alert(1)</script>"));
-    }
-
-    #[test]
-    fn test_normalize_category_metadata_trims_and_falls_back() {
-        assert_eq!(normalize_category_title(Category::Physics, "   "), "物理学");
-        assert_eq!(normalize_category_title(Category::Tech, "  Tech  "), "Tech");
-        assert_eq!(normalize_category_description(Some("   ")), None);
-        assert_eq!(
-            normalize_category_description(Some("  Technology landing  ")),
-            Some("Technology landing".to_string())
-        );
     }
 }

--- a/crates/publish/src/render/document.rs
+++ b/crates/publish/src/render/document.rs
@@ -5,15 +5,10 @@ use crate::{
     links,
 };
 use domain::{
-    ArticleBody, ArticleMeta, ArticleMetaInput, Category, CategoryLandingMeta,
-    CategoryLandingMetaInput, HomeFragmentArtifactDocument, PageArtifactDocument, Title,
+    ArticleBody, ArticleMeta, Category, CategoryLandingMeta, HomeFragmentArtifactDocument,
+    PageArtifactDocument, PublishableArticle, Timestamp, Title,
 };
 use html_escape::encode_text;
-
-pub(crate) struct RenderedArticle {
-    pub(crate) meta: ArticleMeta,
-    pub(crate) html: String,
-}
 
 pub(crate) struct RenderedCategoryLanding {
     pub(crate) meta: CategoryLandingMeta,
@@ -24,9 +19,9 @@ pub(crate) async fn render_article(
     parsed_file: ParsedArticleFile,
     link_index: &links::Index,
     enrich: BookmarkEnricher,
-) -> Result<RenderedArticle> {
+) -> Result<PublishableArticle> {
     let html = body::render(&parsed_file.markdown_body, link_index, &enrich).await;
-    let meta = ArticleMeta::new(ArticleMetaInput {
+    let meta = ArticleMeta {
         slug: parsed_file.slug,
         title: Title::new(parsed_file.front_matter.title)?,
         category: parsed_file.category,
@@ -34,14 +29,11 @@ pub(crate) async fn render_article(
         description: parsed_file.front_matter.summary,
         tags: parsed_file.front_matter.tags.unwrap_or_default(),
         priority: parsed_file.front_matter.priority,
-        created_at: parsed_file.front_matter.created,
-        updated_at: parsed_file.front_matter.updated,
-    })?;
+        created_at: Timestamp::new(parsed_file.front_matter.created)?,
+        updated_at: Timestamp::new(parsed_file.front_matter.updated)?,
+    };
     let body = ArticleBody::new(html)?;
-    Ok(RenderedArticle {
-        meta,
-        html: body.html,
-    })
+    Ok(PublishableArticle::new(meta, body))
 }
 
 pub(crate) async fn render_category(
@@ -57,12 +49,12 @@ pub(crate) async fn render_category(
     } else {
         html
     };
-    let meta = CategoryLandingMeta::new(CategoryLandingMetaInput {
+    let meta = CategoryLandingMeta {
         category: parsed_file.category,
         title: Title::new(title)?,
         description,
-        updated_at: parsed_file.front_matter.updated,
-    })?;
+        updated_at: Timestamp::new(parsed_file.front_matter.updated)?,
+    };
     Ok(RenderedCategoryLanding { meta, html })
 }
 

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -2,6 +2,7 @@ mod test_fixtures;
 
 use indoc::indoc;
 use publish::{BookmarkEnricher, PublishError, publish, publish_with_bookmark_enricher};
+use rstest::rstest;
 use std::{fs, path::Path, sync::Arc};
 use tempfile::TempDir;
 use test_fixtures::{collect_html_files, write_about_page};
@@ -369,7 +370,7 @@ async fn test_publish_with_category_landing_file() {
         title: "Tech"
         kind: category
         category: tech
-        summary: "Technology landing"
+        summary: "  Technology landing  "
         created: "2025-01-01T00:00:00+09:00"
         updated: "2025-01-01T00:00:00+09:00"
         is_completed: true
@@ -406,8 +407,40 @@ async fn test_publish_with_category_landing_file() {
 
     assert!(category_index.contains("\"category\": \"tech\""));
     assert!(category_index.contains("\"title\": \"Tech\""));
-    assert!(category_index.contains("\"description\": \"Technology landing\""));
+    assert!(category_index.contains("\"description\": \"  Technology landing  \""));
     assert!(category_page.contains("Welcome to the category landing page."));
+}
+
+#[rstest]
+#[case::blank_title("   ", "# Tech\n\nCategory description.")]
+#[case::blank_body("Tech", "   ")]
+#[tokio::test]
+async fn test_publish_rejects_incomplete_category_landing(#[case] title: &str, #[case] body: &str) {
+    let temp_dir = TempDir::new().unwrap();
+    let obsidian_dir = temp_dir.path().join("obsidian");
+    let output_dir = temp_dir.path().join("dist");
+
+    write_required_article(&obsidian_dir);
+    write_about_page(&obsidian_dir);
+    let category_content = format!(
+        r#"---
+title: "{title}"
+kind: category
+category: tech
+summary: "Technology landing"
+created: "2025-01-01T00:00:00+09:00"
+updated: "2025-01-01T00:00:00+09:00"
+is_completed: true
+---
+
+{body}
+"#
+    );
+    fs::write(obsidian_dir.join("tech/index.md"), category_content).unwrap();
+
+    let result = publish(&obsidian_dir, &output_dir).await;
+
+    assert!(result.is_err(), "publish should reject incomplete landing");
 }
 
 #[tokio::test]

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -59,7 +59,7 @@ okawak_blog/
 - `crates/domain`
   - 公開コンテンツの純粋なdomain model・ルールと、`publish` / readerが共有する契約
   - `Category`、`Slug`、`PageKey`、`SectionPath`
-  - `ArticleMeta`、`CategoryLandingMeta`と記事・カテゴリ索引を構築する純粋ルール
+  - `ArticleMeta`、`PublishableArticle`、`CategoryLandingMeta`、`PublishableCategoryLanding`と記事・カテゴリ索引を構築する純粋ルール
   - artifact contract
   - site page contract
 - `crates/publish`
@@ -274,6 +274,7 @@ artifact の意味は次の通り。
 - `categories/<category>/page.html`
   - カテゴリ landing page 本文
   - landing Markdown が無い場合は fallback HTML を生成する
+  - landing Markdown がある場合はfrontmatterのtitleと本文を必須とし、空値をfallbackで補完しない
 - `pages/<page>.json`
   - 固定ページ
   - HTML 本文と title / description / updated_at を含む
@@ -285,7 +286,7 @@ artifact の意味は次の通り。
 
 `PageArtifactDocument` は固定ページを保持する。homeは完成したpageではなく実行時に記事一覧やmetadataと合成する一部分なので、`HomeFragmentArtifactDocument` として独立させる。
 
-`publish`は描画済みカテゴリのmetadataを`CategoryLandingMeta`としてdomainへ渡す。domainはlandingだけが存在するカテゴリも含めて`CategoryIndex`へ統合し、カテゴリ順、記事順、`SiteMetadata`の集計を確定する。Markdown変換、HTML生成、filesystemへの書込みは`publish`に残す。
+`publish`は描画済みカテゴリを`PublishableCategoryLanding`として組み立て、metadataを`CategoryLandingMeta`としてdomainへ渡す。frontmatterのtitleと描画済み本文はdomainの値オブジェクトで検証し、descriptionはArticleと同様に入力値を保持する。domainはlandingだけが存在するカテゴリも含めて`CategoryIndex`へ統合し、カテゴリ順、記事順、`SiteMetadata`の集計を確定する。Markdown変換、HTML生成、filesystemへの書込みは`publish`に残す。
 
 ### S3 release 契約
 


### PR DESCRIPTION
## Summary

- replace duplicated metadata input structs with validated `Timestamp` values
- model rendered articles and category landing pages as domain publishable types
- encapsulate rendered HTML bodies and remove publisher-local rendered structs
- remove the category landing HTML fallback

## Why

Publishable state and its invariants belong to the domain model, while `publish::render` should focus on converting source content and assembling validated domain values. This also aligns article and category landing processing.

## Behavior changes

When an explicit category landing Markdown file exists, both its frontmatter `title` and rendered body are required. Blank values now fail publishing instead of falling back to the category display name or generated HTML. A category without a landing file still receives the existing generated fallback page.

Category landing `description` now follows article metadata behavior and preserves the authored frontmatter value instead of trimming or discarding blank text.

The serialized artifact shape is unchanged.

## Validation

- `mise run format`
- `mise run test`
- `mise run clippy`
- `git diff --check`