### PR TITLE
refactor: extract bookmark metadata handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
 依存と配置の境界:
 
 - `crates/domain`: 公開コンテンツの純粋なdomain model・ルールと、`publish` / readerが共有する契約。I/O、`async`、AWS SDK、Axum、Leptos を持ち込まない。WASM 互換を意識する
-- `crates/publish`: 単一の`publish` crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`links` moduleを公開URL索引とWikiLink event解決の境界、`render` moduleをcontent描画の境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。`render`内ではcontent kind別の組み立て、共通本文処理、Markdown event生成とHTML変換、URLとraw HTMLの安全化、bookmark構文とenrichmentを分離する。`publish`専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
+- `crates/publish`: 単一の`publish` crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`links` moduleを公開URL索引とWikiLink event解決の境界、`render` moduleをcontent描画の境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。`render`内ではcontent kind別の組み立て、共通本文処理、Markdown event生成とHTML変換、URLとraw HTMLの安全化、bookmark構文・card生成とOGP metadata取得を分離する。`publish`専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
 - `crates/site/infra`: server が artifact を読む外部境界（local / S3、設定、将来のcache）。vault読取、Markdown変換、uploadを置かない
 - `crates/site/server`: Axum + Leptos SSR host、reader注入、API、health/readiness、release-aware conditional GET
 - `crates/site/web`: Leptos UI / route / metadataと、artifact内のmath spanに対するKaTeX描画。SSR時もstorage実装へ直接依存しない

--- a/crates/publish/src/render.rs
+++ b/crates/publish/src/render.rs
@@ -2,6 +2,7 @@ mod body;
 mod bookmark;
 mod document;
 mod html;
+mod ogp;
 mod sanitize;
 
 pub use bookmark::BookmarkEnricher;

--- a/crates/publish/src/render/bookmark.rs
+++ b/crates/publish/src/render/bookmark.rs
@@ -1,9 +1,9 @@
+use super::ogp::{self, BookmarkMetadata};
 use crate::error::Result;
 
 use futures::future::BoxFuture;
 use html_escape::{encode_double_quoted_attribute, encode_text};
 use regex::Regex;
-use scraper::{Html, Selector};
 use std::future::Future;
 use std::ops::Range;
 use std::sync::Arc;
@@ -97,151 +97,8 @@ fn simple_bookmarks(html: &str) -> impl Iterator<Item = SimpleBookmark<'_>> {
     })
 }
 
