### PR TITLE
refactor: normalize escaped table wikilinks

### DIFF
--- a/crates/publish/src/links.rs
+++ b/crates/publish/src/links.rs
@@ -92,7 +92,7 @@ fn resolve_wikilink_destination<'a>(
     index: &'a Index,
 ) -> CowStr<'a> {
     let target = target.trim();
-    // The table prepass escapes a piped WikiLink delimiter, leaving this suffix on its target.
+    // pulldown-cmark keeps the escape before a piped WikiLink delimiter in its target.
     let target = if has_pothole {
         target.strip_suffix('\\').unwrap_or(target)
     } else {

--- a/crates/publish/src/render/body.rs
+++ b/crates/publish/src/render/body.rs
@@ -79,7 +79,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_render_preserves_piped_wikilinks_inside_table_cells() {
+    async fn test_render_resolves_escaped_piped_wikilinks_inside_tables() {
         let files = ClassifiedFiles {
             articles: vec![parsed_article("notes/article", Category::Tech, "def456")],
             ..Default::default()
@@ -87,9 +87,9 @@ mod tests {
         let link_index = links::Index::from_classified_files(&files);
         let enrich: BookmarkEnricher = Arc::new(|html| Box::pin(async move { Ok(html) }));
         let markdown = indoc! {r#"
-            | [[article|Header link]] | ![[article|Header embed]] |
+            | [[article\|Header link]] | ![[article\|Header embed]] |
             | --- | --- |
-            | [[article|Cell link]] | ![[article|Cell embed]] |
+            | [[article\|Cell link]] | ![[article\|Cell embed]] |
         "#};
 
         let html = render(markdown, &link_index, &enrich).await;

--- a/crates/publish/src/render/html.rs
+++ b/crates/publish/src/render/html.rs
@@ -1,12 +1,9 @@
 use super::sanitize;
 use crate::links::{self, Index};
-use pulldown_cmark::{Event, LinkType, Options, Parser, Tag, html};
-use std::{borrow::Cow, ops::Range};
+use pulldown_cmark::{Options, Parser, html};
 
 /// Converts Markdown to sanitized HTML.
 pub(crate) fn convert_markdown_to_html(markdown_content: &str, link_index: &Index) -> String {
-    let prepared_markdown = escape_table_wikilink_pipes(markdown_content);
-
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
     options.insert(Options::ENABLE_FOOTNOTES);
@@ -16,102 +13,12 @@ pub(crate) fn convert_markdown_to_html(markdown_content: &str, link_index: &Inde
     options.insert(Options::ENABLE_MATH);
     options.insert(Options::ENABLE_WIKILINKS);
 
-    let parser = Parser::new_ext(&prepared_markdown, options);
+    let parser = Parser::new_ext(markdown_content, options);
     let parser = links::resolve_wikilinks(parser, link_index);
-    let mut html_output = String::with_capacity(prepared_markdown.len() * 2);
+    let mut html_output = String::with_capacity(markdown_content.len() * 2);
     html::push_html(&mut html_output, sanitize::events(parser).into_iter());
 
     html_output
-}
-
-/// Escapes piped WikiLinks only where pulldown-cmark would treat their pipes as table separators.
-/// Remove this workaround once pulldown-cmark handles piped WikiLinks inside tables.
-fn escape_table_wikilink_pipes(markdown: &str) -> Cow<'_, str> {
-    let piped_wikilinks = piped_wikilink_ranges(markdown);
-
-    if piped_wikilinks.is_empty() {
-        return Cow::Borrowed(markdown);
-    }
-
-    // Hide WikiLink pipes while detecting tables. `/` preserves the original byte offsets.
-    let table_probe = replace_wikilink_pipes(markdown, &piped_wikilinks, "/");
-    let table_ranges = Parser::new_ext(
-        &table_probe,
-        Options::ENABLE_TABLES | Options::ENABLE_WIKILINKS,
-    )
-    .into_offset_iter()
-    .filter_map(|(event, range)| match event {
-        Event::Start(Tag::Table(_)) => Some(range),
-        _ => None,
-    })
-    .collect::<Vec<_>>();
-
-    let table_wikilinks = piped_wikilinks
-        .into_iter()
-        .filter(|wikilink| {
-            table_ranges
-                .iter()
-                .any(|table| table.start <= wikilink.start && wikilink.end <= table.end)
-        })
-        .collect::<Vec<_>>();
-
-    if table_wikilinks.is_empty() {
-        return Cow::Borrowed(markdown);
-    }
-
-    Cow::Owned(replace_wikilink_pipes(markdown, &table_wikilinks, r"\|"))
-}
-
-fn piped_wikilink_ranges(markdown: &str) -> Vec<Range<usize>> {
-    let mut ranges = Parser::new_ext(markdown, Options::ENABLE_WIKILINKS)
-        .into_offset_iter()
-        .filter_map(|(event, range)| match event {
-            Event::Start(
-                Tag::Link {
-                    link_type: LinkType::WikiLink { has_pothole: true },
-                    ..
-                }
-                | Tag::Image {
-                    link_type: LinkType::WikiLink { has_pothole: true },
-                    ..
-                },
-            ) => Some(range),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    ranges.sort_unstable_by_key(|range| range.start);
-
-    let mut disjoint_ranges: Vec<Range<usize>> = Vec::with_capacity(ranges.len());
-    for range in ranges {
-        if let Some(previous) = disjoint_ranges.last_mut()
-            && range.start <= previous.end
-        {
-            previous.end = previous.end.max(range.end);
-        } else {
-            disjoint_ranges.push(range);
-        }
-    }
-
-    disjoint_ranges
-}
-
-fn replace_wikilink_pipes(
-    markdown: &str,
-    wikilink_ranges: &[Range<usize>],
-    replacement: &str,
-) -> String {
-    let mut replaced = String::with_capacity(markdown.len());
-    let mut previous_end = 0;
-
-    for range in wikilink_ranges {
-        replaced.push_str(&markdown[previous_end..range.start]);
-        replaced.push_str(&markdown[range.clone()].replace('|', replacement));
-        previous_end = range.end;
-    }
-
-    replaced.push_str(&markdown[previous_end..]);
-    replaced
 }
 
 #[cfg(test)]
@@ -122,37 +29,6 @@ mod tests {
 
     fn convert_markdown_to_html(markdown: &str) -> String {
         super::convert_markdown_to_html(markdown, &Index::default())
-    }
-
-    #[rstest]
-    #[case::link_outside_table("See [[Page|Label]].", "See [[Page|Label]].")]
-    #[case::nested_wikilinks_outside_table("![[image|[[page|text]]]]", "![[image|[[page|text]]]]")]
-    #[case::link_inside_table(
-        indoc! {r#"
-            | Link |
-            | --- |
-            | [[Page|Label]] |
-        "#},
-        indoc! {r#"
-            | Link |
-            | --- |
-            | [[Page\|Label]] |
-        "#}
-    )]
-    #[case::embed_inside_table(
-        indoc! {r#"
-            | Image |
-            | --- |
-            | ![[image.png|Alt]] |
-        "#},
-        indoc! {r#"
-            | Image |
-            | --- |
-            | ![[image.png\|Alt]] |
-        "#}
-    )]
-    fn test_escape_table_wikilink_pipes(#[case] markdown: &str, #[case] expected: &str) {
-        assert_eq!(escape_table_wikilink_pipes(markdown), expected);
     }
 
     #[rstest]

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -68,9 +68,9 @@ okawak_blog/
   - crate外向けAPIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に限定する
   - path処理の対応環境はmacOSとLinuxとし、Windows形式のpathは対象外とする
   - vault moduleによるObsidian vault走査、Markdown読込、frontmatter parse
-  - links moduleによる全公開contentのvault相対source keyと公開URLの索引構築、およびWikiLink link / image eventの公開URL解決
+  - links moduleによる全公開contentのvault相対source keyと公開URLの索引構築、およびtable用にescapeされたpipeの正規化を含むWikiLink link / image eventの公開URL解決
   - render moduleによるcontent kindごとのdocument組み立てと共通本文処理
-  - render/htmlによるWikiLinkと数式を含む`pulldown-cmark` event生成とHTML変換。数式spanには`.math-inline` / `.math-display`を使用する
+  - render/htmlによる入力Markdownを事前書換えしないWikiLinkと数式を含む`pulldown-cmark` event生成とHTML変換。数式spanには`.math-inline` / `.math-display`を使用する
   - render/sanitizeによるlink・image URLとraw HTMLの安全化
   - render/bookmarkによるsimple bookmark構文の判定、外部HTTPを伴うmetadata取得、rich bookmark HTML生成
   - classify moduleによる公開種別の確定と`section_path`の導出

--- a/docs/content/obsidian-template.md
+++ b/docs/content/obsidian-template.md
@@ -80,6 +80,8 @@ Obsidian link や bookmark 埋め込みを含めてよい。
 
 本文の基本的な Markdown 記法は CommonMark に従う。Obsidian 固有の解釈だけで成立する強調記法などは`publish`では補正しない。
 
+Markdown table内の表示名付きWikiLinkは、cell区切りと区別するためpipeをescapeして`[[target\|label]]`と書く。embedも同様に`![[target\|alt]]`とする。table外では通常どおり`[[target|label]]`と書ける。`publish`はMarkdown自体を書き換えず、`pulldown-cmark`が生成したWikiLink eventのtargetからtable用escapeだけを除去して公開URLを解決する。
+
 メモ:
 
 - `kind` を省略した場合は `article` として扱う


### PR DESCRIPTION
## Summary

- require escaped WikiLink pipes inside Markdown tables
- remove publisher-side WikiLink table preprocessing
- normalize the parser-retained escape during WikiLink event resolution
- document the table input contract and retain regression coverage for links and embeds

## Verification

- mise run format
- mise run test
- mise run clippy
- mise run check
- git diff --check

Closes #174