### PR TITLE
feat: migrate about page to Topcoat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,6 +3727,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
+ "chrono",
  "domain",
  "httpdate",
  "infra",
@@ -4501,6 +4502,7 @@ dependencies = [
  "tokio",
  "topcoat-core",
  "topcoat-view",
+ "tower",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ sha2 = "0.11"
 tempfile = "3"
 thiserror = "2"
 tokio = "1"
-topcoat = { version = "=0.6.2", default-features = false, features = ["router", "serve"] }
+topcoat = { version = "=0.6.2", default-features = false, features = ["router", "serve", "tower"] }
 tower = "0.5"
 tower-http = "0.7"
 tracing = "0.1"

--- a/crates/site/server/Cargo.toml
+++ b/crates/site/server/Cargo.toml
@@ -34,6 +34,7 @@ web = { path = "../web", features = ["hydrate"] }
 infra = { path = "../infra" }
 web = { path = "../web", features = ["ssr"], optional = true }
 axum.workspace = true
+chrono.workspace = true
 httpdate.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 topcoat.workspace = true

--- a/crates/site/server/src/lib.rs
+++ b/crates/site/server/src/lib.rs
@@ -20,3 +20,6 @@ pub mod readiness;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod topcoat_runtime;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod topcoat_pages;

--- a/crates/site/server/src/topcoat_pages.rs
+++ b/crates/site/server/src/topcoat_pages.rs
@@ -1,0 +1,242 @@
+//! Topcoat SSR pages introduced route by route during the migration.
+
+use chrono::Datelike;
+use domain::{
+    PageKey, StaticPageDocument, build_static_page_canonical_path, build_static_page_description,
+    build_static_page_document, build_static_page_title,
+};
+use infra::DynArtifactSnapshot;
+use topcoat::{
+    Result,
+    context::{Cx, app_context, try_request_context},
+    router::{StatusCode, route},
+    view::{Unescaped, View, component, view},
+};
+
+use crate::topcoat_runtime::ArtifactReaderContext;
+
+const ABOUT_PAGE_KEY: &str = "about";
+const NOT_FOUND_TITLE: &str = "ページが見つかりません";
+const NOT_FOUND_DESCRIPTION: &str = "お探しのページは見つかりませんでした。";
+const STYLESHEET_PATH: &str = "/pkg/web.css";
+
+#[route(GET "/about")]
+pub(crate) async fn about(cx: &Cx) -> Result<View> {
+    let snapshot = match try_request_context::<DynArtifactSnapshot>(cx) {
+        Some(snapshot) => snapshot.clone(),
+        None => {
+            app_context::<ArtifactReaderContext>(cx)
+                .0
+                .snapshot()
+                .await?
+        }
+    };
+    let page = PageKey::new(ABOUT_PAGE_KEY.to_string())?;
+
+    match snapshot.read_page_document(&page).await {
+        Ok(artifact) => match build_static_page_document(&artifact) {
+            Ok(document) => view! { about_document(document: document) },
+            Err(error) => {
+                eprintln!("About page artifact is invalid: {error}");
+                view! { internal_server_error_page() }
+            }
+        },
+        Err(error) if error.is_not_found() => view! { not_found_page() },
+        Err(error) => {
+            eprintln!("About page artifact read failed: {error}");
+            view! { internal_server_error_page() }
+        }
+    }
+}
+
+#[component]
+async fn about_document(document: StaticPageDocument) -> Result {
+    let title = build_static_page_title(&document, web::SITE_NAME);
+    let description = build_static_page_description(&document);
+    let canonical_url = web::build_site_url(&build_static_page_canonical_path(&document));
+    let page_title = document.title;
+    // The publish pipeline escapes raw Markdown HTML and neutralizes unsafe href schemes before
+    // persisting this fragment. It is therefore the trusted HTML boundary for Topcoat as well.
+    let html = Unescaped::new_unchecked(document.html);
+
+    view! {
+        site_shell(
+            status: StatusCode::OK,
+            title: title,
+            description: description,
+            canonical_url: canonical_url,
+            <div
+                class="mx-auto grid min-h-full w-full max-w-[var(--site-content-width)] gap-8 px-4 py-8 text-left sm:px-6 sm:py-12"
+            >
+                <section
+                    class="flex min-h-64 items-center justify-center rounded-2xl border border-border/70 bg-gradient-to-br from-card via-card to-secondary/70 p-8 text-center shadow-[0_18px_42px_rgb(0_0_0/0.24)] sm:min-h-80"
+                >
+                    <div
+                        class="grid max-w-xl gap-3 rounded-xl border border-border/60 bg-background/20 p-6 shadow-[0_10px_28px_rgb(0_0_0/0.22)] sm:p-8"
+                    >
+                        <p
+                            class="m-0 text-sm tracking-[0.16em] text-muted-foreground uppercase"
+                        >
+                            "Page"
+                        </p>
+                        <h1
+                            class="m-0 text-3xl leading-tight font-bold text-primary after:mx-auto after:mt-3 after:block after:h-1 after:w-12 after:rounded-full after:bg-primary sm:text-4xl"
+                        >
+                            (page_title)
+                        </h1>
+                    </div>
+                </section>
+                <article
+                    class="content-prose w-full rounded-xl border border-border/80 bg-card p-6 shadow-[0_12px_32px_rgb(0_0_0/0.22)] sm:p-8"
+                >
+                    (html)
+                </article>
+            </div>
+        )
+    }
+}
+
+#[component]
+async fn not_found_page() -> Result {
+    view! {
+        site_shell(
+            status: StatusCode::NOT_FOUND,
+            title: format!("{NOT_FOUND_TITLE} | {}", web::SITE_NAME),
+            description: NOT_FOUND_DESCRIPTION.to_string(),
+            canonical_url: web::build_site_url("/about"),
+            <div>"ページが見つかりませんでした。"</div>
+        )
+    }
+}
+
+#[component]
+async fn internal_server_error_page() -> Result {
+    view! {
+        site_shell(
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            title: format!("About | {}", web::SITE_NAME),
+            description: "About ページです。".to_string(),
+            canonical_url: web::build_site_url("/about"),
+            <div
+                class="mx-auto my-8 w-[calc(100%-2rem)] max-w-[var(--site-content-width)] rounded-xl bg-secondary p-8 text-center text-muted-foreground"
+            >
+                "ページの読み込みに失敗しました"
+            </div>
+        )
+    }
+}
+
+#[component]
+async fn site_shell(
+    status: StatusCode,
+    title: String,
+    description: String,
+    canonical_url: String,
+    child: View,
+) -> Result {
+    let year = chrono::Local::now().year();
+    let stylesheet_href = stylesheet_href();
+
+    view! {
+        (status)
+        <!DOCTYPE html>
+        <html lang="ja">
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <title>(title.clone())</title>
+                <meta name="description" content=(description.clone())>
+                <link rel="canonical" href=(canonical_url.clone())>
+                <meta property="og:title" content=(title)>
+                <meta property="og:description" content=(description)>
+                <meta property="og:url" content=(canonical_url)>
+                <meta property="og:type" content="website">
+                <link rel="stylesheet" href=(stylesheet_href)>
+                <link
+                    rel="icon"
+                    href="/favicon.ico?v=f544a69c"
+                    type="image/x-icon"
+                    sizes="16x16 32x32 48x48"
+                >
+                <link
+                    rel="stylesheet"
+                    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
+                >
+            </head>
+            <body>
+                <div class="flex min-h-dvh flex-col text-foreground">
+                    <header
+                        class="sticky top-0 z-50 h-[var(--site-header-height)] border-b border-border/60 bg-[image:var(--site-header-background)] shadow-[0_8px_24px_rgb(0_0_0/0.45)] backdrop-blur-sm"
+                    >
+                        <div
+                            class="relative mx-auto flex h-full max-w-[var(--site-content-width)] items-center justify-between gap-3 px-4 sm:px-6"
+                        >
+                            <a
+                                href="/"
+                                class="min-w-0 text-foreground no-underline transition-colors hover:text-primary focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring"
+                            >
+                                <h1
+                                    class="m-0 truncate text-xl leading-tight font-bold sm:text-2xl"
+                                >
+                                    (web::SITE_NAME)
+                                </h1>
+                            </a>
+                            <nav aria-label="メインナビゲーション">
+                                <ul class="m-0 flex list-none items-center gap-2 p-0">
+                                    <li><a href="/">"ホーム"</a></li>
+                                    <li><a href="/about" aria-current="page">"About"</a></li>
+                                </ul>
+                            </nav>
+                        </div>
+                    </header>
+                    <main class="content-container flex-1">(child)</main>
+                    <footer
+                        class="border-t border-border bg-gradient-to-r from-card to-background px-4 py-8 text-center text-sm text-muted-foreground"
+                    >
+                        <div class="mx-auto max-w-[var(--site-content-width)]">
+                            <p class="my-2 leading-relaxed">
+                                (format!("© {year} okawak. All Rights Reserved."))
+                            </p>
+                            <p class="my-2 leading-relaxed">
+                                <small>
+                                    "Powered by "
+                                    <a
+                                        href="https://github.com/tokio-rs/topcoat"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        "Topcoat"
+                                    </a>
+                                </small>
+                            </p>
+                        </div>
+                    </footer>
+                </div>
+            </body>
+        </html>
+    }
+}
+
+fn stylesheet_href() -> String {
+    let hash = std::env::current_exe()
+        .ok()
+        .and_then(|executable| executable.parent().map(std::path::Path::to_owned))
+        .and_then(|directory| {
+            [directory.join("hash.txt"), directory.join("../hash.txt")]
+                .into_iter()
+                .find_map(|path| std::fs::read_to_string(path).ok())
+        })
+        .and_then(|hashes| {
+            hashes.lines().find_map(|line| {
+                let (name, hash) = line.trim().split_once(':')?;
+                (name == "css")
+                    .then(|| hash.trim().to_string())
+                    .filter(|hash| !hash.is_empty())
+            })
+        });
+
+    match hash {
+        Some(hash) => format!("/pkg/web.{hash}.css"),
+        None => STYLESHEET_PATH.to_string(),
+    }
+}

--- a/crates/site/server/src/topcoat_pages.rs
+++ b/crates/site/server/src/topcoat_pages.rs
@@ -14,6 +14,10 @@ use topcoat::{
 };
 
 use crate::topcoat_runtime::ArtifactReaderContext;
+use web::generated_content::{
+    CODE_HIGHLIGHT_SCRIPT, HIGHLIGHT_SCRIPT_URL, HIGHLIGHT_STYLESHEET_URL, KATEX_SCRIPT_INTEGRITY,
+    KATEX_SCRIPT_URL, KATEX_STYLESHEET_INTEGRITY, KATEX_STYLESHEET_URL, MATH_RENDER_SCRIPT,
+};
 
 const ABOUT_PAGE_KEY: &str = "about";
 const NOT_FOUND_TITLE: &str = "ページが見つかりません";
@@ -136,6 +140,8 @@ async fn site_shell(
 ) -> Result {
     let year = chrono::Local::now().year();
     let stylesheet_href = stylesheet_href();
+    let math_render_script = Unescaped::new_unchecked(MATH_RENDER_SCRIPT);
+    let code_highlight_script = Unescaped::new_unchecked(CODE_HIGHLIGHT_SCRIPT);
 
     view! {
         (status)
@@ -162,6 +168,27 @@ async fn site_shell(
                     rel="stylesheet"
                     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
                 >
+                <link
+                    rel="stylesheet"
+                    href=(KATEX_STYLESHEET_URL)
+                    integrity=(KATEX_STYLESHEET_INTEGRITY)
+                    crossorigin="anonymous"
+                >
+                <script
+                    defer=""
+                    src=(KATEX_SCRIPT_URL)
+                    integrity=(KATEX_SCRIPT_INTEGRITY)
+                    crossorigin="anonymous"
+                    onload="window.okawakScheduleMathRender && window.okawakScheduleMathRender();"
+                ></script>
+                <script>(math_render_script)</script>
+                <link rel="stylesheet" href=(HIGHLIGHT_STYLESHEET_URL)>
+                <script
+                    defer=""
+                    src=(HIGHLIGHT_SCRIPT_URL)
+                    onload="window.okawakScheduleCodeHighlight && window.okawakScheduleCodeHighlight();"
+                ></script>
+                <script>(code_highlight_script)</script>
             </head>
             <body>
                 <div class="flex min-h-dvh flex-col text-foreground">

--- a/crates/site/server/src/topcoat_runtime.rs
+++ b/crates/site/server/src/topcoat_runtime.rs
@@ -1,23 +1,27 @@
 //! Parallel Topcoat runtime shell used during the framework migration.
 
+use std::path::PathBuf;
+
 use infra::{DynArtifactReader, DynArtifactSnapshot};
 use topcoat::{
     Result,
     context::{Cx, app_context, try_request_context},
     router::{
-        Body, LayerFn, LayerFuture, Next, Router, StatusCode, content::Json,
-        error::internal_server_error, request, response::Response, route,
+        Body, LayerFn, LayerFuture, Method, Next, Router, StatusCode, content::Json,
+        error::internal_server_error, request, response::Response, route, tower::TowerRoute,
     },
 };
+use tower_http::services::ServeDir;
 
 use crate::{
     article_index::{read_article_index, read_article_index_from_snapshot},
     http_cache::{ArtifactConditionalGetDecision, ArtifactHttpCacheState},
     readiness::check_artifact_readiness,
+    topcoat_pages,
 };
 
 #[derive(Clone)]
-struct ArtifactReaderContext(DynArtifactReader);
+pub(crate) struct ArtifactReaderContext(pub(crate) DynArtifactReader);
 
 #[route(GET "/api/health")]
 async fn health() -> Result<&'static str> {
@@ -90,14 +94,38 @@ pub fn create_topcoat_router(
     artifact_reader: DynArtifactReader,
     validators_enabled: bool,
 ) -> Router {
+    create_topcoat_router_with_site_root(
+        artifact_reader,
+        validators_enabled,
+        PathBuf::from("target/site"),
+    )
+}
+
+fn create_topcoat_router_with_site_root(
+    artifact_reader: DynArtifactReader,
+    validators_enabled: bool,
+    site_root: PathBuf,
+) -> Router {
+    let static_files = ServeDir::new(site_root);
+
     Router::builder()
         .route(health)
         .route(readiness)
         .route(articles)
+        .route(topcoat_pages::about)
+        // Reuse the current generated asset directory during the parallel-runtime period. The
+        // final asset pipeline will replace this compatibility mount before Leptos is removed.
+        .route(TowerRoute::new(
+            Method::GET,
+            "/pkg/{*rest}",
+            static_files.clone(),
+        ))
+        .route(TowerRoute::new(Method::GET, "/favicon.ico", static_files))
         .layer(LayerFn::new(
             Some("/api/articles"),
             artifact_conditional_get,
         ))
+        .layer(LayerFn::new(Some("/about"), artifact_conditional_get))
         .app_context(ArtifactHttpCacheState::new(
             artifact_reader.clone(),
             validators_enabled,
@@ -131,7 +159,7 @@ mod tests {
         Body, HeaderMap, Router, StatusCode, header, request::Request, to_bytes,
     };
 
-    use super::create_topcoat_router;
+    use super::{create_topcoat_router, create_topcoat_router_with_site_root};
 
     struct TestResponse {
         status: StatusCode,
@@ -342,6 +370,207 @@ mod tests {
         .await;
 
         assert_eq!(response.status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn about_renders_the_published_page_as_html() {
+        let router = create_topcoat_router(fixture_reader(), false);
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/about")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(
+            response.content_type.as_deref(),
+            Some("text/html; charset=utf-8")
+        );
+        assert!(response.body.starts_with("<!DOCTYPE html>"));
+        assert!(response.body.contains("<html lang=\"ja\">"));
+        assert!(
+            response
+                .body
+                .contains("<title>Fixture About | ぶくせんの探窟メモ</title>")
+        );
+        assert!(
+            response
+                .body
+                .contains("<meta name=\"description\" content=\"About fixture description\">")
+        );
+        assert!(
+            response
+                .body
+                .contains("<link rel=\"canonical\" href=\"https://www.okawak.net/about\">")
+        );
+        assert!(response.body.contains(
+            "<meta property=\"og:title\" content=\"Fixture About | ぶくせんの探窟メモ\">"
+        ));
+        assert!(
+            response.body.contains(
+                "<meta property=\"og:description\" content=\"About fixture description\">"
+            )
+        );
+        assert!(
+            response
+                .body
+                .contains("<meta property=\"og:url\" content=\"https://www.okawak.net/about\">")
+        );
+        assert!(
+            response
+                .body
+                .contains("<meta property=\"og:type\" content=\"website\">")
+        );
+        assert!(
+            response
+                .body
+                .contains("<link rel=\"stylesheet\" href=\"/pkg/web")
+        );
+        assert!(response.body.contains(".css\">"));
+        assert!(response.body.contains(">Fixture About</h1>"));
+        assert!(
+            response
+                .body
+                .contains("<h1>About artifact</h1><p>About fixture body</p>")
+        );
+        assert!(!response.body.contains("&lt;h1&gt;About artifact"));
+    }
+
+    #[tokio::test]
+    async fn about_returns_not_found_page_when_artifact_is_missing() {
+        let temp_dir = tempdir().unwrap();
+        let router =
+            create_topcoat_router(Arc::new(LocalArtifactReader::new(temp_dir.path())), false);
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/about")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::NOT_FOUND);
+        assert!(
+            response
+                .body
+                .contains("<title>ページが見つかりません | ぶくせんの探窟メモ</title>")
+        );
+        assert!(response.body.contains("ページが見つかりませんでした。"));
+    }
+
+    #[tokio::test]
+    async fn about_returns_internal_server_error_page_for_invalid_artifact() {
+        let temp_dir = tempdir().unwrap();
+        std::fs::create_dir_all(temp_dir.path().join("pages")).unwrap();
+        std::fs::write(temp_dir.path().join("pages/about.json"), "not json").unwrap();
+        let router =
+            create_topcoat_router(Arc::new(LocalArtifactReader::new(temp_dir.path())), false);
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/about")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(response.body.contains("ページの読み込みに失敗しました"));
+    }
+
+    #[tokio::test]
+    async fn about_supports_release_aware_conditional_get() {
+        let router = create_topcoat_router(validator_reader(fixture_reader()), true);
+        let first = response(
+            &router,
+            Request::builder()
+                .uri("/about")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        let etag = first
+            .headers
+            .get(header::ETAG)
+            .expect("ETag")
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let cached = response(
+            &router,
+            Request::builder()
+                .uri("/about")
+                .header(header::IF_NONE_MATCH, etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(cached.status, StatusCode::NOT_MODIFIED);
+        assert!(cached.body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn conditional_get_and_about_share_one_snapshot() {
+        let snapshot_calls = Arc::new(AtomicUsize::new(0));
+        let reader = Arc::new(CountingReader {
+            inner: fixture_reader(),
+            snapshot_calls: snapshot_calls.clone(),
+        });
+        let router = create_topcoat_router(validator_reader(reader), true);
+
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/about")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert_eq!(snapshot_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn topcoat_serves_transitional_static_assets() {
+        let temp_dir = tempdir().unwrap();
+        std::fs::create_dir_all(temp_dir.path().join("pkg")).unwrap();
+        std::fs::write(temp_dir.path().join("pkg/web.css"), "body { color: red; }").unwrap();
+        std::fs::write(temp_dir.path().join("favicon.ico"), b"icon").unwrap();
+        let router = create_topcoat_router_with_site_root(
+            fixture_reader(),
+            false,
+            temp_dir.path().to_path_buf(),
+        );
+
+        let stylesheet = response(
+            &router,
+            Request::builder()
+                .uri("/pkg/web.css")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+        let favicon = response(
+            &router,
+            Request::builder()
+                .uri("/favicon.ico")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(stylesheet.status, StatusCode::OK);
+        assert_eq!(stylesheet.content_type.as_deref(), Some("text/css"));
+        assert_eq!(stylesheet.body, "body { color: red; }");
+        assert_eq!(favicon.status, StatusCode::OK);
+        assert_eq!(favicon.body, "icon");
     }
 
     #[tokio::test]

--- a/crates/site/server/src/topcoat_runtime.rs
+++ b/crates/site/server/src/topcoat_runtime.rs
@@ -440,6 +440,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn about_shell_initializes_generated_content_renderers() {
+        let router = create_topcoat_router(fixture_reader(), false);
+        let response = response(
+            &router,
+            Request::builder()
+                .uri("/about")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert!(response.body.contains("katex@0.16.22/dist/katex.min.css"));
+        assert!(response.body.contains("katex@0.16.22/dist/katex.min.js"));
+        assert!(response.body.contains("window.okawakRenderMath"));
+        assert!(response.body.contains("window.okawakScheduleMathRender"));
+        assert!(
+            response
+                .body
+                .contains("if (window.katex && window.okawakRenderMath)")
+        );
+        assert!(
+            response
+                .body
+                .contains("highlight.js/11.11.1/styles/github-dark.min.css")
+        );
+        assert!(
+            response
+                .body
+                .contains("highlight.js/11.11.1/highlight.min.js")
+        );
+        assert!(response.body.contains("window.okawakHighlightCode"));
+        assert!(response.body.contains("window.okawakScheduleCodeHighlight"));
+        assert!(!response.body.contains("window.katex &amp;&amp;"));
+    }
+
+    #[tokio::test]
     async fn about_returns_not_found_page_when_artifact_is_missing() {
         let temp_dir = tempdir().unwrap();
         let router =

--- a/crates/site/web/src/app.rs
+++ b/crates/site/web/src/app.rs
@@ -1,5 +1,9 @@
 use crate::SITE_NAME;
 use crate::components::{footer::Footer, header::Header};
+use crate::generated_content::{
+    CODE_HIGHLIGHT_SCRIPT, HIGHLIGHT_SCRIPT_URL, HIGHLIGHT_STYLESHEET_URL, KATEX_SCRIPT_INTEGRITY,
+    KATEX_SCRIPT_URL, KATEX_STYLESHEET_INTEGRITY, KATEX_STYLESHEET_URL, MATH_RENDER_SCRIPT,
+};
 use crate::routes::about::AboutPage;
 use crate::routes::article::ArticlePage;
 use crate::routes::category::CategoryPage;
@@ -41,104 +45,28 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
                 // Load KaTeX from the CDN.
                 <link
                     rel="stylesheet"
-                    href="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css"
-                    integrity="sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP"
+                    href=KATEX_STYLESHEET_URL
+                    integrity=KATEX_STYLESHEET_INTEGRITY
                     crossorigin="anonymous"
                 />
                 <script
                     // Load asynchronously.
                     defer
-                    src="https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js"
-                    integrity="sha384-cMkvdD8LoxVzGF/RPUKAcvmm49FQ0oxwDF3BGKtDXcEc+T1b2N+teh/OJfpU0jr6"
+                    src=KATEX_SCRIPT_URL
+                    integrity=KATEX_SCRIPT_INTEGRITY
                     crossorigin="anonymous"
                     onload="window.okawakScheduleMathRender && window.okawakScheduleMathRender();"
                 ></script>
-                <script>
-                    {r#"
-                    window.okawakRenderMath = function(root) {
-                    if (!window.katex) return;
-                    
-                    const scope = root || document.body;
-                    const normalizeExpression = (value) =>
-                    (value || '').replace(/[\u2009\u200A\u200B\u200C\u200D\u2061\u202F\u2060\uFEFF]/g, '');
-                    
-                    scope.querySelectorAll('.math-inline').forEach((element) => {
-                    if (element.dataset.katexRendered === 'true') return;
-                    
-                    const expression = normalizeExpression(element.textContent);
-                    window.katex.render(expression, element, {
-                    displayMode: false,
-                    throwOnError: false,
-                    });
-                    element.dataset.katexRendered = 'true';
-                    });
-                    
-                    scope.querySelectorAll('.math-display').forEach((element) => {
-                    if (element.dataset.katexRendered === 'true') return;
-                    
-                    const expression = normalizeExpression(element.textContent);
-                    window.katex.render(expression, element, {
-                    displayMode: true,
-                    throwOnError: false,
-                    });
-                    element.dataset.katexRendered = 'true';
-                    });
-                    };
-                    
-                    window.okawakScheduleMathRender = function(root) {
-                    let remaining = 200;
-                    const attempt = function() {
-                    if (window.katex && window.okawakRenderMath) {
-                    window.okawakRenderMath(root);
-                    return;
-                    }
-                    
-                    if (remaining > 0) {
-                    remaining -= 1;
-                    window.setTimeout(attempt, 50);
-                    }
-                    };
-                    
-                    attempt();
-                    };
-                    
-                    "#}
-                </script>
+                <script>{MATH_RENDER_SCRIPT}</script>
 
                 // Load highlight.js from the CDN.
-                <link
-                    rel="stylesheet"
-                    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css"
-                />
+                <link rel="stylesheet" href=HIGHLIGHT_STYLESHEET_URL />
                 <script
                     defer
-                    src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"
+                    src=HIGHLIGHT_SCRIPT_URL
                     onload="window.okawakScheduleCodeHighlight && window.okawakScheduleCodeHighlight();"
                 ></script>
-                <script>
-                    {r#"
-                    window.okawakHighlightCode = function(root) {
-                    if (!window.hljs) return;
-                    const scope = root || document.body;
-                    scope.querySelectorAll('.content-prose pre code:not([data-highlighted])')
-                    .forEach((element) => window.hljs.highlightElement(element));
-                    };
-                    window.okawakScheduleCodeHighlight = function(root) {
-                    let remaining = 200;
-                    const attempt = function() {
-                    if (window.hljs && window.okawakHighlightCode) {
-                    window.okawakHighlightCode(root);
-                    return;
-                    }
-                    if (remaining > 0) {
-                    remaining -= 1;
-                    window.setTimeout(attempt, 50);
-                    }
-                    };
-                    attempt();
-                    };
-                    "#}
-                </script>
+                <script>{CODE_HIGHLIGHT_SCRIPT}</script>
                 <AutoReload options=options.clone() />
                 <HydrationScripts options />
                 <MetaTags />

--- a/crates/site/web/src/generated_content.rs
+++ b/crates/site/web/src/generated_content.rs
@@ -1,0 +1,85 @@
+//! Shared browser resources for build-time generated content.
+
+pub const KATEX_STYLESHEET_URL: &str =
+    "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css";
+pub const KATEX_STYLESHEET_INTEGRITY: &str =
+    "sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP";
+pub const KATEX_SCRIPT_URL: &str = "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js";
+pub const KATEX_SCRIPT_INTEGRITY: &str =
+    "sha384-cMkvdD8LoxVzGF/RPUKAcvmm49FQ0oxwDF3BGKtDXcEc+T1b2N+teh/OJfpU0jr6";
+pub const HIGHLIGHT_STYLESHEET_URL: &str =
+    "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css";
+pub const HIGHLIGHT_SCRIPT_URL: &str =
+    "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js";
+
+pub const MATH_RENDER_SCRIPT: &str = r#"
+window.okawakRenderMath = function(root) {
+if (!window.katex) return;
+
+const scope = root || document.body;
+const normalizeExpression = (value) =>
+(value || '').replace(/[\u2009\u200A\u200B\u200C\u200D\u2061\u202F\u2060\uFEFF]/g, '');
+
+scope.querySelectorAll('.math-inline').forEach((element) => {
+if (element.dataset.katexRendered === 'true') return;
+
+const expression = normalizeExpression(element.textContent);
+window.katex.render(expression, element, {
+displayMode: false,
+throwOnError: false,
+});
+element.dataset.katexRendered = 'true';
+});
+
+scope.querySelectorAll('.math-display').forEach((element) => {
+if (element.dataset.katexRendered === 'true') return;
+
+const expression = normalizeExpression(element.textContent);
+window.katex.render(expression, element, {
+displayMode: true,
+throwOnError: false,
+});
+element.dataset.katexRendered = 'true';
+});
+};
+
+window.okawakScheduleMathRender = function(root) {
+let remaining = 200;
+const attempt = function() {
+if (window.katex && window.okawakRenderMath) {
+window.okawakRenderMath(root);
+return;
+}
+
+if (remaining > 0) {
+remaining -= 1;
+window.setTimeout(attempt, 50);
+}
+};
+
+attempt();
+};
+"#;
+
+pub const CODE_HIGHLIGHT_SCRIPT: &str = r#"
+window.okawakHighlightCode = function(root) {
+if (!window.hljs) return;
+const scope = root || document.body;
+scope.querySelectorAll('.content-prose pre code:not([data-highlighted])')
+.forEach((element) => window.hljs.highlightElement(element));
+};
+window.okawakScheduleCodeHighlight = function(root) {
+let remaining = 200;
+const attempt = function() {
+if (window.hljs && window.okawakHighlightCode) {
+window.okawakHighlightCode(root);
+return;
+}
+if (remaining > 0) {
+remaining -= 1;
+window.setTimeout(attempt, 50);
+}
+};
+attempt();
+};
+"#;

--- a/crates/site/web/src/lib.rs
+++ b/crates/site/web/src/lib.rs
@@ -4,6 +4,7 @@ pub mod app;
 pub mod components;
 pub mod error;
 pub mod format;
+pub mod generated_content;
 pub mod routes;
 
 pub const SITE_NAME: &str = "ぶくせんの探窟メモ";

--- a/mise.toml
+++ b/mise.toml
@@ -129,7 +129,7 @@ cargo leptos serve -p server
 description = "Run the transitional Topcoat runtime shell with fixture artifacts"
 depends = ["build-project"]
 env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "e2e/fixtures/site", OKAWAK_BLOG_TOPCOAT_ADDR = "127.0.0.1:8009" }
-run = "cargo run -p server --bin topcoat-server"
+run = "cargo run -p server --bin topcoat-server --release"
 
 [tasks.clean-project]
 description = "Clean the Cargo build artifacts"

--- a/mise.toml
+++ b/mise.toml
@@ -127,6 +127,7 @@ cargo leptos serve -p server
 
 [tasks.dev-topcoat-shell]
 description = "Run the transitional Topcoat runtime shell with fixture artifacts"
+depends = ["build-project"]
 env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "e2e/fixtures/site", OKAWAK_BLOG_TOPCOAT_ADDR = "127.0.0.1:8009" }
 run = "cargo run -p server --bin topcoat-server"
 


### PR DESCRIPTION
## 概要

Issue #182 のSSR route移行の最初のsliceとして、`/about`をTopcoatでrenderします。production entrypointは引き続きLeptosのまま維持し、並行runtime上で観測可能な契約を固定します。

## 変更内容

- Topcoat `GET /about`でpage artifactから`StaticPageDocument`を構築
- title、description、canonical、Open Graph、status code、trusted artifact HTMLをSSR
- artifact不在を404、読取・validation errorを500へmapping
- conditional GETで取得したsnapshotを本文renderにも共有
- 現行のcontent-hash CSSとfaviconをTower compatibility mountから配信
- Topcoat固有page/componentを`topcoat_pages`へ分離

## 検証

- `mise run format`
- `mise run test`
- `mise run clippy`
- `mise run check`
- `mise run build-project`
- `cargo build -p server --bin topcoat-server --release`
- Topcoat release serverへ実HTTP request（`/about`、hashed CSS）
- browser E2E: 通常14件 + empty fixture 1件

`mise run test-e2e`は依存browser install確認が進まなかったため停止し、導入済みChromiumを使って同一の`e2e` package script `bun run test`を実行しました。実S3 smoke testはcredentialsを使用する手動公開前gateとして維持します。

Relates #182