### PR TITLE
refactor: clarify artifact writing boundaries

### DIFF
--- a/crates/publish/src/artifacts.rs
+++ b/crates/publish/src/artifacts.rs
@@ -2,6 +2,6 @@ mod builder;
 mod validator;
 mod writer;
 
-pub(crate) use builder::build_site_artifacts;
+pub(crate) use builder::build_site_documents;
 pub(crate) use validator::validate_site_artifacts;
-pub(crate) use writer::{SiteDirectories, write_article_page, write_site_artifacts};
+pub(crate) use writer::{SiteOutput, write_article_page, write_site_documents};

--- a/crates/publish/src/artifacts/builder.rs
+++ b/crates/publish/src/artifacts/builder.rs
@@ -1,26 +1,26 @@
 use crate::error::Result;
 use domain::{
-    ArticleMeta, CategoryArtifactDocument, HomeFragmentArtifactDocument, PageArtifactDocument,
-    PublishableCategoryLanding, SiteMetadata, build_article_index, build_category_indexes,
-    build_site_metadata,
+    ArticleIndexDocument, ArticleMeta, CategoryArtifactDocument, HomeFragmentArtifactDocument,
+    PageArtifactDocument, PublishableCategoryLanding, SiteMetadataDocument, build_article_index,
+    build_category_indexes, build_site_metadata,
 };
 
-/// Complete artifact bundle produced from validated content.
+/// JSON documents produced from validated content.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SiteArtifacts {
-    pub(crate) article_index: Vec<domain::PublishedArticleSummary>,
+pub(crate) struct SiteDocuments {
+    pub(crate) article_index: ArticleIndexDocument,
     pub(super) category_documents: Vec<CategoryArtifactDocument>,
     pub(super) page_documents: Vec<PageArtifactDocument>,
     pub(super) home_fragment: Option<HomeFragmentArtifactDocument>,
-    pub(super) site_metadata: SiteMetadata,
+    pub(super) site_metadata: SiteMetadataDocument,
 }
 
