### PR TITLE
feat: migrate article API to Topcoat

### DIFF
--- a/crates/site/server/src/article_index.rs
+++ b/crates/site/server/src/article_index.rs
@@ -1,0 +1,11 @@
+//! Framework-neutral article index access shared by server runtimes.
+
+use domain::ArticleIndexDocument;
+use infra::{DynArtifactReader, Result};
+
+pub async fn read_article_index(
+    artifact_reader: &DynArtifactReader,
+) -> Result<ArticleIndexDocument> {
+    let snapshot = artifact_reader.snapshot().await?;
+    snapshot.read_article_index().await
+}

--- a/crates/site/server/src/handlers/api/articles.rs
+++ b/crates/site/server/src/handlers/api/articles.rs
@@ -4,14 +4,12 @@ use axum::{Extension, Json, http::StatusCode};
 use domain::ArticleIndexDocument;
 use infra::DynArtifactReader;
 
+use crate::article_index::read_article_index;
+
 pub async fn list_articles(
     Extension(artifact_reader): Extension<DynArtifactReader>,
 ) -> Result<Json<ArticleIndexDocument>, StatusCode> {
-    let document = artifact_reader
-        .snapshot()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        .read_article_index()
+    let document = read_article_index(&artifact_reader)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 

--- a/crates/site/server/src/lib.rs
+++ b/crates/site/server/src/lib.rs
@@ -7,6 +7,9 @@
 pub use web::*;
 
 #[cfg(not(target_arch = "wasm32"))]
+pub mod article_index;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub mod handlers;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/site/server/src/topcoat_runtime.rs
+++ b/crates/site/server/src/topcoat_runtime.rs
@@ -4,10 +4,10 @@ use infra::DynArtifactReader;
 use topcoat::{
     Result,
     context::{Cx, app_context},
-    router::{Router, StatusCode, route},
+    router::{Router, StatusCode, content::Json, error::internal_server_error, route},
 };
 
-use crate::readiness::check_artifact_readiness;
+use crate::{article_index::read_article_index, readiness::check_artifact_readiness};
 
 #[derive(Clone)]
 struct ArtifactReaderContext(DynArtifactReader);
@@ -30,10 +30,20 @@ async fn readiness(cx: &Cx) -> Result<(StatusCode, &'static str)> {
     }
 }
 
+#[route(GET "/api/articles")]
+async fn articles(cx: &Cx) -> Result<Json<domain::ArticleIndexDocument>> {
+    let artifact_reader = &app_context::<ArtifactReaderContext>(cx).0;
+    let document = read_article_index(artifact_reader)
+        .await
+        .map_err(internal_server_error)?;
+    Ok(Json(document))
+}
+
 pub fn create_topcoat_router(artifact_reader: DynArtifactReader) -> Router {
     Router::builder()
         .route(health)
         .route(readiness)
+        .route(articles)
         .app_context(ArtifactReaderContext(artifact_reader))
         .build()
 }