-#[derive(Debug, Clone, PartialEq)]
-struct BookmarkData {
-    url: String,
-    title: String,
-    description: Option<String>,
-    image_url: Option<String>,
-    favicon_url: Option<String>,
-}
-
-/// Fetches OGP metadata from a URL with a 10-second timeout.
-async fn fetch_ogp_metadata(url: &str) -> Result<BookmarkData> {
-    let client = create_http_client()?;
-    let html_content = fetch_html_content(&client, url).await?;
-    let document = Html::parse_document(&html_content);
-
-    Ok(BookmarkData {
-        url: url.to_string(),
-        title: extract_title(&document).unwrap_or_else(|| url.to_string()),
-        description: extract_description(&document),
-        image_url: extract_image(&document, url),
-        favicon_url: extract_favicon(&document, url),
-    })
-}
-
-fn create_http_client() -> Result<reqwest::Client> {
-    // Use a standard User-Agent format without exposing internal package details.
-    let user_agent = "publish-bookmark/1.0 (+https://github.com/okawak/okawak_blog)";
-
-    reqwest::Client::builder()
-        .user_agent(user_agent)
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(Into::into)
-}
-
-async fn fetch_html_content(client: &reqwest::Client, url: &str) -> Result<String> {
-    let response = client.get(url).send().await?;
-
-    response.text().await.map_err(Into::into)
-}
-
-fn extract_title(document: &Html) -> Option<String> {
-    extract_meta_content(document, "meta[property='og:title']")
-        .or_else(|| extract_meta_content(document, "meta[name='twitter:title']"))
-        .or_else(|| extract_title_tag(document))
-}
-
-/// Extracts the `content` attribute from a meta tag.
-fn extract_meta_content(document: &Html, selector: &str) -> Option<String> {
-    let selector = Selector::parse(selector).ok()?;
-    let content = document
-        .select(&selector)
-        .next()?
-        .value()
-        .attr("content")?
-        .trim();
-
-    if content.is_empty() {
-        None
-    } else {
-        Some(content.to_string())
-    }
-}
-
-fn extract_title_tag(document: &Html) -> Option<String> {
-    let selector = Selector::parse("title").ok()?;
-    let title_text = document
-        .select(&selector)
-        .next()?
-        .text()
-        .collect::<String>();
-
-    let trimmed = title_text.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-fn extract_description(document: &Html) -> Option<String> {
-    extract_meta_content(document, "meta[property='og:description']")
-        .or_else(|| extract_meta_content(document, "meta[name='twitter:description']"))
-        .or_else(|| extract_meta_content(document, "meta[name='description']"))
-}
-
-fn extract_image(document: &Html, base_url: &str) -> Option<String> {
-    use url::Url;
-
-    let base = Url::parse(base_url).ok()?;
-
-    extract_meta_content(document, "meta[property='og:image']")
-        .or_else(|| extract_meta_content(document, "meta[name='twitter:image']"))
-        .and_then(|content| {
-            // Keep absolute URLs as-is and resolve relative URLs against the base URL.
-            if content.starts_with("http://") || content.starts_with("https://") {
-                Some(content)
-            } else {
-                base.join(&content).ok().map(|url| url.to_string())
-            }
-        })
-}
-
-fn extract_favicon(document: &Html, base_url: &str) -> Option<String> {
-    use url::Url;
-
-    let base = Url::parse(base_url).ok()?;
-
-    let selectors = [
-        "link[rel='apple-touch-icon']",
-        "link[rel='icon']",
-        "link[rel='shortcut icon']",
-    ];
-
-    for selector in &selectors {
-        if let Some(href) = extract_link_href(document, selector) {
-            // Keep absolute URLs as-is and resolve relative URLs against the base URL.
-            let result_url = if href.starts_with("http://") || href.starts_with("https://") {
-                Some(href)
-            } else {
-                base.join(&href).ok().map(|url| url.to_string())
-            };
-
-            if let Some(url) = result_url {
-                return Some(url);
-            }
-        }
-    }
-
-    // A valid base URL can always resolve `/favicon.ico`, so `unwrap` is acceptable here.
-    Some(base.join("/favicon.ico").unwrap().to_string())
-}
-
-fn extract_link_href(document: &Html, selector: &str) -> Option<String> {
-    let selector = Selector::parse(selector).ok()?;
-    document
-        .select(&selector)
-        .next()?
-        .value()
-        .attr("href")
-        .map(ToString::to_string)
-}
-
 /// Generates rich bookmark HTML using the `bookmark` class.
-fn generate_rich_bookmark(data: &BookmarkData) -> String {
+fn generate_rich_bookmark(data: &BookmarkMetadata) -> String {
     let domain = extract_domain(&data.url);
 
     let mut html = String::with_capacity(HTML_INITIAL_CAPACITY);
@@ -272,7 +129,7 @@ fn write_bookmark_link(html: &mut String, url: &str) {
     ));
 }
 
-fn write_bookmark_container(html: &mut String, data: &BookmarkData, domain: &str) {
+fn write_bookmark_container(html: &mut String, data: &BookmarkMetadata, domain: &str) {
     html.push_str("    <div class=\"bookmark-container\">\n");
 
     write_bookmark_info(html, data, domain);
@@ -281,7 +138,7 @@ fn write_bookmark_container(html: &mut String, data: &BookmarkData, domain: &str
     html.push_str("    </div>\n");
 }
 
-fn write_bookmark_info(html: &mut String, data: &BookmarkData, domain: &str) {
+fn write_bookmark_info(html: &mut String, data: &BookmarkMetadata, domain: &str) {
     html.push_str("      <div class=\"bookmark-info\">\n");
     html.push_str(&format!(
         "        <div class=\"bookmark-title\">{}</div>\n",
@@ -299,7 +156,7 @@ fn write_bookmark_info(html: &mut String, data: &BookmarkData, domain: &str) {
     html.push_str("      </div>\n");
 }
 
-fn write_bookmark_link_info(html: &mut String, data: &BookmarkData, domain: &str) {
+fn write_bookmark_link_info(html: &mut String, data: &BookmarkMetadata, domain: &str) {
     html.push_str("        <div class=\"bookmark-link-info\">\n");
 
     if let Some(favicon) = &data.favicon_url {
@@ -316,7 +173,7 @@ fn write_bookmark_link_info(html: &mut String, data: &BookmarkData, domain: &str
     html.push_str("        </div>\n");
 }
 
-fn write_bookmark_image(html: &mut String, data: &BookmarkData) {
+fn write_bookmark_image(html: &mut String, data: &BookmarkMetadata) {
     if let Some(image_url) = &data.image_url {
         html.push_str("      <div class=\"bookmark-image\">\n");
         html.push_str(&format!(
@@ -332,7 +189,7 @@ fn write_bookmark_image(html: &mut String, data: &BookmarkData) {
 async fn convert_simple_bookmarks_with<F, Fut>(html_content: &str, fetch_data: F) -> String
 where
     F: Fn(String, String) -> Fut,
-    Fut: Future<Output = BookmarkData>,
+    Fut: Future<Output = BookmarkMetadata>,
 {
     let mut result = String::with_capacity(html_content.len() + HTML_EXTENSION_CAPACITY);
     let mut last_end = 0;
@@ -344,8 +201,8 @@ where
 
         result.push_str(&html_content[last_end..range.start]);
 
-        let bookmark_data = fetch_data(url, original_title).await;
-        let rich_bookmark_html = generate_rich_bookmark(&bookmark_data);
+        let metadata = fetch_data(url, original_title).await;
+        let rich_bookmark_html = generate_rich_bookmark(&metadata);
         result.push_str(&rich_bookmark_html);
 
         last_end = range.end;
@@ -359,26 +216,12 @@ where
 /// Replaces simple bookmark markup with rich bookmark cards fetched from OGP metadata.
 async fn convert_simple_bookmarks_to_rich(html_content: &str) -> String {
     convert_simple_bookmarks_with(html_content, |url, original_title| async move {
-        fetch_ogp_metadata(&url).await.unwrap_or_else(|error| {
+        ogp::fetch(&url).await.unwrap_or_else(|error| {
             tracing::warn!(%url, %error, "failed to fetch OGP metadata");
-            create_fallback_bookmark_data(&url, &original_title)
+            ogp::fallback(&url, &original_title)
         })
     })
     .await
-}
-
-fn create_fallback_bookmark_data(url: &str, original_title: &str) -> BookmarkData {
-    BookmarkData {
-        url: url.to_string(),
-        title: if original_title.trim().is_empty() {
-            url.to_string()
-        } else {
-            original_title.to_string()
-        },
-        description: None,
-        image_url: None,
-        favicon_url: None,
-    }
 }
 
 #[cfg(test)]
@@ -414,7 +257,7 @@ mod tests {
 
     #[rstest]
     #[case::full_metadata(
-        &BookmarkData {
+        &BookmarkMetadata {
             url: "https://example.com".to_string(),
             title: "Example Title".to_string(),
             description: Some("This is an example description".to_string()),
@@ -441,7 +284,7 @@ mod tests {
             </div>"#}
     )]
     #[case::minimal_metadata(
-        &BookmarkData {
+        &BookmarkMetadata {
             url: "https://github.com".to_string(),
             title: "GitHub".to_string(),
             description: None,
@@ -463,7 +306,7 @@ mod tests {
             </div>"#}
     )]
     fn test_generate_rich_bookmark(
-        #[case] bookmark_data: &BookmarkData,
+        #[case] bookmark_data: &BookmarkMetadata,
         #[case] expected_html: &str,
     ) {
         let result = generate_rich_bookmark(bookmark_data);
@@ -541,7 +384,7 @@ mod tests {
     #[tokio::test]
     async fn test_convert_simple_bookmarks_to_rich(#[case] input: &str, #[case] expected: &str) {
         let result = convert_simple_bookmarks_with(input, |url, title| async move {
-            create_fallback_bookmark_data(&url, &title)
+            ogp::fallback(&url, &title)
         })
         .await;
 

--- a/crates/publish/src/render/ogp.rs
+++ b/crates/publish/src/render/ogp.rs
@@ -1,0 +1,210 @@
+use crate::error::Result;
+
+use scraper::{Html, Selector};
+use std::time::Duration;
+use url::Url;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const USER_AGENT: &str = "publish-bookmark/1.0 (+https://github.com/okawak/okawak_blog)";
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct BookmarkMetadata {
+    pub(super) url: String,
+    pub(super) title: String,
+    pub(super) description: Option<String>,
+    pub(super) image_url: Option<String>,
+    pub(super) favicon_url: Option<String>,
+}
+
+/// Fetches bookmark metadata from a URL.
+pub(super) async fn fetch(url: &str) -> Result<BookmarkMetadata> {
+    let client = create_http_client()?;
+    let html_content = fetch_html_content(&client, url).await?;
+
+    Ok(parse_metadata(url, &html_content))
+}
+
+pub(super) fn fallback(url: &str, original_title: &str) -> BookmarkMetadata {
+    BookmarkMetadata {
+        url: url.to_string(),
+        title: if original_title.trim().is_empty() {
+            url.to_string()
+        } else {
+            original_title.to_string()
+        },
+        description: None,
+        image_url: None,
+        favicon_url: None,
+    }
+}
+
+fn create_http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(Into::into)
+}
+
+async fn fetch_html_content(client: &reqwest::Client, url: &str) -> Result<String> {
+    let response = client.get(url).send().await?;
+
+    response.text().await.map_err(Into::into)
+}
+
+fn parse_metadata(url: &str, html_content: &str) -> BookmarkMetadata {
+    let document = Html::parse_document(html_content);
+
+    BookmarkMetadata {
+        url: url.to_string(),
+        title: extract_title(&document).unwrap_or_else(|| url.to_string()),
+        description: extract_description(&document),
+        image_url: extract_image(&document, url),
+        favicon_url: extract_favicon(&document, url),
+    }
+}
+
+fn extract_title(document: &Html) -> Option<String> {
+    extract_meta_content(document, "meta[property='og:title']")
+        .or_else(|| extract_meta_content(document, "meta[name='twitter:title']"))
+        .or_else(|| extract_title_tag(document))
+}
+
+fn extract_meta_content(document: &Html, selector: &str) -> Option<String> {
+    let selector = Selector::parse(selector).ok()?;
+    let content = document
+        .select(&selector)
+        .next()?
+        .value()
+        .attr("content")?
+        .trim();
+
+    if content.is_empty() {
+        None
+    } else {
+        Some(content.to_string())
+    }
+}
+
+fn extract_title_tag(document: &Html) -> Option<String> {
+    let selector = Selector::parse("title").ok()?;
+    let title_text = document
+        .select(&selector)
+        .next()?
+        .text()
+        .collect::<String>();
+
+    let trimmed = title_text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn extract_description(document: &Html) -> Option<String> {
+    extract_meta_content(document, "meta[property='og:description']")
+        .or_else(|| extract_meta_content(document, "meta[name='twitter:description']"))
+        .or_else(|| extract_meta_content(document, "meta[name='description']"))
+}
+
+fn extract_image(document: &Html, base_url: &str) -> Option<String> {
+    let base = Url::parse(base_url).ok()?;
+
+    extract_meta_content(document, "meta[property='og:image']")
+        .or_else(|| extract_meta_content(document, "meta[name='twitter:image']"))
+        .and_then(|content| resolve_url(&base, content))
+}
+
+fn extract_favicon(document: &Html, base_url: &str) -> Option<String> {
+    let base = Url::parse(base_url).ok()?;
+    let selectors = [
+        "link[rel='apple-touch-icon']",
+        "link[rel='icon']",
+        "link[rel='shortcut icon']",
+    ];
+
+    selectors
+        .iter()
+        .find_map(|selector| {
+            extract_link_href(document, selector).and_then(|href| resolve_url(&base, href))
+        })
+        .or_else(|| base.join("/favicon.ico").ok().map(|url| url.to_string()))
+}
+
+fn extract_link_href(document: &Html, selector: &str) -> Option<String> {
+    let selector = Selector::parse(selector).ok()?;
+    document
+        .select(&selector)
+        .next()?
+        .value()
+        .attr("href")
+        .map(ToString::to_string)
+}
+
+fn resolve_url(base: &Url, value: String) -> Option<String> {
+    if value.starts_with("http://") || value.starts_with("https://") {
+        Some(value)
+    } else {
+        base.join(&value).ok().map(|url| url.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn test_parse_metadata_prefers_open_graph_values() {
+        let html = indoc! {r#"
+            <html>
+              <head>
+                <title>Title tag</title>
+                <meta property="og:title" content="Open Graph title">
+                <meta property="og:description" content="Open Graph description">
+                <meta property="og:image" content="/images/card.png">
+                <link rel="icon" href="/favicon.png">
+              </head>
+            </html>
+        "#};
+
+        let metadata = parse_metadata("https://example.com/articles/page", html);
+
+        assert_eq!(metadata.title, "Open Graph title");
+        assert_eq!(
+            metadata.description.as_deref(),
+            Some("Open Graph description")
+        );
+        assert_eq!(
+            metadata.image_url.as_deref(),
+            Some("https://example.com/images/card.png")
+        );
+        assert_eq!(
+            metadata.favicon_url.as_deref(),
+            Some("https://example.com/favicon.png")
+        );
+    }
+
+    #[test]
+    fn test_parse_metadata_uses_fallback_values() {
+        let html = indoc! {r#"
+            <html>
+              <head>
+                <title>  Title tag  </title>
+                <meta name="description" content="Description">
+              </head>
+            </html>
+        "#};
+
+        let metadata = parse_metadata("https://example.com/articles/page", html);
+
+        assert_eq!(metadata.title, "Title tag");
+        assert_eq!(metadata.description.as_deref(), Some("Description"));
+        assert_eq!(metadata.image_url, None);
+        assert_eq!(
+            metadata.favicon_url.as_deref(),
+            Some("https://example.com/favicon.ico")
+        );
+    }
+}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -72,7 +72,8 @@ okawak_blog/
   - render moduleによるcontent kindごとのdocument組み立てと共通本文処理
   - render/htmlによる入力Markdownを事前書換えしないWikiLinkと数式を含む`pulldown-cmark` event生成とHTML変換。数式spanには`.math-inline` / `.math-display`を使用する
   - render/sanitizeによるlink・image URLとraw HTMLの安全化
-  - render/bookmarkによるsimple bookmark構文の判定、外部HTTPを伴うmetadata取得、rich bookmark HTML生成
+  - render/bookmarkによるsimple bookmark構文の判定、enrichmentの制御、rich bookmark HTML生成
+  - render/ogpによる外部HTTPを伴うbookmark metadata取得、OGP・Twitter Card・HTML fallbackの解析
   - classify moduleによる公開種別の確定と`section_path`の導出
   - artifacts moduleによるartifact構築、`site/`配下への書込み、生成結果のvalidation
   - `ObsidianFrontMatter`と`ContentKind`は`publish`入力形式として内部に保持する


### PR DESCRIPTION
## Summary

- extract bookmark HTTP and metadata parsing into a flat `render::ogp` module
- rename `BookmarkData` to `BookmarkMetadata`
- keep bookmark syntax, enrichment orchestration, and card generation in `bookmark.rs`
- add pure metadata parsing tests and update architecture documentation

This PR preserves enrichment behavior. HTTP client reuse, concurrent fetching, fallback API changes, and card generation cleanup remain separate follow-up work.

## Verification

- mise run format
- mise run test
- mise run clippy
- mise run check
- git diff --check