### PR TITLE
feat: add conditional GET to Topcoat

### DIFF
--- a/crates/site/server/src/article_index.rs
+++ b/crates/site/server/src/article_index.rs
@@ -1,11 +1,17 @@
 //! Framework-neutral article index access shared by server runtimes.
 
 use domain::ArticleIndexDocument;
-use infra::{DynArtifactReader, Result};
+use infra::{DynArtifactReader, DynArtifactSnapshot, Result};
+
+pub async fn read_article_index_from_snapshot(
+    snapshot: &DynArtifactSnapshot,
+) -> Result<ArticleIndexDocument> {
+    snapshot.read_article_index().await
+}
 
 pub async fn read_article_index(
     artifact_reader: &DynArtifactReader,
 ) -> Result<ArticleIndexDocument> {
     let snapshot = artifact_reader.snapshot().await?;
-    snapshot.read_article_index().await
+    read_article_index_from_snapshot(&snapshot).await
 }

--- a/crates/site/server/src/bin/topcoat_server.rs
+++ b/crates/site/server/src/bin/topcoat_server.rs
@@ -1,6 +1,7 @@
 //! Temporary Topcoat entry point that runs alongside the Leptos server.
 
 use infra::{ArtifactSourceConfig, build_artifact_reader};
+use server::http_cache::artifact_validators_enabled;
 use server::topcoat_runtime::create_topcoat_router;
 
 const DEFAULT_ADDR: &str = "127.0.0.1:8009";
@@ -11,7 +12,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = std::env::var(ADDR_ENV).unwrap_or_else(|_| DEFAULT_ADDR.to_string());
     let artifact_source = ArtifactSourceConfig::from_env()?;
     let artifact_reader = build_artifact_reader(artifact_source.clone()).await?;
-    let router = create_topcoat_router(artifact_reader);
+    let validators_enabled = artifact_validators_enabled(&artifact_source);
+    let router = create_topcoat_router(artifact_reader, validators_enabled);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
 
     println!("Starting Topcoat migration server on http://{addr}");

--- a/crates/site/server/src/handlers/api/articles.rs
+++ b/crates/site/server/src/handlers/api/articles.rs
@@ -2,16 +2,19 @@
 
 use axum::{Extension, Json, http::StatusCode};
 use domain::ArticleIndexDocument;
-use infra::DynArtifactReader;
+use infra::{DynArtifactReader, DynArtifactSnapshot};
 
-use crate::article_index::read_article_index;
+use crate::article_index::{read_article_index, read_article_index_from_snapshot};
 
 pub async fn list_articles(
     Extension(artifact_reader): Extension<DynArtifactReader>,
+    snapshot: Option<Extension<DynArtifactSnapshot>>,
 ) -> Result<Json<ArticleIndexDocument>, StatusCode> {
-    let document = read_article_index(&artifact_reader)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let document = match snapshot {
+        Some(Extension(snapshot)) => read_article_index_from_snapshot(&snapshot).await,
+        None => read_article_index(&artifact_reader).await,
+    }
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(document))
 }
@@ -47,9 +50,10 @@ mod tests {
         )
         .unwrap();
 
-        let Json(document) = list_articles(Extension(Arc::new(LocalArtifactReader::new(
-            temp_dir.path(),
-        ))))
+        let Json(document) = list_articles(
+            Extension(Arc::new(LocalArtifactReader::new(temp_dir.path()))),
+            None,
+        )
         .await
         .unwrap();
 

--- a/crates/site/server/src/http_cache.rs
+++ b/crates/site/server/src/http_cache.rs
@@ -6,7 +6,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use infra::DynArtifactReader;
+use infra::{ArtifactSourceConfig, DynArtifactReader};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -16,6 +16,14 @@ use std::{
 };
 
 const CACHE_CONTROL_VALUE: &str = "public, max-age=0, must-revalidate";
+
+/// Enables release validators only when an S3 snapshot cache can provide a stable identity.
+pub fn artifact_validators_enabled(config: &ArtifactSourceConfig) -> bool {
+    matches!(
+        config,
+        ArtifactSourceConfig::S3 { cache_ttl, .. } if !cache_ttl.is_zero()
+    )
+}
 
 #[derive(Clone)]
 pub struct ArtifactHttpCacheState {
@@ -28,6 +36,12 @@ pub struct ArtifactHttpCacheState {
 struct ArtifactValidators {
     etag: String,
     last_modified: Option<SystemTime>,
+}
+
+pub(crate) struct ArtifactConditionalGetDecision {
+    validators: Option<ArtifactValidators>,
+    etag_matches: bool,
+    not_modified_since: bool,
 }
 
 impl ArtifactHttpCacheState {
@@ -74,6 +88,57 @@ impl ArtifactHttpCacheState {
             ),
         })
     }