-pub(crate) fn build_site_artifacts(
+pub(crate) fn build_site_documents(
     article_metas: Vec<ArticleMeta>,
     category_landings: Vec<PublishableCategoryLanding>,
     page_documents: Vec<PageArtifactDocument>,
     home_fragment: Option<HomeFragmentArtifactDocument>,
-) -> Result<SiteArtifacts> {
+) -> Result<SiteDocuments> {
     let category_metas = category_landings
         .iter()
         .map(|landing| landing.meta.clone())
@@ -39,12 +39,12 @@ pub(crate) fn build_site_artifacts(
         })
         .collect::<domain::Result<Vec<_>>>()?;
 
-    Ok(SiteArtifacts {
-        article_index,
+    Ok(SiteDocuments {
+        article_index: ArticleIndexDocument::from(article_index.as_slice()),
         category_documents,
         page_documents,
         home_fragment,
-        site_metadata,
+        site_metadata: SiteMetadataDocument::from(&site_metadata),
     })
 }
 
@@ -92,8 +92,8 @@ mod tests {
     }
 
     #[test]
-    fn test_build_site_artifacts() {
-        let artifacts = build_site_artifacts(
+    fn test_build_site_documents() {
+        let documents = build_site_documents(
             vec![
                 article_meta(
                     "First",
@@ -119,15 +119,15 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(artifacts.article_index.len(), 2);
-        assert_eq!(artifacts.category_documents.len(), 2);
-        assert_eq!(artifacts.site_metadata.total_articles, 2);
-        assert_eq!(artifacts.article_index[0].slug.as_str(), "second000002");
+        assert_eq!(documents.article_index.articles.len(), 2);
+        assert_eq!(documents.category_documents.len(), 2);
+        assert_eq!(documents.site_metadata.total_articles, 2);
+        assert_eq!(documents.article_index.articles[0].slug, "second000002");
     }
 
     #[test]
-    fn test_build_site_artifacts_includes_landing_only_category() {
-        let artifacts = build_site_artifacts(
+    fn test_build_site_documents_includes_landing_only_category() {
+        let documents = build_site_documents(
             vec![],
             vec![publishable_category_landing(Category::Physics, "Physics")],
             vec![],
@@ -135,15 +135,15 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(artifacts.category_documents.len(), 1);
-        assert_eq!(artifacts.category_documents[0].category, "physics");
-        assert_eq!(artifacts.site_metadata.categories.len(), 1);
-        assert_eq!(artifacts.site_metadata.categories[0].article_count, 0);
+        assert_eq!(documents.category_documents.len(), 1);
+        assert_eq!(documents.category_documents[0].category, "physics");
+        assert_eq!(documents.site_metadata.categories.len(), 1);
+        assert_eq!(documents.site_metadata.categories[0].article_count, 0);
     }
 
     #[test]
-    fn test_build_site_artifacts_requires_category_landing() {
-        let result = build_site_artifacts(
+    fn test_build_site_documents_requires_category_landing() {
+        let result = build_site_documents(
             vec![article_meta(
                 "First",
                 "first0000001",

--- a/crates/publish/src/artifacts/validator.rs
+++ b/crates/publish/src/artifacts/validator.rs
@@ -187,8 +187,8 @@ fn read_required_nonempty(site_root: &Path, relative_path: &Path) -> Result<Stri
 
 #[cfg(test)]
 mod tests {
-    use super::super::builder::build_site_artifacts;
-    use super::super::writer::{SiteDirectories, write_article_page, write_site_artifacts};
+    use super::super::builder::build_site_documents;
+    use super::super::writer::{SiteOutput, write_article_page, write_site_documents};
     use super::*;
     use domain::{
         ArticleMeta, CategoryLandingBody, CategoryLandingMeta, PageKey, PublishableCategoryLanding,
@@ -202,7 +202,7 @@ mod tests {
 
     fn write_complete_site() -> TempDir {
         let temp_dir = TempDir::new().unwrap();
-        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
+        let output = SiteOutput::prepare(temp_dir.path()).unwrap();
         let timestamp = Timestamp::new("2025-01-01T00:00:00+09:00".to_string()).unwrap();
         let article = ArticleMeta {
             slug: Slug::new("artifact00001".to_string()).unwrap(),
@@ -221,7 +221,7 @@ mod tests {
             description: Some("Tech landing".to_string()),
             updated_at: timestamp,
         };
-        let artifacts = build_site_artifacts(
+        let documents = build_site_documents(
             vec![article.clone()],
             vec![PublishableCategoryLanding::new(
                 landing,
@@ -239,13 +239,13 @@ mod tests {
         .unwrap();
 
         write_article_page(
-            &directories,
+            &output,
             article.category,
             &article.slug,
             "<h1>Artifact Test</h1>",
         )
         .unwrap();
-        write_site_artifacts(&directories, &artifacts).unwrap();
+        write_site_documents(&output, &documents).unwrap();
 
         temp_dir
     }
@@ -263,10 +263,10 @@ mod tests {
     #[test]
     fn test_validate_site_artifacts_rejects_empty_article_index() {
         let temp_dir = TempDir::new().unwrap();
-        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
-        write_site_artifacts(
-            &directories,
-            &build_site_artifacts(vec![], vec![], vec![], None).unwrap(),
+        let output = SiteOutput::prepare(temp_dir.path()).unwrap();
+        write_site_documents(
+            &output,
+            &build_site_documents(vec![], vec![], vec![], None).unwrap(),
         )
         .unwrap();
 

--- a/crates/publish/src/artifacts/writer.rs
+++ b/crates/publish/src/artifacts/writer.rs
@@ -1,103 +1,95 @@
-use super::builder::SiteArtifacts;
+use super::builder::SiteDocuments;
 use crate::error::Result;
 
-use domain::{ArticleIndexDocument, Category, SiteMetadataDocument, Slug};
+use domain::{Category, Slug};
 use serde::Serialize;
 use std::{
     fs::{self, File},
-    io::BufWriter,
+    io::{BufWriter, Write},
     path::{Path, PathBuf},
 };
 
-/// Output directories for generated local site artifacts.
+/// Prepared root directory for generated site artifacts.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SiteDirectories {
-    home_fragment_path: PathBuf,
-    articles_dir: PathBuf,
-    categories_dir: PathBuf,
-    metadata_dir: PathBuf,
-    pages_dir: PathBuf,
+pub(crate) struct SiteOutput {
+    root: PathBuf,
 }
 
-impl SiteDirectories {
+impl SiteOutput {
     pub(crate) fn prepare(output_dir: impl AsRef<Path>) -> Result<Self> {
-        let site_root = output_dir.as_ref().join("site");
-        let site_directories = Self {
-            home_fragment_path: site_root.join("home.json"),
-            articles_dir: site_root.join("articles"),
-            categories_dir: site_root.join("categories"),
-            metadata_dir: site_root.join("metadata"),
-            pages_dir: site_root.join("pages"),
-        };
+        let root = output_dir.as_ref().join("site");
+        for directory in ["articles", "categories", "metadata", "pages"] {
+            fs::create_dir_all(root.join(directory))?;
+        }
 
-        fs::create_dir_all(&site_directories.articles_dir)?;
-        fs::create_dir_all(&site_directories.categories_dir)?;
-        fs::create_dir_all(&site_directories.metadata_dir)?;
-        fs::create_dir_all(&site_directories.pages_dir)?;
+        Ok(Self { root })
+    }
 
-        Ok(site_directories)
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
     }
 }
 
 pub(crate) fn write_article_page(
-    site_directories: &SiteDirectories,
+    site_output: &SiteOutput,
     category: Category,
     slug: &Slug,
     html: &str,
 ) -> Result<PathBuf> {
-    let article_dir = site_directories.articles_dir.join(category.as_str());
+    let article_dir = site_output.root.join("articles").join(category.as_str());
     fs::create_dir_all(&article_dir)?;
     let output_file_path = article_dir.join(format!("{}.html", slug.as_str()));
     fs::write(&output_file_path, html)?;
     Ok(output_file_path)
 }
 
-pub(crate) fn write_site_artifacts(
-    site_directories: &SiteDirectories,
-    site_artifacts: &SiteArtifacts,
+pub(crate) fn write_site_documents(
+    site_output: &SiteOutput,
+    site_documents: &SiteDocuments,
 ) -> Result<()> {
-    write_json_pretty(
-        &site_directories.articles_dir.join("index.json"),
-        &ArticleIndexDocument::from(site_artifacts.article_index.as_slice()),
+    write_json(
+        &site_output.root.join("articles/index.json"),
+        &site_documents.article_index,
     )?;
-    for category_document in &site_artifacts.category_documents {
-        write_json_pretty(
-            &site_directories
-                .categories_dir
-                .join(format!("{}.json", category_document.category)),
+    for category_document in &site_documents.category_documents {
+        write_json(
+            &site_output
+                .root
+                .join(format!("categories/{}.json", category_document.category)),
             category_document,
         )?;
     }
-    for page_document in &site_artifacts.page_documents {
-        write_json_pretty(
-            &site_directories
-                .pages_dir
-                .join(format!("{}.json", page_document.page)),
+    for page_document in &site_documents.page_documents {
+        write_json(
+            &site_output
+                .root
+                .join(format!("pages/{}.json", page_document.page)),
             page_document,
         )?;
     }
-    if let Some(home_fragment) = &site_artifacts.home_fragment {
-        write_json_pretty(&site_directories.home_fragment_path, home_fragment)?;
+    if let Some(home_fragment) = &site_documents.home_fragment {
+        write_json(&site_output.root.join("home.json"), home_fragment)?;
     }
 
-    write_json_pretty(
-        &site_directories.metadata_dir.join("site.json"),
-        &SiteMetadataDocument::from(&site_artifacts.site_metadata),
+    write_json(
+        &site_output.root.join("metadata/site.json"),
+        &site_documents.site_metadata,
     )?;
 
     Ok(())
 }
 
-fn write_json_pretty(path: &Path, value: &impl Serialize) -> Result<()> {
+fn write_json(path: &Path, value: &impl Serialize) -> Result<()> {
     let file = File::create(path)?;
-    let writer = BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, value)?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer(&mut writer, value)?;
+    writer.flush()?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::super::builder::build_site_artifacts;
+    use super::super::builder::build_site_documents;
     use super::*;
     use domain::{
         ArticleMeta, CategoryLandingMeta, HomeFragmentArtifactDocument, PageArtifactDocument,
@@ -131,9 +123,9 @@ mod tests {
     #[test]
     fn test_write_local_artifacts() {
         let temp_dir = TempDir::new().unwrap();
-        let directories = SiteDirectories::prepare(temp_dir.path()).unwrap();
+        let output = SiteOutput::prepare(temp_dir.path()).unwrap();
         let article = article_meta();
-        let artifacts = build_site_artifacts(
+        let documents = build_site_documents(
             vec![article.clone()],
             vec![domain::PublishableCategoryLanding::new(
                 category_landing(),
@@ -156,23 +148,26 @@ mod tests {
         .unwrap();
 
         let article_path = write_article_page(
-            &directories,
+            &output,
             article.category,
             &article.slug,
             "<h1>Artifact Test</h1>",
         )
         .unwrap();
-        write_site_artifacts(&directories, &artifacts).unwrap();
+        write_site_documents(&output, &documents).unwrap();
 
         for path in [
             article_path,
-            directories.articles_dir.join("index.json"),
-            directories.categories_dir.join("tech.json"),
-            directories.pages_dir.join("about.json"),
-            directories.home_fragment_path.clone(),
-            directories.metadata_dir.join("site.json"),
+            output.root.join("articles/index.json"),
+            output.root.join("categories/tech.json"),
+            output.root.join("pages/about.json"),
+            output.root.join("home.json"),
+            output.root.join("metadata/site.json"),
         ] {
             assert!(path.exists(), "{} should exist", path.display());
         }
+
+        let article_index = fs::read_to_string(output.root.join("articles/index.json")).unwrap();
+        assert!(article_index.starts_with("{\"articles\":["));
     }
 }

--- a/crates/publish/src/pipeline.rs
+++ b/crates/publish/src/pipeline.rs
@@ -1,6 +1,6 @@
 use crate::artifacts::{
-    SiteDirectories, build_site_artifacts, validate_site_artifacts, write_article_page,
-    write_site_artifacts,
+    SiteOutput, build_site_documents, validate_site_artifacts, write_article_page,
+    write_site_documents,
 };
 use crate::classify::{
     ParsedArticleFile, classify_obsidian_files, ensure_category_landings,
@@ -71,7 +71,7 @@ pub async fn publish_with_bookmark_enricher(
         ..
     } = classified_files;
 
-    let site_directories = SiteDirectories::prepare(output_dir)?;
+    let site_output = SiteOutput::prepare(output_dir)?;
 
     const CONCURRENT_LIMIT: usize = 4;
 
@@ -82,7 +82,7 @@ pub async fn publish_with_bookmark_enricher(
                 parsed_file,
                 &link_index,
                 Arc::clone(&enrich),
-                site_directories.clone(),
+                site_output.clone(),
             )
         })
         .buffer_unordered(CONCURRENT_LIMIT)
@@ -108,20 +108,20 @@ pub async fn publish_with_bookmark_enricher(
         .await;
     let category_landings = category_results.into_iter().collect::<Result<Vec<_>>>()?;
 
-    let site_artifacts = build_site_artifacts(
+    let site_documents = build_site_documents(
         article_metas,
         category_landings,
         page_documents,
         home_fragment,
     )?;
-    let site_directories_for_write = site_directories.clone();
-    let site_artifacts = tokio::task::spawn_blocking(move || {
-        write_site_artifacts(&site_directories_for_write, &site_artifacts)?;
-        Ok::<_, PublishError>(site_artifacts)
+    let site_output_for_write = site_output.clone();
+    let site_documents = tokio::task::spawn_blocking(move || {
+        write_site_documents(&site_output_for_write, &site_documents)?;
+        Ok::<_, PublishError>(site_documents)
     })
     .await??;
 
-    let site_root = output_dir.join("site");
+    let site_root = site_output.root().to_path_buf();
     let validation =
         tokio::task::spawn_blocking(move || validate_site_artifacts(site_root)).await??;
     info!(
@@ -130,7 +130,7 @@ pub async fn publish_with_bookmark_enricher(
         "validated site artifacts"
     );
 
-    let processed_count = site_artifacts.article_index.len();
+    let processed_count = site_documents.article_index.articles.len();
     let duration = start_time.elapsed();
 
     info!(
@@ -140,8 +140,8 @@ pub async fn publish_with_bookmark_enricher(
         "publish completed"
     );
 
-    if !site_artifacts.article_index.is_empty() {
-        for article in &site_artifacts.article_index {
+    if !site_documents.article_index.articles.is_empty() {
+        for article in &site_documents.article_index.articles {
             info!(
                 title = article.title.as_str(),
                 slug = article.slug.as_str(),
@@ -158,12 +158,12 @@ async fn process_article(
     parsed_file: ParsedArticleFile,
     link_index: &links::Index,
     enrich: BookmarkEnricher,
-    site_directories: SiteDirectories,
+    site_output: SiteOutput,
 ) -> Result<domain::ArticleMeta> {
     let article = render_article(parsed_file, link_index, enrich).await?;
     let (meta, output_file_path) = tokio::task::spawn_blocking(move || {
         let output_file_path = write_article_page(
-            &site_directories,
+            &site_output,
             article.meta.category,
             &article.meta.slug,
             article.body.as_str(),

--- a/crates/publish/tests/e2e_test.rs
+++ b/crates/publish/tests/e2e_test.rs
@@ -1,12 +1,11 @@
 mod test_fixtures;
 
-use domain::ArticleIndexDocument;
+use domain::{ArticleIndexDocument, CategoryArtifactDocument, SiteMetadataDocument};
 use indoc::indoc;
 use publish::publish;
 use std::fs;
 use tempfile::TempDir;
-use test_fixtures::collect_html_files;
-use test_fixtures::{write_about_page, write_tech_category_landing};
+use test_fixtures::{collect_html_files, read_json, write_about_page, write_tech_category_landing};
 
 /// End-to-end test that simulates a realistic Obsidian vault.
 #[tokio::test]
@@ -309,11 +308,13 @@ async fn test_end_to_end_obsidian_processing() {
         );
     }
 
-    let tech_category = fs::read_to_string(site_root.join("categories").join("tech.json")).unwrap();
-    assert!(tech_category.contains("\"category\": \"tech\""));
+    let tech_category: CategoryArtifactDocument =
+        read_json(site_root.join("categories").join("tech.json"));
+    assert_eq!(tech_category.category, "tech");
 
-    let site_metadata = fs::read_to_string(site_root.join("metadata").join("site.json")).unwrap();
-    assert!(site_metadata.contains("\"total_articles\": 3"));
+    let site_metadata: SiteMetadataDocument =
+        read_json(site_root.join("metadata").join("site.json"));
+    assert_eq!(site_metadata.total_articles, 3);
 
     println!(
         "✅ End-to-end test finished: generated {} HTML files",

--- a/crates/publish/tests/integration_test.rs
+++ b/crates/publish/tests/integration_test.rs
@@ -1,11 +1,15 @@
 mod test_fixtures;
 
+use domain::{
+    ArticleIndexDocument, CategoryArtifactDocument, HomeFragmentArtifactDocument,
+    PageArtifactDocument, SiteMetadataDocument,
+};
 use indoc::indoc;
 use publish::{BookmarkEnricher, PublishError, publish, publish_with_bookmark_enricher};
 use rstest::rstest;
 use std::{fs, path::Path, sync::Arc};
 use tempfile::TempDir;
-use test_fixtures::{collect_html_files, write_about_page, write_tech_category_landing};
+use test_fixtures::{collect_html_files, read_json, write_about_page, write_tech_category_landing};
 
 fn offline_bookmark_enricher() -> BookmarkEnricher {
     Arc::new(|html: String| {
@@ -116,12 +120,13 @@ async fn test_publish_with_sample_file() {
     assert!(html_content.contains("Test Article"));
     assert!(html_content.contains("This is a test article"));
 
-    let article_index = fs::read_to_string(articles_dir.join("index.json")).unwrap();
-    assert!(article_index.contains("\"articles\""));
-    assert!(article_index.contains("\"category\": \"tech\""));
+    let article_index: ArticleIndexDocument = read_json(articles_dir.join("index.json"));
+    assert_eq!(article_index.articles.len(), 1);
+    assert_eq!(article_index.articles[0].category, "tech");
 
-    let site_metadata = fs::read_to_string(site_root.join("metadata").join("site.json")).unwrap();
-    assert!(site_metadata.contains("\"total_articles\": 1"));
+    let site_metadata: SiteMetadataDocument =
+        read_json(site_root.join("metadata").join("site.json"));
+    assert_eq!(site_metadata.total_articles, 1);
 }
 
 #[tokio::test]
@@ -265,12 +270,16 @@ async fn test_publish_with_static_page_file() {
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
 
-    let page_document =
-        fs::read_to_string(output_dir.join("site").join("pages").join("about.json")).unwrap();
+    let page_document: PageArtifactDocument =
+        read_json(output_dir.join("site").join("pages").join("about.json"));
 
-    assert!(page_document.contains("\"page\": \"about\""));
-    assert!(page_document.contains("\"title\": \"About\""));
-    assert!(page_document.contains("This page is generated from markdown."));
+    assert_eq!(page_document.page.as_str(), "about");
+    assert_eq!(page_document.title, "About");
+    assert!(
+        page_document
+            .html
+            .contains("This page is generated from markdown.")
+    );
 }
 
 #[tokio::test]
@@ -305,11 +314,15 @@ async fn test_publish_with_home_fragment_file() {
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
 
-    let page_document = fs::read_to_string(output_dir.join("site").join("home.json")).unwrap();
+    let home_fragment: HomeFragmentArtifactDocument =
+        read_json(output_dir.join("site").join("home.json"));
 
-    assert!(!page_document.contains("\"page\""));
-    assert!(page_document.contains("\"title\": \"Home\""));
-    assert!(page_document.contains("This fragment is generated from markdown."));
+    assert_eq!(home_fragment.title, "Home");
+    assert!(
+        home_fragment
+            .html
+            .contains("This fragment is generated from markdown.")
+    );
     assert!(!output_dir.join("site/pages/home.json").exists());
 }
 
@@ -392,13 +405,20 @@ async fn test_publish_with_category_landing_file() {
     let result = publish(&obsidian_dir, &output_dir).await;
     assert!(result.is_ok());
 
-    let category_document =
-        fs::read_to_string(output_dir.join("site").join("categories").join("tech.json")).unwrap();
+    let category_document: CategoryArtifactDocument =
+        read_json(output_dir.join("site").join("categories").join("tech.json"));
 
-    assert!(category_document.contains("\"category\": \"tech\""));
-    assert!(category_document.contains("\"title\": \"Tech\""));
-    assert!(category_document.contains("\"description\": \"  Technology landing  \""));
-    assert!(category_document.contains("Welcome to the category landing page."));
+    assert_eq!(category_document.category, "tech");
+    assert_eq!(category_document.title, "Tech");
+    assert_eq!(
+        category_document.description.as_deref(),
+        Some("  Technology landing  ")
+    );
+    assert!(
+        category_document
+            .html
+            .contains("Welcome to the category landing page.")
+    );
 }
 
 #[tokio::test]

--- a/crates/publish/tests/test_fixtures.rs
+++ b/crates/publish/tests/test_fixtures.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code, reason = "shared by integration test crates")]
 
+use serde::de::DeserializeOwned;
 use std::{
-    fs,
+    fs::{self, File},
     path::{Path, PathBuf},
 };
 
@@ -20,6 +21,10 @@ pub(crate) fn collect_html_files(root: &Path) -> Vec<PathBuf> {
     }
 
     html_files
+}
+
+pub(crate) fn read_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> T {
+    serde_json::from_reader(File::open(path).unwrap()).unwrap()
 }
 
 pub(crate) fn write_about_page(obsidian_dir: &Path) {


### PR DESCRIPTION
## Summary

- artifact builderで最終的なJSON documentを構築する
- 出力先をrootのみ保持する SiteOutput へ整理する
- writerをartifact配置とserializationに限定する
- 生成JSONをcompact化し、BufWriterのflush errorを伝播する
- JSONの空白に依存していたテストをdocumentのdeserializeによる検証へ変更する

## Verification

- mise run format
- mise run test
- mise run clippy
- mise run check
- git diff --check