### PR TITLE
perf: fetch bookmark metadata concurrently

### DIFF
--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -21,7 +21,7 @@ use std::{
 use tracing::info;
 
 pub async fn publish(obsidian_dir: &Path, output_dir: &Path) -> Result<()> {
-    publish_with_bookmark_enricher(obsidian_dir, output_dir, rich_bookmark_enricher()?).await
+    publish_with_bookmark_enricher(obsidian_dir, output_dir, rich_bookmark_enricher()).await
 }
 
 #[tracing::instrument(

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -21,7 +21,7 @@ use std::{
 use tracing::info;
 
 pub async fn publish(obsidian_dir: &Path, output_dir: &Path) -> Result<()> {
-    publish_with_bookmark_enricher(obsidian_dir, output_dir, rich_bookmark_enricher()).await
+    publish_with_bookmark_enricher(obsidian_dir, output_dir, rich_bookmark_enricher()?).await
 }
 
 #[tracing::instrument(

--- a/crates/publish/src/render/bookmark.rs
+++ b/crates/publish/src/render/bookmark.rs
@@ -1,13 +1,14 @@
 use super::ogp::{self, BookmarkMetadata};
 use crate::error::Result;
 
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, join_all};
 use html_escape::{encode_double_quoted_attribute, encode_text};
 use regex::Regex;
-use std::future::Future;
-use std::ops::Range;
-use std::sync::Arc;
-use std::sync::LazyLock;
+use std::{
+    future::Future,
+    ops::Range,
+    sync::{Arc, LazyLock},
+};
 
 const HTML_INITIAL_CAPACITY: usize = 1024;
 const HTML_EXTENSION_CAPACITY: usize = 2048;
@@ -23,10 +24,13 @@ static SIMPLE_BOOKMARK_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Async function that enriches page HTML with rich bookmark cards.
 pub type BookmarkEnricher = Arc<dyn Fn(String) -> BoxFuture<'static, Result<String>> + Send + Sync>;
 
-pub(crate) fn rich_bookmark_enricher() -> BookmarkEnricher {
-    Arc::new(|html: String| {
-        Box::pin(async move { Ok(convert_simple_bookmarks_to_rich(&html).await) })
-    })
+pub(crate) fn rich_bookmark_enricher() -> Result<BookmarkEnricher> {
+    let fetcher = ogp::Fetcher::new()?;
+
+    Ok(Arc::new(move |html: String| {
+        let fetcher = fetcher.clone();
+        Box::pin(async move { Ok(convert_simple_bookmarks_to_rich(&html, &fetcher).await) })
+    }))
 }
 
 pub(super) struct SimpleBookmark<'a> {
@@ -193,15 +197,16 @@ where
 {
     let mut result = String::with_capacity(html_content.len() + HTML_EXTENSION_CAPACITY);
     let mut last_end = 0;
-
-    for bookmark in simple_bookmarks(html_content) {
+    let bookmarks = simple_bookmarks(html_content).map(|bookmark| {
         let range = bookmark.range();
-        let url = bookmark.href().to_string();
-        let original_title = bookmark.title().to_string();
+        let metadata = fetch_data(bookmark.href().to_string(), bookmark.title().to_string());
 
+        async move { (range, metadata.await) }
+    });
+
+    // `join_all` polls metadata fetches concurrently and returns them in source order.
+    for (range, metadata) in join_all(bookmarks).await {
         result.push_str(&html_content[last_end..range.start]);
-
-        let metadata = fetch_data(url, original_title).await;
         let rich_bookmark_html = generate_rich_bookmark(&metadata);
         result.push_str(&rich_bookmark_html);
 
@@ -214,12 +219,16 @@ where
 }
 
 /// Replaces simple bookmark markup with rich bookmark cards fetched from OGP metadata.
-async fn convert_simple_bookmarks_to_rich(html_content: &str) -> String {
-    convert_simple_bookmarks_with(html_content, |url, original_title| async move {
-        ogp::fetch(&url).await.unwrap_or_else(|error| {
-            tracing::warn!(%url, %error, "failed to fetch OGP metadata");
-            ogp::fallback(&url, &original_title)
-        })
+async fn convert_simple_bookmarks_to_rich(html_content: &str, fetcher: &ogp::Fetcher) -> String {
+    convert_simple_bookmarks_with(html_content, |url, original_title| {
+        let fetcher = fetcher.clone();
+
+        async move {
+            fetcher.fetch(&url).await.unwrap_or_else(|error| {
+                tracing::warn!(%url, %error, "failed to fetch OGP metadata");
+                ogp::fallback(&url, &original_title)
+            })
+        }
     })
     .await
 }
@@ -229,6 +238,14 @@ mod tests {
     use super::*;
     use indoc::indoc;
     use rstest::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use tokio::{
+        sync::Barrier,
+        time::{Duration, sleep, timeout},
+    };
 
     #[rstest]
     #[case::single_line(
@@ -389,5 +406,52 @@ mod tests {
         .await;
 
         assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn test_convert_simple_bookmarks_fetches_concurrently_and_preserves_order() {
+        let input = indoc! {r#"
+            <div class="bookmark"><a href="https://example.com">Example</a></div>
+            <div class="bookmark"><a href="https://github.com">GitHub</a></div>
+        "#};
+        let barrier = Arc::new(Barrier::new(2));
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+
+        let result = timeout(
+            Duration::from_secs(1),
+            convert_simple_bookmarks_with(input, {
+                let barrier = Arc::clone(&barrier);
+                let active = Arc::clone(&active);
+                let max_active = Arc::clone(&max_active);
+
+                move |url, title| {
+                    let barrier = Arc::clone(&barrier);
+                    let active = Arc::clone(&active);
+                    let max_active = Arc::clone(&max_active);
+
+                    async move {
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active.fetch_max(current, Ordering::SeqCst);
+                        barrier.wait().await;
+
+                        if url == "https://example.com" {
+                            sleep(Duration::from_millis(20)).await;
+                        }
+
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        ogp::fallback(&url, &title)
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("bookmark metadata fetches should run concurrently");
+
+        assert_eq!(max_active.load(Ordering::SeqCst), 2);
+        assert!(
+            result.find("https://example.com").unwrap()
+                < result.find("https://github.com").unwrap()
+        );
     }
 }

--- a/crates/publish/src/render/bookmark.rs
+++ b/crates/publish/src/render/bookmark.rs
@@ -24,13 +24,19 @@ static SIMPLE_BOOKMARK_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Async function that enriches page HTML with rich bookmark cards.
 pub type BookmarkEnricher = Arc<dyn Fn(String) -> BoxFuture<'static, Result<String>> + Send + Sync>;
 
-pub(crate) fn rich_bookmark_enricher() -> Result<BookmarkEnricher> {
-    let fetcher = ogp::Fetcher::new()?;
+pub(crate) fn rich_bookmark_enricher() -> BookmarkEnricher {
+    let fetcher = match ogp::Fetcher::new() {
+        Ok(fetcher) => Some(fetcher),
+        Err(error) => {
+            tracing::warn!(%error, "failed to initialize OGP metadata fetcher");
+            None
+        }
+    };
 
-    Ok(Arc::new(move |html: String| {
+    Arc::new(move |html: String| {
         let fetcher = fetcher.clone();
-        Box::pin(async move { Ok(convert_simple_bookmarks_to_rich(&html, &fetcher).await) })
-    }))
+        Box::pin(async move { Ok(convert_simple_bookmarks_to_rich(&html, fetcher).await) })
+    })
 }
 
 pub(super) struct SimpleBookmark<'a> {
@@ -219,15 +225,21 @@ where
 }
 
 /// Replaces simple bookmark markup with rich bookmark cards fetched from OGP metadata.
-async fn convert_simple_bookmarks_to_rich(html_content: &str, fetcher: &ogp::Fetcher) -> String {
-    convert_simple_bookmarks_with(html_content, |url, original_title| {
+async fn convert_simple_bookmarks_to_rich(
+    html_content: &str,
+    fetcher: Option<ogp::Fetcher>,
+) -> String {
+    convert_simple_bookmarks_with(html_content, move |url, original_title| {
         let fetcher = fetcher.clone();
 
         async move {
-            fetcher.fetch(&url).await.unwrap_or_else(|error| {
-                tracing::warn!(%url, %error, "failed to fetch OGP metadata");
-                ogp::fallback(&url, &original_title)
-            })
+            match fetcher {
+                Some(fetcher) => fetcher.fetch(&url).await.unwrap_or_else(|error| {
+                    tracing::warn!(%url, %error, "failed to fetch OGP metadata");
+                    ogp::fallback(&url, &original_title)
+                }),
+                None => ogp::fallback(&url, &original_title),
+            }
         }
     })
     .await
@@ -406,6 +418,17 @@ mod tests {
         .await;
 
         assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn test_convert_simple_bookmarks_to_rich_without_fetcher() {
+        let input = r#"<div class="bookmark"><a href="https://example.com">Example</a></div>"#;
+
+        let result = convert_simple_bookmarks_to_rich(input, None).await;
+
+        assert!(result.contains("class=\"bookmark-link\""));
+        assert!(result.contains("https://example.com"));
+        assert!(result.contains(">Example</div>"));
     }
 
     #[tokio::test]

--- a/crates/publish/src/render/ogp.rs
+++ b/crates/publish/src/render/ogp.rs
@@ -1,11 +1,47 @@
 use crate::error::Result;
 
 use scraper::{Html, Selector};
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Semaphore;
 use url::Url;
 
+const CONCURRENT_REQUEST_LIMIT: usize = 8;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const USER_AGENT: &str = "publish-bookmark/1.0 (+https://github.com/okawak/okawak_blog)";
+
+#[derive(Clone)]
+pub(super) struct Fetcher {
+    client: reqwest::Client,
+    permits: Arc<Semaphore>,
+}
+
+impl Fetcher {
+    pub(super) fn new() -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()?;
+
+        Ok(Self {
+            client,
+            permits: Arc::new(Semaphore::new(CONCURRENT_REQUEST_LIMIT)),
+        })
+    }
+
+    /// Fetches bookmark metadata while bounding requests across all rendered documents.
+    pub(super) async fn fetch(&self, url: &str) -> Result<BookmarkMetadata> {
+        let html_content = {
+            let _permit = self
+                .permits
+                .acquire()
+                .await
+                .expect("bookmark request semaphore must remain open");
+            fetch_html_content(&self.client, url).await?
+        };
+
+        Ok(parse_metadata(url, &html_content))
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct BookmarkMetadata {
@@ -14,14 +50,6 @@ pub(super) struct BookmarkMetadata {
     pub(super) description: Option<String>,
     pub(super) image_url: Option<String>,
     pub(super) favicon_url: Option<String>,
-}
-
-/// Fetches bookmark metadata from a URL.
-pub(super) async fn fetch(url: &str) -> Result<BookmarkMetadata> {
-    let client = create_http_client()?;
-    let html_content = fetch_html_content(&client, url).await?;
-
-    Ok(parse_metadata(url, &html_content))
 }
 
 pub(super) fn fallback(url: &str, original_title: &str) -> BookmarkMetadata {
@@ -36,14 +64,6 @@ pub(super) fn fallback(url: &str, original_title: &str) -> BookmarkMetadata {
         image_url: None,
         favicon_url: None,
     }
-}
-
-fn create_http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .user_agent(USER_AGENT)
-        .timeout(REQUEST_TIMEOUT)
-        .build()
-        .map_err(Into::into)
 }
 
 async fn fetch_html_content(client: &reqwest::Client, url: &str) -> Result<String> {

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -73,7 +73,7 @@ okawak_blog/
   - render/htmlによる入力Markdownを事前書換えしないWikiLinkと数式を含む`pulldown-cmark` event生成とHTML変換。数式spanには`.math-inline` / `.math-display`を使用する
   - render/sanitizeによるlink・image URLとraw HTMLの安全化
   - render/bookmarkによるsimple bookmark構文の判定、enrichmentの制御、rich bookmark HTML生成
-  - render/ogpによる外部HTTPを伴うbookmark metadata取得、OGP・Twitter Card・HTML fallbackの解析
+  - render/ogpによる共有HTTP clientと上限付き並行処理を使ったbookmark metadata取得、OGP・Twitter Card・HTML fallbackの解析
   - classify moduleによる公開種別の確定と`section_path`の導出
   - artifacts moduleによるartifact構築、`site/`配下への書込み、生成結果のvalidation
   - `ObsidianFrontMatter`と`ContentKind`は`publish`入力形式として内部に保持する


### PR DESCRIPTION
## Summary
- reuse a single reqwest client across bookmark enrichment
- fetch bookmark metadata concurrently while limiting active requests to 8
- preserve bookmark output order and per-bookmark fallback behavior
- document the shared client and bounded concurrency design

## Tests
- mise run format
- mise run test
- mise run clippy
- mise run check
- git diff --check

Closes #187