+
+    pub(crate) async fn conditional_get(
+        &self,
+        method: &Method,
+        uri: &Uri,
+        headers: &HeaderMap,
+    ) -> Option<ArtifactConditionalGetDecision> {
+        if !is_artifact_request(method, uri.path()) {
+            return None;
+        }
+
+        let validators = self.validators_for(uri).await;
+        let has_if_none_match = headers.contains_key(header::IF_NONE_MATCH);
+        let etag_matches = has_if_none_match
+            && validators
+                .as_ref()
+                .is_some_and(|validators| if_none_match_matches(headers, &validators.etag));
+        let not_modified_since = !has_if_none_match
+            && validators
+                .as_ref()
+                .and_then(|validators| validators.last_modified)
+                .is_some_and(|last_modified| {
+                    if_modified_since_not_modified(headers, last_modified)
+                });
+
+        Some(ArtifactConditionalGetDecision {
+            validators,
+            etag_matches,
+            not_modified_since,
+        })
+    }
+}
+
+impl ArtifactConditionalGetDecision {
+    pub(crate) fn should_short_circuit(&self) -> bool {
+        self.etag_matches
+    }
+
+    pub(crate) fn should_return_not_modified_after_response(&self, status: StatusCode) -> bool {
+        status == StatusCode::OK && self.not_modified_since
+    }
+
+    pub(crate) fn should_attach_validators(&self, status: StatusCode) -> bool {
+        status == StatusCode::OK && self.validators.is_some()
+    }
+
+    pub(crate) fn insert_headers(&self, headers: &mut HeaderMap) {
+        if let Some(validators) = self.validators.as_ref() {
+            insert_cache_headers(headers, validators);
+        }
+    }
 }
 
 pub async fn artifact_conditional_get(
@@ -81,39 +146,28 @@ pub async fn artifact_conditional_get(
     request: Request,
     next: Next,
 ) -> Response {
-    if !is_artifact_request(request.method(), request.uri().path()) {
+    let Some(conditional_get) = state
+        .conditional_get(request.method(), request.uri(), request.headers())
+        .await
+    else {
         return next.run(request).await;
-    }
+    };
 
-    let validators = state.validators_for(request.uri()).await;
-    let has_if_none_match = request.headers().contains_key(header::IF_NONE_MATCH);
-    if has_if_none_match
-        && let Some(validators) = validators.as_ref()
-        && if_none_match_matches(request.headers(), &validators.etag)
-    {
+    if conditional_get.should_short_circuit() {
         let mut response = StatusCode::NOT_MODIFIED.into_response();
-        insert_cache_headers(response.headers_mut(), validators);
+        conditional_get.insert_headers(response.headers_mut());
         return response;
     }
-    let not_modified_since = !has_if_none_match
-        && validators
-            .as_ref()
-            .and_then(|validators| validators.last_modified)
-            .is_some_and(|last_modified| {
-                if_modified_since_not_modified(request.headers(), last_modified)
-            });
 
     let mut response = next.run(request).await;
-    if response.status() == StatusCode::OK
-        && let Some(validators) = validators.as_ref()
-    {
-        if not_modified_since {
-            let mut response = StatusCode::NOT_MODIFIED.into_response();
-            insert_cache_headers(response.headers_mut(), validators);
-            return response;
-        }
+    if conditional_get.should_return_not_modified_after_response(response.status()) {
+        let mut response = StatusCode::NOT_MODIFIED.into_response();
+        conditional_get.insert_headers(response.headers_mut());
+        return response;
+    }
 
-        insert_cache_headers(response.headers_mut(), validators);
+    if conditional_get.should_attach_validators(response.status()) {
+        conditional_get.insert_headers(response.headers_mut());
     }
     response
 }

--- a/crates/site/server/src/http_cache.rs
+++ b/crates/site/server/src/http_cache.rs
@@ -6,7 +6,7 @@ use axum::{
     middleware::Next,
     response::{IntoResponse, Response},
 };
-use infra::{ArtifactSourceConfig, DynArtifactReader};
+use infra::{ArtifactSourceConfig, DynArtifactReader, DynArtifactSnapshot};
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
@@ -39,6 +39,7 @@ struct ArtifactValidators {
 }
 
 pub(crate) struct ArtifactConditionalGetDecision {
+    snapshot: Option<DynArtifactSnapshot>,
     validators: Option<ArtifactValidators>,
     etag_matches: bool,
     not_modified_since: bool,
@@ -73,12 +74,19 @@ impl ArtifactHttpCacheState {
         }
     }
 
-    async fn validators_for(&self, uri: &Uri) -> Option<ArtifactValidators> {
+    async fn snapshot_for_request(&self) -> Option<DynArtifactSnapshot> {
         if !self.enabled {
             return None;
         }
 
-        let snapshot = self.artifact_reader.snapshot().await.ok()?;
+        self.artifact_reader.snapshot().await.ok()
+    }
+
+    fn validators_for(
+        &self,
+        snapshot: &DynArtifactSnapshot,
+        uri: &Uri,
+    ) -> Option<ArtifactValidators> {
         let identity = snapshot.cache_identity()?;
         Some(ArtifactValidators {
             etag: build_weak_etag(&self.process_tag, identity, uri),
@@ -99,7 +107,10 @@ impl ArtifactHttpCacheState {
             return None;
         }
 
-        let validators = self.validators_for(uri).await;
+        let snapshot = self.snapshot_for_request().await;
+        let validators = snapshot
+            .as_ref()
+            .and_then(|snapshot| self.validators_for(snapshot, uri));
         let has_if_none_match = headers.contains_key(header::IF_NONE_MATCH);
         let etag_matches = has_if_none_match
             && validators
@@ -114,6 +125,7 @@ impl ArtifactHttpCacheState {
                 });
 
         Some(ArtifactConditionalGetDecision {
+            snapshot,
             validators,
             etag_matches,
             not_modified_since,
@@ -122,6 +134,10 @@ impl ArtifactHttpCacheState {
 }
 
 impl ArtifactConditionalGetDecision {
+    pub(crate) fn snapshot(&self) -> Option<DynArtifactSnapshot> {
+        self.snapshot.clone()
+    }
+
     pub(crate) fn should_short_circuit(&self) -> bool {
         self.etag_matches
     }
@@ -143,7 +159,7 @@ impl ArtifactConditionalGetDecision {
 
 pub async fn artifact_conditional_get(
     State(state): State<ArtifactHttpCacheState>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Response {
     let Some(conditional_get) = state
@@ -157,6 +173,10 @@ pub async fn artifact_conditional_get(
         let mut response = StatusCode::NOT_MODIFIED.into_response();
         conditional_get.insert_headers(response.headers_mut());
         return response;
+    }
+
+    if let Some(snapshot) = conditional_get.snapshot() {
+        request.extensions_mut().insert(snapshot);
     }
 
     let mut response = next.run(request).await;

--- a/crates/site/server/src/main.rs
+++ b/crates/site/server/src/main.rs
@@ -5,7 +5,9 @@ use infra::{ArtifactSourceConfig, build_artifact_reader};
 use leptos::prelude::*;
 use leptos_axum::{LeptosRoutes, file_and_error_handler, generate_route_list};
 use server::handlers::create_api_router;
-use server::http_cache::{ArtifactHttpCacheState, artifact_conditional_get};
+use server::http_cache::{
+    ArtifactHttpCacheState, artifact_conditional_get, artifact_validators_enabled,
+};
 use tower_http::services::{ServeDir, ServeFile};
 use web::app::{App, shell};
 
@@ -21,10 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = leptos_options.site_addr;
     let artifact_source = ArtifactSourceConfig::from_env()?;
     let artifact_reader = build_artifact_reader(artifact_source.clone()).await?;
-    let validators_enabled = matches!(
-        &artifact_source,
-        ArtifactSourceConfig::S3 { cache_ttl, .. } if !cache_ttl.is_zero()
-    );
+    let validators_enabled = artifact_validators_enabled(&artifact_source);
 
     println!("Starting Leptos blog server on http://{}", addr);
     println!("Leptos設定読み込み完了: {:?}", addr);

--- a/crates/site/server/src/topcoat_runtime.rs
+++ b/crates/site/server/src/topcoat_runtime.rs
@@ -4,10 +4,17 @@ use infra::DynArtifactReader;
 use topcoat::{
     Result,
     context::{Cx, app_context},
-    router::{Router, StatusCode, content::Json, error::internal_server_error, route},
+    router::{
+        Body, LayerFn, LayerFuture, Next, Router, StatusCode, content::Json,
+        error::internal_server_error, request, response::Response, route,
+    },
 };
 
-use crate::{article_index::read_article_index, readiness::check_artifact_readiness};
+use crate::{
+    article_index::read_article_index,
+    http_cache::{ArtifactConditionalGetDecision, ArtifactHttpCacheState},
+    readiness::check_artifact_readiness,
+};
 
 #[derive(Clone)]
 struct ArtifactReaderContext(DynArtifactReader);
@@ -39,46 +46,155 @@ async fn articles(cx: &Cx) -> Result<Json<domain::ArticleIndexDocument>> {
     Ok(Json(document))
 }
 
-pub fn create_topcoat_router(artifact_reader: DynArtifactReader) -> Router {
+fn not_modified_response(conditional_get: &ArtifactConditionalGetDecision) -> Response {
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::NOT_MODIFIED;
+    conditional_get.insert_headers(response.headers_mut());
+    response
+}
+
+fn artifact_conditional_get<'a>(cx: &'a Cx, body: Body, next: Next<'a>) -> LayerFuture<'a> {
+    Box::pin(async move {
+        let state = app_context::<ArtifactHttpCacheState>(cx);
+        let Some(conditional_get) = state
+            .conditional_get(request::method(cx), request::uri(cx), request::headers(cx))
+            .await
+        else {
+            return next.run(cx, body).await;
+        };
+
+        if conditional_get.should_short_circuit() {
+            return Ok(not_modified_response(&conditional_get));
+        }
+
+        let mut response = next.run(cx, body).await?;
+        if conditional_get.should_return_not_modified_after_response(response.status()) {
+            return Ok(not_modified_response(&conditional_get));
+        }
+        if conditional_get.should_attach_validators(response.status()) {
+            conditional_get.insert_headers(response.headers_mut());
+        }
+        Ok(response)
+    })
+}
+
+pub fn create_topcoat_router(
+    artifact_reader: DynArtifactReader,
+    validators_enabled: bool,
+) -> Router {
     Router::builder()
         .route(health)
         .route(readiness)
         .route(articles)
+        .layer(LayerFn::new(
+            Some("/api/articles"),
+            artifact_conditional_get,
+        ))
+        .app_context(ArtifactHttpCacheState::new(
+            artifact_reader.clone(),
+            validators_enabled,
+        ))
         .app_context(ArtifactReaderContext(artifact_reader))
         .build()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc};
+    use std::{path::PathBuf, sync::Arc, time::SystemTime};
 
-    use axum::http::{Request, StatusCode};
-    use infra::LocalArtifactReader;
+    use async_trait::async_trait;
+    use domain::{
+        ArticleIndexDocument, Category, CategoryArtifactDocument, HomeFragmentArtifactDocument,
+        PageArtifactDocument, PageKey, SiteMetadataDocument, Slug,
+    };
+    use infra::{
+        ArtifactReader, ArtifactSnapshot, DynArtifactReader, DynArtifactSnapshot,
+        LocalArtifactReader, Result,
+    };
     use tempfile::tempdir;
-    use topcoat::router::{Body, to_bytes};
+    use topcoat::router::{
+        Body, HeaderMap, Router, StatusCode, header, request::Request, to_bytes,
+    };
 
     use super::create_topcoat_router;
 
     struct TestResponse {
         status: StatusCode,
+        headers: HeaderMap,
         content_type: Option<String>,
         body: String,
     }
 
-    fn fixture_reader() -> Arc<LocalArtifactReader> {
+    fn fixture_reader() -> DynArtifactReader {
         Arc::new(LocalArtifactReader::new(
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../e2e/fixtures/site"),
         ))
     }
 
-    async fn response(path: &str, reader: Arc<LocalArtifactReader>) -> TestResponse {
-        let router = create_topcoat_router(reader);
-        let request = Request::builder()
-            .uri(path)
-            .body(Body::empty())
-            .expect("request should be valid");
+    #[derive(Clone)]
+    struct ValidatorReader {
+        inner: DynArtifactReader,
+    }
+
+    #[async_trait]
+    impl ArtifactReader for ValidatorReader {
+        async fn snapshot(&self) -> Result<DynArtifactSnapshot> {
+            Ok(Arc::new(ValidatorSnapshot {
+                inner: self.inner.snapshot().await?,
+            }))
+        }
+    }
+
+    struct ValidatorSnapshot {
+        inner: DynArtifactSnapshot,
+    }
+
+    #[async_trait]
+    impl ArtifactSnapshot for ValidatorSnapshot {
+        fn cache_identity(&self) -> Option<&str> {
+            Some("release-1")
+        }
+
+        fn last_modified(&self) -> Option<SystemTime> {
+            self.inner.last_modified().or(Some(SystemTime::UNIX_EPOCH))
+        }
+
+        async fn read_article_index(&self) -> Result<ArticleIndexDocument> {
+            self.inner.read_article_index().await
+        }
+
+        async fn read_category_document(
+            &self,
+            category: &Category,
+        ) -> Result<CategoryArtifactDocument> {
+            self.inner.read_category_document(category).await
+        }
+
+        async fn read_site_metadata(&self) -> Result<SiteMetadataDocument> {
+            self.inner.read_site_metadata().await
+        }
+
+        async fn read_article_html(&self, category: &Category, slug: &Slug) -> Result<String> {
+            self.inner.read_article_html(category, slug).await
+        }
+
+        async fn read_home_fragment(&self) -> Result<HomeFragmentArtifactDocument> {
+            self.inner.read_home_fragment().await
+        }
+
+        async fn read_page_document(&self, page: &PageKey) -> Result<PageArtifactDocument> {
+            self.inner.read_page_document(page).await
+        }
+    }
+
+    fn validator_reader(inner: DynArtifactReader) -> DynArtifactReader {
+        Arc::new(ValidatorReader { inner })
+    }
+
+    async fn response(router: &Router, request: Request<Body>) -> TestResponse {
         let response = router.handle(request).await;
         let status = response.status();
+        let headers = response.headers().clone();
         let content_type = response.headers().get("content-type").map(|value| {
             value
                 .to_str()
@@ -91,6 +207,7 @@ mod tests {
 
         TestResponse {
             status,
+            headers,
             content_type,
             body: String::from_utf8(body.to_vec()).expect("response body should be UTF-8"),
         }
@@ -99,9 +216,14 @@ mod tests {
     #[tokio::test]
     async fn health_does_not_require_artifacts() {
         let temp_dir = tempdir().expect("temp dir should be created");
+        let router =
+            create_topcoat_router(Arc::new(LocalArtifactReader::new(temp_dir.path())), false);
         let response = response(
-            "/api/health",
-            Arc::new(LocalArtifactReader::new(temp_dir.path())),
+            &router,
+            Request::builder()
+                .uri("/api/health")
+                .body(Body::empty())
+                .expect("request should be valid"),
         )
         .await;
 
@@ -111,7 +233,15 @@ mod tests {
 
     #[tokio::test]
     async fn readiness_succeeds_when_site_metadata_is_readable() {
-        let response = response("/api/ready", fixture_reader()).await;
+        let router = create_topcoat_router(fixture_reader(), false);
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/api/ready")
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
 
         assert_eq!(response.status, StatusCode::OK);
         assert_eq!(response.body, "READY");
@@ -120,9 +250,14 @@ mod tests {
     #[tokio::test]
     async fn readiness_fails_when_site_metadata_is_missing() {
         let temp_dir = tempdir().expect("temp dir should be created");
+        let router =
+            create_topcoat_router(Arc::new(LocalArtifactReader::new(temp_dir.path())), false);
         let response = response(
-            "/api/ready",
-            Arc::new(LocalArtifactReader::new(temp_dir.path())),
+            &router,
+            Request::builder()
+                .uri("/api/ready")
+                .body(Body::empty())
+                .expect("request should be valid"),
         )
         .await;
 
@@ -132,7 +267,15 @@ mod tests {
 
     #[tokio::test]
     async fn articles_returns_the_published_index_as_json() {
-        let response = response("/api/articles", fixture_reader()).await;
+        let router = create_topcoat_router(fixture_reader(), false);
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/api/articles")
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
 
         assert_eq!(response.status, StatusCode::OK);
         assert_eq!(response.content_type.as_deref(), Some("application/json"));
@@ -158,12 +301,139 @@ mod tests {
     #[tokio::test]
     async fn articles_returns_internal_server_error_when_index_is_missing() {
         let temp_dir = tempdir().expect("temp dir should be created");
+        let router =
+            create_topcoat_router(Arc::new(LocalArtifactReader::new(temp_dir.path())), false);
         let response = response(
-            "/api/articles",
-            Arc::new(LocalArtifactReader::new(temp_dir.path())),
+            &router,
+            Request::builder()
+                .uri("/api/articles")
+                .body(Body::empty())
+                .expect("request should be valid"),
         )
         .await;
 
         assert_eq!(response.status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn articles_supports_release_aware_conditional_get() {
+        let router = create_topcoat_router(validator_reader(fixture_reader()), true);
+        let first = response(
+            &router,
+            Request::builder()
+                .uri("/api/articles")
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+        let etag = first
+            .headers
+            .get(header::ETAG)
+            .expect("successful artifact response should have an ETag")
+            .clone();
+        let last_modified = first
+            .headers
+            .get(header::LAST_MODIFIED)
+            .expect("successful artifact response should have Last-Modified")
+            .clone();
+
+        assert_eq!(first.status, StatusCode::OK);
+        assert_eq!(
+            first.headers.get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=0, must-revalidate"
+        );
+        assert!(first.headers.contains_key(header::LAST_MODIFIED));
+
+        let second = response(
+            &router,
+            Request::builder()
+                .uri("/api/articles")
+                .header(header::IF_NONE_MATCH, etag)
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+
+        assert_eq!(second.status, StatusCode::NOT_MODIFIED);
+        assert!(second.body.is_empty());
+        assert!(second.headers.contains_key(header::ETAG));
+        assert!(second.headers.contains_key(header::LAST_MODIFIED));
+
+        let third = response(
+            &router,
+            Request::builder()
+                .uri("/api/articles")
+                .header(header::IF_MODIFIED_SINCE, &last_modified)
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+
+        assert_eq!(third.status, StatusCode::NOT_MODIFIED);
+        assert!(third.body.is_empty());
+
+        let etag_precedence = response(
+            &router,
+            Request::builder()
+                .uri("/api/articles")
+                .header(header::IF_NONE_MATCH, "\"different\"")
+                .header(header::IF_MODIFIED_SINCE, last_modified)
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+
+        assert_eq!(etag_precedence.status, StatusCode::OK);
+        assert!(!etag_precedence.body.is_empty());
+
+        let head = response(
+            &router,
+            Request::builder()
+                .method("HEAD")
+                .uri("/api/articles")
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+
+        assert_eq!(head.status, StatusCode::OK);
+        assert!(head.headers.contains_key(header::ETAG));
+    }
+
+    #[tokio::test]
+    async fn articles_omits_validators_when_disabled_or_unsuccessful() {
+        let disabled = create_topcoat_router(validator_reader(fixture_reader()), false);
+        let disabled_response = response(
+            &disabled,
+            Request::builder()
+                .uri("/api/articles")
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+
+        assert_eq!(disabled_response.status, StatusCode::OK);
+        assert!(!disabled_response.headers.contains_key(header::ETAG));
+        assert!(
+            !disabled_response
+                .headers
+                .contains_key(header::CACHE_CONTROL)
+        );
+
+        let temp_dir = tempdir().expect("temp dir should be created");
+        let missing_reader: DynArtifactReader = Arc::new(LocalArtifactReader::new(temp_dir.path()));
+        let enabled = create_topcoat_router(validator_reader(missing_reader), true);
+        let error_response = response(
+            &enabled,
+            Request::builder()
+                .uri("/api/articles")
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+
+        assert_eq!(error_response.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!error_response.headers.contains_key(header::ETAG));
+        assert!(!error_response.headers.contains_key(header::CACHE_CONTROL));
     }
 }

--- a/crates/site/server/src/topcoat_runtime.rs
+++ b/crates/site/server/src/topcoat_runtime.rs
@@ -1,9 +1,9 @@
 //! Parallel Topcoat runtime shell used during the framework migration.
 
-use infra::DynArtifactReader;
+use infra::{DynArtifactReader, DynArtifactSnapshot};
 use topcoat::{
     Result,
-    context::{Cx, app_context},
+    context::{Cx, app_context, try_request_context},
     router::{
         Body, LayerFn, LayerFuture, Next, Router, StatusCode, content::Json,
         error::internal_server_error, request, response::Response, route,
@@ -11,7 +11,7 @@ use topcoat::{
 };
 
 use crate::{
-    article_index::read_article_index,
+    article_index::{read_article_index, read_article_index_from_snapshot},
     http_cache::{ArtifactConditionalGetDecision, ArtifactHttpCacheState},
     readiness::check_artifact_readiness,
 };
@@ -40,9 +40,11 @@ async fn readiness(cx: &Cx) -> Result<(StatusCode, &'static str)> {
 #[route(GET "/api/articles")]
 async fn articles(cx: &Cx) -> Result<Json<domain::ArticleIndexDocument>> {
     let artifact_reader = &app_context::<ArtifactReaderContext>(cx).0;
-    let document = read_article_index(artifact_reader)
-        .await
-        .map_err(internal_server_error)?;
+    let document = match try_request_context::<DynArtifactSnapshot>(cx) {
+        Some(snapshot) => read_article_index_from_snapshot(snapshot).await,
+        None => read_article_index(artifact_reader).await,
+    }
+    .map_err(internal_server_error)?;
     Ok(Json(document))
 }
 
@@ -67,7 +69,13 @@ fn artifact_conditional_get<'a>(cx: &'a Cx, body: Body, next: Next<'a>) -> Layer
             return Ok(not_modified_response(&conditional_get));
         }
 
-        let mut response = next.run(cx, body).await?;
+        let mut response = match conditional_get.snapshot() {
+            Some(snapshot) => {
+                let cx = cx.with(snapshot);
+                next.run(&cx, body).await?
+            }
+            None => next.run(cx, body).await?,
+        };
         if conditional_get.should_return_not_modified_after_response(response.status()) {
             return Ok(not_modified_response(&conditional_get));
         }
@@ -100,7 +108,14 @@ pub fn create_topcoat_router(
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc, time::SystemTime};
+    use std::{
+        path::PathBuf,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::SystemTime,
+    };
 
     use async_trait::async_trait;
     use domain::{
@@ -134,6 +149,20 @@ mod tests {
     #[derive(Clone)]
     struct ValidatorReader {
         inner: DynArtifactReader,
+    }
+
+    #[derive(Clone)]
+    struct CountingReader {
+        inner: DynArtifactReader,
+        snapshot_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ArtifactReader for CountingReader {
+        async fn snapshot(&self) -> Result<DynArtifactSnapshot> {
+            self.snapshot_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.snapshot().await
+        }
     }
 
     #[async_trait]
@@ -435,5 +464,27 @@ mod tests {
         assert_eq!(error_response.status, StatusCode::INTERNAL_SERVER_ERROR);
         assert!(!error_response.headers.contains_key(header::ETAG));
         assert!(!error_response.headers.contains_key(header::CACHE_CONTROL));
+    }
+
+    #[tokio::test]
+    async fn conditional_get_and_articles_share_one_snapshot() {
+        let snapshot_calls = Arc::new(AtomicUsize::new(0));
+        let reader: DynArtifactReader = Arc::new(CountingReader {
+            inner: fixture_reader(),
+            snapshot_calls: Arc::clone(&snapshot_calls),
+        });
+        let router = create_topcoat_router(validator_reader(reader), true);
+
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/api/articles")
+                .body(Body::empty())
+                .expect("request should be valid"),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(snapshot_calls.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## 概要

Issue #182 の段階移行として、Topcoat版 GET /api/articles に現行Axum runtimeと同じrelease-aware conditional GETを追加します。PR #200のbotレビューで後続対応とした内容です。

## 変更内容

- ETag・Last-Modified・Cache-Controlの生成とconditional header判定をruntime共通decisionへ抽出
- 既存Axum middlewareを共通decision経由へ変更し、挙動を維持
- Topcoat native layerでIf-None-Match / If-Modified-Sinceと304応答を実装
- If-None-Match優先、HEAD、無効設定、artifact error時のheader抑止を検証
- S3 cache TTLが有効な場合だけvalidatorを有効化する設定判定を両runtimeで共有

## 確認

- mise run format
- mise run test
- mise run clippy
- mise run check
- mise run build-project
- cargo build -p server --bin topcoat-server --release
- mise run test-e2e（14件＋empty-home 1件成功）

実S3 smoke testはcredentialsを使う手動公開前gateのため、このPRでは実行していません。

Refs #182