@@ -42,12 +52,18 @@ pub fn create_topcoat_router(artifact_reader: DynArtifactReader) -> Router {
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
-    use axum::http::Request;
+    use axum::http::{Request, StatusCode};
     use infra::LocalArtifactReader;
     use tempfile::tempdir;
-    use topcoat::router::{Body, StatusCode, to_bytes};
+    use topcoat::router::{Body, to_bytes};
 
     use super::create_topcoat_router;
+
+    struct TestResponse {
+        status: StatusCode,
+        content_type: Option<String>,
+        body: String,
+    }
 
     fn fixture_reader() -> Arc<LocalArtifactReader> {
         Arc::new(LocalArtifactReader::new(
@@ -55,7 +71,7 @@ mod tests {
         ))
     }
 
-    async fn response(path: &str, reader: Arc<LocalArtifactReader>) -> (StatusCode, String) {
+    async fn response(path: &str, reader: Arc<LocalArtifactReader>) -> TestResponse {
         let router = create_topcoat_router(reader);
         let request = Request::builder()
             .uri(path)
@@ -63,47 +79,91 @@ mod tests {
             .expect("request should be valid");
         let response = router.handle(request).await;
         let status = response.status();
+        let content_type = response.headers().get("content-type").map(|value| {
+            value
+                .to_str()
+                .expect("content type should be valid")
+                .to_owned()
+        });
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("response body should be readable");
 
-        (
+        TestResponse {
             status,
-            String::from_utf8(body.to_vec()).expect("response body should be UTF-8"),
-        )
+            content_type,
+            body: String::from_utf8(body.to_vec()).expect("response body should be UTF-8"),
+        }
     }
 
     #[tokio::test]
     async fn health_does_not_require_artifacts() {
         let temp_dir = tempdir().expect("temp dir should be created");
-        let (status, body) = response(
+        let response = response(
             "/api/health",
             Arc::new(LocalArtifactReader::new(temp_dir.path())),
         )
         .await;
 
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body, "OK");
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(response.body, "OK");
     }
 
     #[tokio::test]
     async fn readiness_succeeds_when_site_metadata_is_readable() {
-        let (status, body) = response("/api/ready", fixture_reader()).await;
+        let response = response("/api/ready", fixture_reader()).await;
 
-        assert_eq!(status, StatusCode::OK);
-        assert_eq!(body, "READY");
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(response.body, "READY");
     }
 
     #[tokio::test]
     async fn readiness_fails_when_site_metadata_is_missing() {
         let temp_dir = tempdir().expect("temp dir should be created");
-        let (status, body) = response(
+        let response = response(
             "/api/ready",
             Arc::new(LocalArtifactReader::new(temp_dir.path())),
         )
         .await;
 
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(body, "NOT READY");
+        assert_eq!(response.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.body, "NOT READY");
+    }
+
+    #[tokio::test]
+    async fn articles_returns_the_published_index_as_json() {
+        let response = response("/api/articles", fixture_reader()).await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(response.content_type.as_deref(), Some("application/json"));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&response.body)
+                .expect("article index should be JSON"),
+            serde_json::json!({
+                "articles": [{
+                    "slug": "e2e-article",
+                    "title": "E2E Article",
+                    "category": "tech",
+                    "section_path": ["rust", "async"],
+                    "description": "Article fixture description",
+                    "tags": ["rust", "e2e"],
+                    "priority": 10,
+                    "created_at": "2026-01-01T00:00:00+09:00",
+                    "updated_at": "2026-01-02T00:00:00+09:00"
+                }]
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn articles_returns_internal_server_error_when_index_is_missing() {
+        let temp_dir = tempdir().expect("temp dir should be created");
+        let response = response(
+            "/api/articles",
+            Arc::new(LocalArtifactReader::new(temp_dir.path())),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/mise.lock
+++ b/mise.lock
@@ -24,6 +24,10 @@ url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64
 checksum = "sha256:c669e97f6164e1c96e0701748db98dfa77492908cbd8394c7557134a735de381"
 url = "https://github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-darwin-aarch64.zip"
 
+[[tools."cargo:topcoat-cli"]]
+version = "0.6.2"
+backend = "cargo:topcoat-cli"
+
 [[tools."github:bram209/leptosfmt"]]
 version = "0.1.33"
 backend = "github:bram209/leptosfmt"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 bun = "1.4.0"
+"cargo:topcoat-cli" = "0.6.2"
 "github:leptos-rs/cargo-leptos" = "0.3.7"
 "github:bram209/leptosfmt" = "0.1.33"
 
@@ -23,6 +24,7 @@ mise --version
 bun --version
 cargo leptos --version
 leptosfmt --version
+topcoat fmt --version
 '''
 
 [tasks.web-install]
@@ -101,6 +103,7 @@ git submodule update --remote --checkout --recursive "$obsidian_path"
 description = "Format Rust and Leptos source files"
 run = '''
 cargo fmt --all
+find crates/site/server/src -name '*.rs' -exec topcoat fmt {} +
 find crates/site/web -name '*.rs' -exec leptosfmt {} +
 '''
 

--- a/scripts/check_tool_versions.sh
+++ b/scripts/check_tool_versions.sh
@@ -10,14 +10,18 @@ fail() {
 mise_bun_version="$(sed -nE 's/^bun = "([^"]+)"$/\1/p' mise.toml)"
 cargo_leptos_version="$(sed -nE 's/^"github:leptos-rs\/cargo-leptos" = "([^"]+)"$/\1/p' mise.toml)"
 leptosfmt_version="$(sed -nE 's/^"github:bram209\/leptosfmt" = "([^"]+)"$/\1/p' mise.toml)"
+topcoat_cli_version="$(sed -nE 's/^"cargo:topcoat-cli" = "([^"]+)"$/\1/p' mise.toml)"
+topcoat_framework_version="$(sed -nE 's/^topcoat = \{ version = "=([^"]+)".*/\1/p' Cargo.toml)"
 tailwind_version="$(sed -nE 's/^LEPTOS_TAILWIND_VERSION = "v([^"]+)"$/\1/p' mise.toml)"
 tailwind_cli_version="$(sed -nE 's/.*"@tailwindcss\/cli": "([^"]+)".*/\1/p' crates/site/web/package.json)"
 tailwind_package_version="$(sed -nE 's/.*"tailwindcss": "([^"]+)".*/\1/p' crates/site/web/package.json)"
 
-for version in "$mise_bun_version" "$cargo_leptos_version" "$leptosfmt_version" "$tailwind_version"; do
-  [ -n "$version" ] || fail "required version is missing from mise.toml"
+for version in "$mise_bun_version" "$cargo_leptos_version" "$leptosfmt_version" "$topcoat_cli_version" "$topcoat_framework_version" "$tailwind_version"; do
+  [ -n "$version" ] || fail "required version is missing from project configuration"
 done
 
+[ "$topcoat_cli_version" = "$topcoat_framework_version" ] \
+  || fail "Topcoat CLI $topcoat_cli_version does not match framework $topcoat_framework_version"
 [ "$tailwind_version" = "$tailwind_cli_version" ] \
   || fail "Tailwind CLI $tailwind_cli_version does not match LEPTOS_TAILWIND_VERSION $tailwind_version"
 [ "$tailwind_version" = "$tailwind_package_version" ] \
@@ -28,9 +32,11 @@ done
   || fail "active cargo-leptos does not match mise $cargo_leptos_version"
 [ "$(leptosfmt --version | awk '{print $2}')" = "$leptosfmt_version" ] \
   || fail "active leptosfmt does not match mise $leptosfmt_version"
+[ "$(topcoat fmt --version | awk '{print $2}')" = "$topcoat_cli_version" ] \
+  || fail "active Topcoat CLI $(topcoat fmt --version | awk '{print $2}') does not match mise $topcoat_cli_version"
 
 if grep -R -n -E \
-  'BUN_VERSION|CARGO_LEPTOS_VERSION|LEPTOS_TAILWIND_VERSION|oven-sh/setup-bun|cargo-leptos-installer' \
+  'BUN_VERSION|CARGO_LEPTOS_VERSION|TOPCOAT_CLI_VERSION|LEPTOS_TAILWIND_VERSION|oven-sh/setup-bun|cargo-leptos-installer|topcoat-cli-installer' \
   .github/workflows; then
   fail "workflow-local tool version or installer found"
 fi


### PR DESCRIPTION
## 概要

Issue #182 の段階移行として、既存仕様を変えずに記事一覧 API を Topcoat runtime へ追加します。

## 変更内容

- topcoat-cli 0.6.2 を mise / mise.lock に固定
- framework と CLI のバージョン一致を versions-check で検証
- server source を topcoat fmt の対象へ追加
- artifact reader から記事索引を読む処理を framework 非依存に抽出
- Topcoat に GET /api/articles を追加
- 正常時の JSON と artifact 不在時の 500 をテスト
- 既存 Axum / Leptos route も同じ共通処理を利用

## 確認

- mise run format
- mise run versions-check
- mise run test
- mise run clippy
- mise run check
- mise run build-project
- cargo build -p server --bin topcoat-server --release
- Topcoat 実プロセスで /api/articles が 200 / application/json / 既存 JSON 仕様を返すこと

Refs #182