### PR TITLE
feat: add Topcoat mobile navigation runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,10 +4366,12 @@ dependencies = [
  "topcoat-core",
  "topcoat-core-macro",
  "topcoat-font",
+ "topcoat-font-macro",
  "topcoat-mail",
  "topcoat-router",
  "topcoat-router-macro",
  "topcoat-runtime",
+ "topcoat-runtime-macro",
  "topcoat-session",
  "topcoat-view",
  "topcoat-view-macro",
@@ -4464,6 +4466,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "topcoat-font-grammar"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7d68e226827fb7531d0dba69cb74fa7b82515f8428fd1a75f556f5a2bf87c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "topcoat-core-grammar",
+ "topcoat-font",
+]
+
+[[package]]
+name = "topcoat-font-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e655c430bcb380f879603ea750c6222ade2ff3ade33869d9eaa32e3fc49f5469"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+ "topcoat-font-grammar",
+]
+
+[[package]]
 name = "topcoat-mail"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,6 +4569,33 @@ dependencies = [
  "topcoat-router",
  "topcoat-view",
  "uuid",
+]
+
+[[package]]
+name = "topcoat-runtime-grammar"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b73f7e4e10f49e006a71dd43e8ee629c76c08451acbc51faa7ec5b6952c53c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+ "topcoat-core-grammar",
+ "topcoat-runtime",
+ "uuid",
+]
+
+[[package]]
+name = "topcoat-runtime-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc3e4e245abcaea6af780437cae072e8f2157c9852ec5b3058a658c61b9e0bf"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+ "topcoat-runtime-grammar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ sha2 = "0.11"
 tempfile = "3"
 thiserror = "2"
 tokio = "1"
-topcoat = { version = "=0.6.2", default-features = false, features = ["router", "serve", "tower"] }
+topcoat = { version = "=0.6.2", default-features = false, features = ["asset", "router", "runtime", "serve", "tower"] }
 tower = "0.5"
 tower-http = "0.7"
 tracing = "0.1"

--- a/crates/site/server/src/bin/topcoat_server.rs
+++ b/crates/site/server/src/bin/topcoat_server.rs
@@ -3,6 +3,7 @@
 use infra::{ArtifactSourceConfig, build_artifact_reader};
 use server::http_cache::artifact_validators_enabled;
 use server::topcoat_runtime::create_topcoat_router;
+use topcoat::asset::AssetBundle;
 
 const DEFAULT_ADDR: &str = "127.0.0.1:8009";
 const ADDR_ENV: &str = "OKAWAK_BLOG_TOPCOAT_ADDR";
@@ -13,7 +14,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let artifact_source = ArtifactSourceConfig::from_env()?;
     let artifact_reader = build_artifact_reader(artifact_source.clone()).await?;
     let validators_enabled = artifact_validators_enabled(&artifact_source);
-    let router = create_topcoat_router(artifact_reader, validators_enabled);
+    let assets = AssetBundle::load()?;
+    let router = create_topcoat_router(artifact_reader, validators_enabled, assets.into());
     let listener = tokio::net::TcpListener::bind(&addr).await?;
 
     println!("Starting Topcoat migration server on http://{addr}");

--- a/crates/site/server/src/http_cache.rs
+++ b/crates/site/server/src/http_cache.rs
@@ -285,6 +285,8 @@ fn is_static_path(path: &str) -> bool {
         || path.starts_with("/pkg/")
         || path == "/assets"
         || path.starts_with("/assets/")
+        || path == "/_topcoat/assets"
+        || path.starts_with("/_topcoat/assets/")
         || path == "/favicon.ico"
 }
 
@@ -454,6 +456,10 @@ mod tests {
         assert!(!is_artifact_request(&Method::GET, "/api/server-fn"));
         assert!(!is_artifact_request(&Method::GET, "/pkg/web.js"));
         assert!(!is_artifact_request(&Method::GET, "/assets/logo.png"));
+        assert!(!is_artifact_request(
+            &Method::GET,
+            "/_topcoat/assets/topcoat.js"
+        ));
         assert!(!is_artifact_request(&Method::GET, "/favicon.ico"));
     }
 

