### PR TITLE
refactor: require category landings before render

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ category: "tech"
 - `page`: `kind: page` のときに使う固定ページキーです。
 
 本文は closing `---` の次の行から始まり、Obsidian link や bookmark 埋め込みを含められます。front matter がない Markdown は`publish`でスキップされます。article は frontmatter の `category` と同名のディレクトリ配下に置く必要があります。category 配下のディレクトリ構造は path から `section_path` として導出され、category page 上の grouped navigation に使われます。
+記事が存在するカテゴリでは、対応する`kind: category`のlanding pageが必要です。
 
 ## 運用モデル
 

--- a/crates/publish/src/artifacts/builder.rs
+++ b/crates/publish/src/artifacts/builder.rs
@@ -25,3 +25,83 @@ pub(crate) fn build_site_artifacts(
         site_metadata,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use domain::{Category, SectionPath, Slug, Timestamp, Title};
+
+    fn article_meta(
+        title: &str,
+        slug: &str,
+        category: Category,
+        priority: Option<i32>,
+        created_at: &str,
+    ) -> ArticleMeta {
+        ArticleMeta {
+            slug: Slug::new(slug.to_string()).unwrap(),
+            title: Title::new(title.to_string()).unwrap(),
+            category,
+            section_path: SectionPath::default(),
+            description: Some(format!("{title} summary")),
+            tags: vec!["rust".to_string()],
+            priority,
+            created_at: Timestamp::new(created_at.to_string()).unwrap(),
+            updated_at: Timestamp::new(created_at.to_string()).unwrap(),
+        }
+    }
+
+    fn category_landing(category: Category, title: &str) -> CategoryLandingMeta {
+        CategoryLandingMeta {
+            category,
+            title: Title::new(title.to_string()).unwrap(),
+            description: None,
+            updated_at: Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_build_site_artifacts() {
+        let artifacts = build_site_artifacts(
+            vec![
+                article_meta(
+                    "First",
+                    "first0000001",
+                    Category::Tech,
+                    Some(1),
+                    "2025-01-01T00:00:00+09:00",
+                ),
+                article_meta(
+                    "Second",
+                    "second000002",
+                    Category::Daily,
+                    Some(10),
+                    "2025-01-02T00:00:00+09:00",
+                ),
+            ],
+            vec![],
+        );
+
+        assert_eq!(artifacts.article_index.len(), 2);
+        assert_eq!(artifacts.category_indexes.len(), 2);
+        assert!(
+            artifacts
+                .category_indexes
+                .iter()
+                .all(|index| index.landing.is_none())
+        );
+        assert_eq!(artifacts.site_metadata.total_articles, 2);
+        assert_eq!(artifacts.article_index[0].slug.as_str(), "second000002");
+    }
+
+    #[test]
+    fn test_build_site_artifacts_includes_landing_only_category() {
+        let artifacts =
+            build_site_artifacts(vec![], vec![category_landing(Category::Physics, "Physics")]);
+
+        assert_eq!(artifacts.category_indexes.len(), 1);
+        assert_eq!(artifacts.category_indexes[0].category, Category::Physics);
+        assert_eq!(artifacts.site_metadata.categories.len(), 1);
+        assert_eq!(artifacts.site_metadata.categories[0].article_count, 0);
+    }
+}

--- a/crates/publish/src/artifacts/validator.rs
+++ b/crates/publish/src/artifacts/validator.rs
@@ -175,3 +175,140 @@ fn read_required_nonempty(site_root: &Path, relative_path: &Path) -> Result<Stri
     }
     Ok(contents)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::builder::build_site_artifacts;
+    use super::super::writer::{
+        SiteDirectories, write_article_page, write_category_page, write_page_document,
+        write_site_artifacts,
+    };
+    use super::*;
+    use domain::{ArticleMeta, CategoryLandingMeta, PageKey, SectionPath, Timestamp, Title};
+    use tempfile::TempDir;
+
+    const ARTICLE_PATH: &str = "site/articles/tech/artifact00001.html";
+    const CATEGORY_PATH: &str = "site/categories/tech/page.html";
+    const ABOUT_PATH: &str = "site/pages/about.json";
+
+    fn write_complete_site() -> TempDir {
+        let temp_dir = TempDir::new().unwrap();
+        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
+        let timestamp = Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap();
+        let article = ArticleMeta {
+            slug: Slug::new("artifact00001".to_string()).unwrap(),
+            title: Title::new("Artifact Test".to_string()).unwrap(),
+            category: Category::Tech,
+            section_path: SectionPath::default(),
+            description: Some("Artifact summary".to_string()),
+            tags: vec!["rust".to_string()],
+            priority: Some(1),
+            created_at: timestamp.clone(),
+            updated_at: timestamp.clone(),
+        };
+        let landing = CategoryLandingMeta {
+            category: Category::Tech,
+            title: Title::new("Tech".to_string()).unwrap(),
+            description: Some("Tech landing".to_string()),
+            updated_at: timestamp,
+        };
+        let artifacts = build_site_artifacts(vec![article.clone()], vec![landing]);
+
+        write_article_page(
+            &directories,
+            article.category,
+            &article.slug,
+            "<h1>Artifact Test</h1>",
+        )
+        .unwrap();
+        write_category_page(&directories, Category::Tech, "<h1>Tech</h1>").unwrap();
+        write_page_document(
+            &directories,
+            &PageArtifactDocument {
+                page: PageKey::new("about".to_string()).unwrap(),
+                title: "About".to_string(),
+                description: Some("About this site".to_string()),
+                html: "<article><h1>About</h1></article>".to_string(),
+                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
+            },
+        )
+        .unwrap();
+        write_site_artifacts(&directories, &artifacts).unwrap();
+
+        temp_dir
+    }
+
+    #[test]
+    fn test_validate_site_artifacts_accepts_complete_site() {
+        let temp_dir = write_complete_site();
+
+        let summary = validate_site_artifacts(temp_dir.path().join("site")).unwrap();
+
+        assert_eq!(summary.article_count, 1);
+        assert_eq!(summary.category_count, 1);
+    }
+
+    #[test]
+    fn test_validate_site_artifacts_rejects_empty_article_index() {
+        let temp_dir = TempDir::new().unwrap();
+        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
+        write_site_artifacts(&directories, &build_site_artifacts(vec![], vec![])).unwrap();
+
+        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
+
+        assert!(error.to_string().contains("at least one article"));
+    }
+
+    #[test]
+    fn test_validate_site_artifacts_rejects_missing_article_html() {
+        let temp_dir = write_complete_site();
+        fs::remove_file(temp_dir.path().join(ARTICLE_PATH)).unwrap();
+
+        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("articles/tech/artifact00001.html")
+        );
+    }
+
+    #[test]
+    fn test_validate_site_artifacts_rejects_missing_category_page() {
+        let temp_dir = write_complete_site();
+        fs::remove_file(temp_dir.path().join(CATEGORY_PATH)).unwrap();
+
+        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
+
+        assert!(error.to_string().contains("categories/tech/page.html"));
+    }
+
+    #[test]
+    fn test_validate_site_artifacts_rejects_missing_about_page() {
+        let temp_dir = write_complete_site();
+        fs::remove_file(temp_dir.path().join(ABOUT_PATH)).unwrap();
+
+        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
+
+        assert!(error.to_string().contains("pages/about.json"));
+    }
+
+    #[test]
+    fn test_validate_site_artifacts_rejects_article_category_missing_from_metadata() {
+        let temp_dir = write_complete_site();
+        fs::write(
+            temp_dir.path().join("site/metadata/site.json"),
+            serde_json::to_string_pretty(&SiteMetadataDocument {
+                total_articles: 1,
+                categories: vec![],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
+
+        assert!(error.to_string().contains("missing article categories"));
+        assert!(error.to_string().contains("tech"));
+    }
+}

--- a/crates/publish/src/artifacts/writer.rs
+++ b/crates/publish/src/artifacts/writer.rs
@@ -103,13 +103,6 @@ pub(crate) fn write_site_artifacts(
             &category_dir.join("index.json"),
             &CategoryIndexDocument::from(category_index),
         )?;
-
-        if category_index.landing.is_none() {
-            fs::write(
-                category_dir.join("page.html"),
-                build_fallback_category_page_html(category_index),
-            )?;
-        }
     }
 
     write_json_pretty(
@@ -127,166 +120,71 @@ fn write_json_pretty(path: &Path, value: &impl Serialize) -> Result<()> {
     Ok(())
 }
 
-fn build_fallback_category_page_html(category_index: &domain::CategoryIndex) -> String {
-    format!(
-        "<article><h1>{}</h1><p>{}カテゴリの記事一覧です。</p></article>",
-        category_index.category.display_name(),
-        category_index.category.display_name(),
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::builder::build_site_artifacts;
-    use super::super::validator::validate_site_artifacts;
     use super::*;
-    use domain::{
-        ArticleMeta, Category, CategoryLandingMeta, PageKey, SectionPath, Timestamp, Title,
-    };
+    use domain::{ArticleMeta, CategoryLandingMeta, PageKey, SectionPath, Timestamp, Title};
     use tempfile::TempDir;
 
-    fn build_article_meta(
-        title: &str,
-        slug: &str,
-        category: Category,
-        priority: Option<i32>,
-        created_at: &str,
-    ) -> ArticleMeta {
+    fn article_meta() -> ArticleMeta {
         ArticleMeta {
-            slug: Slug::new(slug.to_string()).unwrap(),
-            title: Title::new(title.to_string()).unwrap(),
-            category,
+            slug: Slug::new("artifact00001".to_string()).unwrap(),
+            title: Title::new("Artifact Test".to_string()).unwrap(),
+            category: Category::Tech,
             section_path: SectionPath::default(),
-            description: Some(format!("{title} summary")),
+            description: Some("Artifact summary".to_string()),
             tags: vec!["rust".to_string()],
-            priority,
-            created_at: Timestamp::new(created_at.to_string()).unwrap(),
-            updated_at: Timestamp::new(created_at.to_string()).unwrap(),
+            priority: Some(1),
+            created_at: Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap(),
+            updated_at: Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap(),
         }
     }
 
-    fn build_category_landing(
-        category: Category,
-        title: &str,
-        description: Option<&str>,
-    ) -> CategoryLandingMeta {
+    fn category_landing() -> CategoryLandingMeta {
         CategoryLandingMeta {
-            category,
-            title: Title::new(title.to_string()).unwrap(),
-            description: description.map(str::to_string),
+            category: Category::Tech,
+            title: Title::new("Tech".to_string()).unwrap(),
+            description: Some("Tech landing".to_string()),
             updated_at: Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap(),
         }
     }
 
     #[test]
-    fn test_build_site_artifacts() {
-        let artifacts = build_site_artifacts(
-            vec![
-                build_article_meta(
-                    "First",
-                    "first0000001",
-                    Category::Tech,
-                    Some(1),
-                    "2025-01-01T00:00:00+09:00",
-                ),
-                build_article_meta(
-                    "Second",
-                    "second000002",
-                    Category::Daily,
-                    Some(10),
-                    "2025-01-02T00:00:00+09:00",
-                ),
-            ],
-            vec![],
-        );
-
-        assert_eq!(artifacts.article_index.len(), 2);
-        assert_eq!(artifacts.category_indexes.len(), 2);
-        assert!(
-            artifacts
-                .category_indexes
-                .iter()
-                .all(|index| index.landing.is_none())
-        );
-        assert_eq!(artifacts.site_metadata.total_articles, 2);
-        assert_eq!(artifacts.article_index[0].slug.as_str(), "second000002");
-    }
-
-    #[test]
     fn test_write_local_artifacts() {
         let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let article_meta = build_article_meta(
-            "Artifact Test",
-            "artifact00001",
-            Category::Tech,
-            Some(1),
-            "2025-01-01T00:00:00+09:00",
-        );
-        let site_artifacts = build_site_artifacts(
-            vec![article_meta.clone()],
-            vec![build_category_landing(
-                Category::Tech,
-                "Tech",
-                Some("Tech landing"),
-            )],
-        );
+        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
+        let article = article_meta();
+        let artifacts = build_site_artifacts(vec![article.clone()], vec![category_landing()]);
 
         let article_path = write_article_page(
-            &site_directories,
-            Category::Tech,
-            &article_meta.slug,
+            &directories,
+            article.category,
+            &article.slug,
             "<h1>Artifact Test</h1>",
         )
         .unwrap();
-        let category_page_path =
-            write_category_page(&site_directories, Category::Tech, "<h1>Tech</h1>").unwrap();
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
+        let category_path =
+            write_category_page(&directories, Category::Tech, "<h1>Tech</h1>").unwrap();
+        write_site_artifacts(&directories, &artifacts).unwrap();
 
-        assert!(article_path.exists());
-        assert_eq!(
+        for path in [
             article_path,
-            site_directories
-                .articles_dir
-                .join("tech")
-                .join("artifact00001.html")
-        );
-        assert!(category_page_path.exists());
-        assert!(
-            site_directories.articles_dir.join("index.json").exists(),
-            "articles/index.json should exist"
-        );
-        assert!(
-            site_directories
-                .categories_dir
-                .join("tech/index.json")
-                .exists(),
-            "categories/tech/index.json should exist"
-        );
-        assert!(
-            site_directories
-                .categories_dir
-                .join("tech/page.html")
-                .exists(),
-            "categories/tech/page.html should exist"
-        );
-        assert!(
-            site_directories.metadata_dir.join("site.json").exists(),
-            "metadata/site.json should exist"
-        );
-        assert!(
-            site_directories.pages_dir.exists(),
-            "pages directory should exist"
-        );
+            category_path,
+            directories.articles_dir.join("index.json"),
+            directories.categories_dir.join("tech/index.json"),
+            directories.metadata_dir.join("site.json"),
+        ] {
+            assert!(path.exists(), "{} should exist", path.display());
+        }
     }
 
     #[test]
     fn test_write_page_document() {
         let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-
+        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
         let output_path = write_page_document(
-            &site_directories,
+            &directories,
             &PageArtifactDocument {
                 page: PageKey::new("about".to_string()).unwrap(),
                 title: "About".to_string(),
@@ -297,17 +195,16 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(output_path, site_directories.pages_dir.join("about.json"));
+        assert_eq!(output_path, directories.pages_dir.join("about.json"));
         assert!(output_path.exists());
     }
 
     #[test]
     fn test_write_home_fragment() {
         let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-
+        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
         let output_path = write_home_fragment(
-            &site_directories,
+            &directories,
             &HomeFragmentArtifactDocument {
                 title: "Home".to_string(),
                 description: Some("Home introduction".to_string()),
@@ -319,219 +216,6 @@ mod tests {
 
         assert_eq!(output_path, temp_dir.path().join("site/home.json"));
         assert!(output_path.exists());
-        assert!(!site_directories.pages_dir.join("home.json").exists());
-    }
-
-    #[test]
-    fn test_build_site_artifacts_includes_landing_only_category_in_indexes_and_metadata() {
-        let artifacts = build_site_artifacts(
-            vec![],
-            vec![build_category_landing(Category::Physics, "Physics", None)],
-        );
-
-        assert_eq!(artifacts.category_indexes.len(), 1);
-        assert_eq!(artifacts.category_indexes[0].category, Category::Physics);
-        assert_eq!(artifacts.site_metadata.categories.len(), 1);
-        assert_eq!(artifacts.site_metadata.categories[0].article_count, 0);
-    }
-
-    #[test]
-    fn test_write_site_artifacts_creates_fallback_category_page_when_landing_is_missing() {
-        let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let article_meta = build_article_meta(
-            "Artifact Test",
-            "artifact00001",
-            Category::Tech,
-            Some(1),
-            "2025-01-01T00:00:00+09:00",
-        );
-        let site_artifacts = build_site_artifacts(vec![article_meta], vec![]);
-
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
-
-        let fallback_html = fs::read_to_string(
-            site_directories
-                .categories_dir
-                .join("tech")
-                .join("page.html"),
-        )
-        .unwrap();
-
-        assert!(fallback_html.contains("<h1>技術</h1>"));
-        assert!(fallback_html.contains("技術カテゴリの記事一覧です。"));
-    }
-
-    #[test]
-    fn test_validate_site_artifacts_accepts_complete_site() {
-        let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let article_meta = build_article_meta(
-            "Artifact Test",
-            "artifact00001",
-            Category::Tech,
-            Some(1),
-            "2025-01-01T00:00:00+09:00",
-        );
-        let site_artifacts = build_site_artifacts(vec![article_meta.clone()], vec![]);
-
-        write_article_page(
-            &site_directories,
-            Category::Tech,
-            &article_meta.slug,
-            "<h1>Artifact Test</h1>",
-        )
-        .unwrap();
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
-        write_required_about_page(&site_directories);
-
-        let summary = validate_site_artifacts(temp_dir.path().join("site")).unwrap();
-
-        assert_eq!(summary.article_count, 1);
-        assert_eq!(summary.category_count, 1);
-    }
-
-    #[test]
-    fn test_validate_site_artifacts_rejects_empty_article_index() {
-        let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let site_artifacts = build_site_artifacts(vec![], vec![]);
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
-
-        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
-
-        assert!(error.to_string().contains("at least one article"));
-    }
-
-    #[test]
-    fn test_validate_site_artifacts_rejects_missing_article_html() {
-        let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let article_meta = build_article_meta(
-            "Artifact Test",
-            "artifact00001",
-            Category::Tech,
-            Some(1),
-            "2025-01-01T00:00:00+09:00",
-        );
-        let site_artifacts = build_site_artifacts(vec![article_meta], vec![]);
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
-
-        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
-
-        assert!(
-            error
-                .to_string()
-                .contains("articles/tech/artifact00001.html")
-        );
-    }
-
-    #[test]
-    fn test_validate_site_artifacts_rejects_missing_category_page() {
-        let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let article_meta = build_article_meta(
-            "Artifact Test",
-            "artifact00001",
-            Category::Tech,
-            Some(1),
-            "2025-01-01T00:00:00+09:00",
-        );
-        let site_artifacts = build_site_artifacts(vec![article_meta.clone()], vec![]);
-        write_article_page(
-            &site_directories,
-            Category::Tech,
-            &article_meta.slug,
-            "<h1>Artifact Test</h1>",
-        )
-        .unwrap();
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
-        fs::remove_file(
-            site_directories
-                .categories_dir
-                .join("tech")
-                .join("page.html"),
-        )
-        .unwrap();
-
-        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
-
-        assert!(error.to_string().contains("categories/tech/page.html"));
-    }
-
-    #[test]
-    fn test_validate_site_artifacts_rejects_missing_about_page() {
-        let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let article_meta = build_article_meta(
-            "Artifact Test",
-            "artifact00001",
-            Category::Tech,
-            Some(1),
-            "2025-01-01T00:00:00+09:00",
-        );
-        let site_artifacts = build_site_artifacts(vec![article_meta.clone()], vec![]);
-        write_article_page(
-            &site_directories,
-            Category::Tech,
-            &article_meta.slug,
-            "<h1>Artifact Test</h1>",
-        )
-        .unwrap();
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
-
-        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
-
-        assert!(error.to_string().contains("pages/about.json"));
-    }
-
-    #[test]
-    fn test_validate_site_artifacts_rejects_article_category_missing_from_metadata() {
-        let temp_dir = TempDir::new().unwrap();
-        let site_directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        let article_meta = build_article_meta(
-            "Artifact Test",
-            "artifact00001",
-            Category::Tech,
-            Some(1),
-            "2025-01-01T00:00:00+09:00",
-        );
-        let site_artifacts = build_site_artifacts(vec![article_meta.clone()], vec![]);
-        write_article_page(
-            &site_directories,
-            Category::Tech,
-            &article_meta.slug,
-            "<h1>Artifact Test</h1>",
-        )
-        .unwrap();
-        write_site_artifacts(&site_directories, &site_artifacts).unwrap();
-        write_required_about_page(&site_directories);
-        write_json_pretty(
-            &site_directories.metadata_dir.join("site.json"),
-            &SiteMetadataDocument {
-                total_articles: 1,
-                categories: vec![],
-            },
-        )
-        .unwrap();
-
-        let error = validate_site_artifacts(temp_dir.path().join("site")).unwrap_err();
-
-        assert!(error.to_string().contains("missing article categories"));
-        assert!(error.to_string().contains("tech"));
-    }
-
-    fn write_required_about_page(site_directories: &SiteDirectories) {
-        write_page_document(
-            site_directories,
-            &PageArtifactDocument {
-                page: PageKey::new("about".to_string()).unwrap(),
-                title: "About".to_string(),
-                description: Some("About this site".to_string()),
-                html: "<article><h1>About</h1></article>".to_string(),
-                updated_at: "2025-01-01T00:00:00+09:00".to_string(),
-            },
-        )
-        .unwrap();
+        assert!(!directories.pages_dir.join("home.json").exists());
     }
 }

--- a/crates/publish/src/classify.rs
+++ b/crates/publish/src/classify.rs
@@ -220,6 +220,22 @@ pub(crate) fn ensure_unique_category_landings(categories: &[ParsedCategoryFile])
     Ok(())
 }
 
+pub(crate) fn ensure_category_landings(
+    articles: &[ParsedArticleFile],
+    categories: &[ParsedCategoryFile],
+) -> Result<()> {
+    let category_landings: HashSet<_> = categories.iter().map(|file| file.category).collect();
+    let missing = articles
+        .iter()
+        .map(|file| file.category)
+        .find(|category| !category_landings.contains(category));
+
+    match missing {
+        Some(category) => Err(PublishError::MissingCategoryLanding { category }),
+        None => Ok(()),
+    }
+}
+
 fn parse_category(category: Option<&str>) -> Result<Category> {
     let category = category
         .ok_or_else(|| PublishError::Parse("Completed content requires a category".to_string()))?;

--- a/crates/publish/src/error.rs
+++ b/crates/publish/src/error.rs
@@ -39,4 +39,7 @@ pub enum PublishError {
 
     #[error("publish rejected {count} invalid content file(s)")]
     ContentErrors { count: usize },
+
+    #[error("missing category landing: {category}")]
+    MissingCategoryLanding { category: domain::Category },
 }

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -4,7 +4,7 @@ use crate::artifacts::{
 };
 use crate::classify::{
     ParsedArticleFile, ParsedCategoryFile, ParsedHomeFile, ParsedPageFile, classify_obsidian_files,
-    ensure_unique_category_landings, ensure_unique_page_keys,
+    ensure_category_landings, ensure_unique_category_landings, ensure_unique_page_keys,
 };
 use crate::error::{PublishError, Result};
 use crate::render::{
@@ -62,6 +62,7 @@ pub async fn publish_with_bookmark_enricher(
 
     ensure_unique_page_keys(&classified_files.pages)?;
     ensure_unique_category_landings(&classified_files.categories)?;
+    ensure_category_landings(&classified_files.articles, &classified_files.categories)?;
 
     let link_index = links::Index::from_classified_files(&classified_files);
     let classify::ClassifiedFiles {

--- a/crates/publish/tests/e2e_test.rs
+++ b/crates/publish/tests/e2e_test.rs
@@ -6,7 +6,7 @@ use publish::publish;
 use std::fs;
 use tempfile::TempDir;
 use test_fixtures::collect_html_files;
-use test_fixtures::write_about_page;
+use test_fixtures::{write_about_page, write_tech_category_landing};
 
 /// End-to-end test that simulates a realistic Obsidian vault.
 #[tokio::test]
@@ -18,6 +18,7 @@ async fn test_end_to_end_obsidian_processing() {
     // Create a realistic Obsidian directory structure.
     fs::create_dir_all(&obsidian_dir).unwrap();
     write_about_page(&obsidian_dir);
+    write_tech_category_landing(&obsidian_dir);
     fs::create_dir_all(obsidian_dir.join("tech")).unwrap();
     fs::create_dir_all(obsidian_dir.join("blog")).unwrap();
 
@@ -331,6 +332,7 @@ async fn test_large_volume_processing() {
     let tech_dir = obsidian_dir.join("tech");
     fs::create_dir_all(&tech_dir).unwrap();
     write_about_page(&obsidian_dir);
+    write_tech_category_landing(&obsidian_dir);
 
     // Generate 100 test files.
     for i in 0..100 {

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -5,7 +5,7 @@ use publish::{BookmarkEnricher, PublishError, publish, publish_with_bookmark_enr
 use rstest::rstest;
 use std::{fs, path::Path, sync::Arc};
 use tempfile::TempDir;
-use test_fixtures::{collect_html_files, write_about_page};
+use test_fixtures::{collect_html_files, write_about_page, write_tech_category_landing};
 
 fn offline_bookmark_enricher() -> BookmarkEnricher {
     Arc::new(|html: String| {
@@ -96,6 +96,7 @@ async fn test_publish_with_sample_file() {
     let sample_file = obsidian_dir.join("tech/test.md");
     fs::write(&sample_file, sample_content).unwrap();
     write_about_page(&obsidian_dir);
+    write_tech_category_landing(&obsidian_dir);
 
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
@@ -221,6 +222,7 @@ async fn test_publish_skips_incomplete_file() {
     fs::write(&sample_file, incomplete_content).unwrap();
     write_required_article(&obsidian_dir);
     write_about_page(&obsidian_dir);
+    write_tech_category_landing(&obsidian_dir);
 
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
@@ -258,6 +260,7 @@ async fn test_publish_with_static_page_file() {
     let page_file = obsidian_dir.join("about.md");
     fs::write(&page_file, page_content).unwrap();
     write_required_article(&obsidian_dir);
+    write_tech_category_landing(&obsidian_dir);
 
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
@@ -297,6 +300,7 @@ async fn test_publish_with_home_fragment_file() {
     fs::write(&page_file, page_content).unwrap();
     write_required_article(&obsidian_dir);
     write_about_page(&obsidian_dir);
+    write_tech_category_landing(&obsidian_dir);
 
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
@@ -411,6 +415,26 @@ async fn test_publish_with_category_landing_file() {
     assert!(category_page.contains("Welcome to the category landing page."));
 }
 
+#[tokio::test]
+async fn test_publish_rejects_missing_category_landing_before_writing() {
+    let temp_dir = TempDir::new().unwrap();
+    let obsidian_dir = temp_dir.path().join("obsidian");
+    let output_dir = temp_dir.path().join("dist");
+
+    write_required_article(&obsidian_dir);
+    write_about_page(&obsidian_dir);
+
+    let result = publish(&obsidian_dir, &output_dir).await;
+
+    assert!(matches!(
+        result,
+        Err(PublishError::MissingCategoryLanding {
+            category: domain::Category::Tech
+        })
+    ));
+    assert!(!output_dir.exists());
+}
+
 #[rstest]
 #[case::blank_title("   ", "# Tech\n\nCategory description.")]
 #[case::blank_body("Tech", "   ")]
@@ -489,6 +513,7 @@ async fn test_publish_with_bookmark_enricher() {
     let sample_file = obsidian_dir.join("tech/bookmark.md");
     fs::write(&sample_file, sample_content).unwrap();
     write_about_page(&obsidian_dir);
+    write_tech_category_landing(&obsidian_dir);
 
     let result =
         publish_with_bookmark_enricher(&obsidian_dir, &output_dir, offline_bookmark_enricher())

--- a/crates/publish/tests/test_fixtures.rs
+++ b/crates/publish/tests/test_fixtures.rs
@@ -42,3 +42,26 @@ This page is required for deployment.
     )
     .unwrap();
 }
+
+pub(crate) fn write_tech_category_landing(obsidian_dir: &Path) {
+    let category_dir = obsidian_dir.join("tech");
+    fs::create_dir_all(&category_dir).unwrap();
+    fs::write(
+        category_dir.join("category.md"),
+        r#"---
+title: "Tech"
+kind: category
+category: tech
+summary: "Technology articles"
+created: "2025-01-01T00:00:00+09:00"
+updated: "2025-01-01T00:00:00+09:00"
+is_completed: true
+---
+
+# Tech
+
+Technology articles.
+"#,
+    )
+    .unwrap();
+}

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -274,8 +274,8 @@ artifact の意味は次の通り。
   - 各記事に`section_path`を含む
 - `categories/<category>/page.html`
   - カテゴリ landing page 本文
-  - landing Markdown が無い場合は fallback HTML を生成する
-  - landing Markdown がある場合はfrontmatterのtitleと本文を必須とし、空値をfallbackで補完しない
+  - 記事が存在するカテゴリでは landing Markdown を必須とする
+  - frontmatterのtitleと本文を必須とし、空値を補完しない
 - `pages/<page>.json`
   - 固定ページ
   - HTML 本文と title / description / updated_at を含む

--- a/docs/content/obsidian-template.md
+++ b/docs/content/obsidian-template.md
@@ -122,6 +122,7 @@ updated: "2026-04-12T10:00:00+09:00"
 
 - ファイル名は固定しない
 - 同じカテゴリ配下で `kind=category` を持つ Markdown を、そのカテゴリの landing page として扱う
+- 記事が存在するカテゴリでは landing page を必須とする
 - 対応する artifact は `site/categories/<category>/page.html` と `site/categories/<category>/index.json`
 
 ## 3. 固定ページ


### PR DESCRIPTION
## Summary

- validate category landing coverage before rendering or writing artifacts
- remove generated fallback category HTML from the artifact writer
- move builder and validator tests to their owning modules
- document category landing requirements

## Testing

- mise run format
- mise run test
- mise run clippy