--- a/crates/site/server/src/topcoat_pages.rs
+++ b/crates/site/server/src/topcoat_pages.rs
@@ -807,8 +807,11 @@ async fn site_shell(
                     onload="window.okawakScheduleCodeHighlight && window.okawakScheduleCodeHighlight();"
                 ></script>
                 <script>(code_highlight_script)</script>
+                topcoat::runtime::script()
             </head>
             <body>
+                signal menu_open = false;
+
                 <div class="flex min-h-dvh flex-col text-foreground">
                     <header
                         class="sticky top-0 z-50 h-[var(--site-header-height)] border-b border-border/60 bg-[image:var(--site-header-background)] shadow-[0_8px_24px_rgb(0_0_0/0.45)] backdrop-blur-sm"
@@ -826,8 +829,63 @@ async fn site_shell(
                                     (web::SITE_NAME)
                                 </h1>
                             </a>
-                            <nav aria-label="メインナビゲーション">
-                                <ul class="m-0 flex list-none items-center gap-2 p-0">
+
+                            <button
+                                type="button"
+                                class="inline-flex size-10 shrink-0 items-center justify-center rounded-md text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 md:hidden"
+                                aria-controls="site-header-nav"
+                                :aria-expanded=$(if menu_open.get() {
+                                    "true"
+                                } else {
+                                    "false"
+                                })
+                                :aria-label=$(if menu_open.get() {
+                                    "ナビゲーションメニューを閉じる"
+                                } else {
+                                    "ナビゲーションメニューを開く"
+                                })
+                                @click=$(|_e| menu_open.toggle())
+                            >
+                                <div
+                                    class="flex size-5 flex-col items-center justify-center gap-1.5"
+                                    aria-hidden="true"
+                                >
+                                    <span
+                                        :class=$(if menu_open.get() {
+                                            "block h-0.5 w-5 translate-y-2 rotate-45 rounded-full bg-current transition-transform"
+                                        } else {
+                                            "block h-0.5 w-5 rounded-full bg-current transition-all"
+                                        })
+                                    ></span>
+                                    <span
+                                        :class=$(if menu_open.get() {
+                                            "block h-0.5 w-5 rounded-full bg-current opacity-0 transition-opacity"
+                                        } else {
+                                            "block h-0.5 w-5 rounded-full bg-current transition-all"
+                                        })
+                                    ></span>
+                                    <span
+                                        :class=$(if menu_open.get() {
+                                            "block h-0.5 w-5 -translate-y-2 -rotate-45 rounded-full bg-current transition-transform"
+                                        } else {
+                                            "block h-0.5 w-5 rounded-full bg-current transition-all"
+                                        })
+                                    ></span>
+                                </div>
+                            </button>
+
+                            <nav
+                                id="site-header-nav"
+                                aria-label="メインナビゲーション"
+                                :class=$(if menu_open.get() {
+                                    "flex absolute inset-x-4 top-[calc(100%+0.5rem)] flex-col gap-3 rounded-lg border border-border bg-card/98 p-4 shadow-[0_18px_36px_rgb(0_0_0/0.55)] backdrop-blur-sm md:static md:flex md:flex-row md:items-center md:gap-6 md:border-0 md:bg-transparent md:p-0 md:shadow-none"
+                                } else {
+                                    "hidden absolute inset-x-4 top-[calc(100%+0.5rem)] flex-col gap-3 rounded-lg border border-border bg-card/98 p-4 shadow-[0_18px_36px_rgb(0_0_0/0.55)] backdrop-blur-sm md:static md:flex md:flex-row md:items-center md:gap-6 md:border-0 md:bg-transparent md:p-0 md:shadow-none"
+                                })
+                            >
+                                <ul
+                                    class="m-0 flex list-none flex-col gap-1 p-0 md:flex-row md:items-center md:gap-2"
+                                >
                                     <li>
                                         <a
                                             href="/"
@@ -836,6 +894,12 @@ async fn site_shell(
                                             } else {
                                                 None
                                             })
+                                            class=(if current_path == "/" {
+                                                "block rounded-md border-b-2 border-primary px-3 py-2 text-sm font-medium text-foreground no-underline"
+                                            } else {
+                                                "block rounded-md border-b-2 border-transparent px-3 py-2 text-sm font-medium text-muted-foreground no-underline transition-colors hover:border-primary hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                                            })
+                                            @click=$(|_e| menu_open.set(false))
                                         >
                                             "ホーム"
                                         </a>
@@ -848,11 +912,31 @@ async fn site_shell(
                                             } else {
                                                 None
                                             })
+                                            class=(if current_path == "/about" {
+                                                "block rounded-md border-b-2 border-primary px-3 py-2 text-sm font-medium text-foreground no-underline"
+                                            } else {
+                                                "block rounded-md border-b-2 border-transparent px-3 py-2 text-sm font-medium text-muted-foreground no-underline transition-colors hover:border-primary hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                                            })
+                                            @click=$(|_e| menu_open.set(false))
                                         >
                                             "About"
                                         </a>
                                     </li>
                                 </ul>
+
+                                <div
+                                    class="border-t border-border pt-3 md:border-t-0 md:pt-0"
+                                >
+                                    <a
+                                        href="https://github.com/okawak"
+                                        class="inline-flex size-10 items-center justify-center rounded-md text-foreground transition-colors hover:bg-accent hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                                        aria-label="Open okawak GitHub profile"
+                                        rel="noopener noreferrer"
+                                        target="_blank"
+                                    >
+                                        <i class="fab fa-github text-xl" aria-hidden="true"></i>
+                                    </a>
+                                </div>
                             </nav>
                         </div>
                     </header>

--- a/crates/site/server/src/topcoat_runtime.rs
+++ b/crates/site/server/src/topcoat_runtime.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use infra::{DynArtifactReader, DynArtifactSnapshot};
 use topcoat::{
     Result,
+    asset::{AssetConfig, RouterBuilderAssetExt},
     context::{Cx, app_context, try_request_context},
     router::{
         Body, LayerFn, LayerFuture, Method, Next, Path, Router, StatusCode, content::Json,
@@ -93,11 +94,13 @@ fn artifact_conditional_get<'a>(cx: &'a Cx, body: Body, next: Next<'a>) -> Layer
 pub fn create_topcoat_router(
     artifact_reader: DynArtifactReader,
     validators_enabled: bool,
+    assets: AssetConfig,
 ) -> Router {
     create_topcoat_router_with_site_root(
         artifact_reader,
         validators_enabled,
         PathBuf::from("target/site"),
+        assets,
     )
 }
 
@@ -105,6 +108,7 @@ fn create_topcoat_router_with_site_root(
     artifact_reader: DynArtifactReader,
     validators_enabled: bool,
     site_root: PathBuf,
+    assets: AssetConfig,
 ) -> Router {
     let static_files = ServeDir::new(site_root);
 
@@ -132,6 +136,7 @@ fn create_topcoat_router_with_site_root(
             validators_enabled,
         ))
         .app_context(ArtifactReaderContext(artifact_reader))
+        .assets(assets)
         .build()
 }
 
@@ -156,11 +161,15 @@ mod tests {
         LocalArtifactReader, Result,
     };
     use tempfile::tempdir;
-    use topcoat::router::{
-        Body, HeaderMap, Router, StatusCode, header, request::Request, to_bytes,
+    use topcoat::{
+        asset::{AssetConfig, Manifest, ManifestEntry},
+        router::{Body, HeaderMap, Router, StatusCode, header, request::Request, to_bytes},
     };
 
-    use super::{create_topcoat_router, create_topcoat_router_with_site_root};
+    use super::{
+        create_topcoat_router as create_topcoat_router_with_assets,
+        create_topcoat_router_with_site_root as create_topcoat_router_with_site_root_and_assets,
+    };
 
     struct TestResponse {
         status: StatusCode,
@@ -179,6 +188,41 @@ mod tests {
         Arc::new(LocalArtifactReader::new(
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../e2e/fixtures/empty-site"),
         ))
+    }
+
+    fn test_asset_config() -> AssetConfig {
+        AssetConfig::hosted_at(
+            "/_topcoat/assets",
+            Manifest {
+                version: 1,
+                assets: vec![ManifestEntry {
+                    id: topcoat::runtime::SCRIPT.id(),
+                    file: "topcoat-test.js".to_string(),
+                    hash: "test".to_string(),
+                    content_type: "text/javascript".to_string(),
+                }],
+            },
+        )
+    }
+
+    fn create_topcoat_router(
+        artifact_reader: DynArtifactReader,
+        validators_enabled: bool,
+    ) -> Router {
+        create_topcoat_router_with_assets(artifact_reader, validators_enabled, test_asset_config())
+    }
+
+    fn create_topcoat_router_with_site_root(
+        artifact_reader: DynArtifactReader,
+        validators_enabled: bool,
+        site_root: PathBuf,
+    ) -> Router {
+        create_topcoat_router_with_site_root_and_assets(
+            artifact_reader,
+            validators_enabled,
+            site_root,
+            test_asset_config(),
+        )
     }
 
     #[derive(Clone)]
@@ -438,6 +482,39 @@ mod tests {
         assert!(response.body.contains("2026年1月1日"));
         assert!(response.body.contains("2026年1月2日"));
         assert!(!response.body.contains("&lt;p&gt;Fixture home content"));
+    }
+
+    #[tokio::test]
+    async fn home_shell_exposes_topcoat_mobile_navigation_contract() {
+        let router = create_topcoat_router(fixture_reader(), false);
+        let response = response(
+            &router,
+            Request::builder().uri("/").body(Body::empty()).unwrap(),
+        )
+        .await;
+
+        assert_eq!(response.status, StatusCode::OK);
+        assert!(response.body.contains(
+            "<script type=\"module\" src=\"/_topcoat/assets/topcoat-test.js\"></script>"
+        ));
+        assert!(response.body.contains("aria-controls=\"site-header-nav\""));
+        assert!(response.body.contains("aria-expanded=\"false\""));
+        assert!(
+            response
+                .body
+                .contains("aria-label=\"ナビゲーションメニューを開く\"")
+        );
+        assert!(response.body.contains("data-topcoat-on:click="));
+        assert!(response.body.contains("data-topcoat-bind:aria-expanded="));
+        assert!(response.body.contains("data-topcoat-bind:aria-label="));
+        assert!(response.body.contains("<nav id=\"site-header-nav\""));
+        assert!(response.body.contains("data-topcoat-bind:class="));
+        assert!(response.body.contains("class=\"hidden absolute inset-x-4"));
+        assert!(
+            response
+                .body
+                .contains("aria-label=\"Open okawak GitHub profile\"")
+        );
     }
 
     #[tokio::test]

--- a/mise.toml
+++ b/mise.toml
@@ -129,7 +129,11 @@ cargo leptos serve -p server
 description = "Run the transitional Topcoat runtime shell with fixture artifacts"
 depends = ["build-project"]
 env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "e2e/fixtures/site", OKAWAK_BLOG_TOPCOAT_ADDR = "127.0.0.1:8009" }
-run = "cargo run -p server --bin topcoat-server --release"
+run = '''
+topcoat asset bundle --package server --bin topcoat-server --release
+# Asset IDs are tied to the exact binary scanned by the bundler.
+./target/release/topcoat-server
+'''
 
 [tasks.clean-project]
 description = "Clean the Cargo build artifacts"


### PR DESCRIPTION
## 概要

Issue #182 の段階的移行として、Topcoat shellへ最初のclient-side interactionを追加します。

- Topcoat runtime JavaScriptをasset bundleとして登録・配信
- 現行Leptosと同じモバイルナビゲーションの開閉、ARIA状態、ハンバーガー表示、GitHubリンクを実装
- `dev-topcoat-shell`でbundleが走査したものと同一のbinaryを起動
- Topcoat route testsへruntime/mobile navigation contractを追加

## スコープ

Topcoat 0.6.2には組み込みのclient-side navigation/prefetchがまだないため、document requestを発生させない内部遷移は後続の独立sliceで扱います。このPRでは現行のURL・表示内容・通常リンク遷移を維持します。

Refs #182

## 検証

- `mise run format`
- `mise run check`
- `mise run clippy`
- `mise run test`
- `mise run build-project`
- `topcoat asset bundle --package server --bin topcoat-server --release`
- fixture release serverでHTML/CSS/runtime assetをHTTP確認
- in-app browser 390x844で初期非表示、開閉、ARIA更新、About遷移後の閉状態、WASM参照なしを確認