### PR TITLE
feat: bundle Topcoat Tailwind assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1352,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2574,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,7 +3461,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3885,6 +3913,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
@@ -4373,6 +4407,7 @@ dependencies = [
  "topcoat-runtime",
  "topcoat-runtime-macro",
  "topcoat-session",
+ "topcoat-tailwind",
  "topcoat-view",
  "topcoat-view-macro",
 ]
@@ -4612,6 +4647,18 @@ dependencies = [
  "topcoat-core",
  "topcoat-router",
  "web-time",
+]
+
+[[package]]
+name = "topcoat-tailwind"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a330145b9aa08c4bafad74400e3b3fcb81c88b96f177e0dc4eba829e4fc5ac79"
+dependencies = [
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "topcoat-core",
+ "ureq",
 ]
 
 [[package]]
@@ -4916,6 +4963,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http 1.5.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4932,6 +5008,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5154,6 +5236,15 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ sha2 = "0.11"
 tempfile = "3"
 thiserror = "2"
 tokio = "1"
-topcoat = { version = "=0.6.2", default-features = false, features = ["asset", "router", "runtime", "serve", "tower"] }
+topcoat = { version = "=0.6.2", default-features = false, features = ["asset", "router", "runtime", "serve", "tailwind", "tower"] }
 tower = "0.5"
 tower-http = "0.7"
 tracing = "0.1"

--- a/crates/site/server/Cargo.toml
+++ b/crates/site/server/Cargo.toml
@@ -54,6 +54,9 @@ serde_json.workspace = true
 tempfile.workspace = true
 tower = { workspace = true, features = ["util"] }
 
+[build-dependencies]
+topcoat = { workspace = true, default-features = false, features = ["tailwind"] }
+
 [package.metadata.leptos]
 # Keep cargo-leptos on the production Leptos binary while the Topcoat binary is developed in parallel.
 bin-target = "server"

--- a/crates/site/server/build.rs
+++ b/crates/site/server/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-changed=../web/src");
+    println!("cargo:rerun-if-changed=../web/style");
+
+    topcoat::tailwind::BuildConfig::new()
+        .input("crates/site/web/style/tailwind.css")
+        .cwd("../../..")
+        .version("4.3.3")
+        .render()
+        .expect("Topcoat should build the site Tailwind stylesheet");
+}

--- a/crates/site/server/src/topcoat_pages.rs
+++ b/crates/site/server/src/topcoat_pages.rs
@@ -31,10 +31,11 @@ use web::generated_content::{
 const ABOUT_PAGE_KEY: &str = "about";
 const NOT_FOUND_TITLE: &str = "ページが見つかりません";
 const NOT_FOUND_DESCRIPTION: &str = "お探しのページは見つかりませんでした。";
-const STYLESHEET_PATH: &str = "/pkg/web.css";
 // Bump when retained shell markup outside `<main>` changes incompatibly.
 const SHELL_VERSION: &str = "topcoat-1";
 pub(crate) const CLIENT_NAVIGATION_SCRIPT: Asset = asset!("./topcoat_navigation.js");
+pub(crate) const STYLESHEET: Asset = topcoat::tailwind::stylesheet!();
+pub(crate) const FAVICON: Asset = asset!("../../web/public/favicon.ico", rename: "favicon");
 
 struct ShellMetadata {
     title: String,
@@ -755,7 +756,6 @@ async fn site_shell(
     child: View,
 ) -> Result {
     let year = chrono::Local::now().year();
-    let stylesheet_href = stylesheet_href();
     let math_render_script = Unescaped::new_unchecked(MATH_RENDER_SCRIPT);
     let code_highlight_script = Unescaped::new_unchecked(CODE_HIGHLIGHT_SCRIPT);
     let ShellMetadata {
@@ -780,10 +780,10 @@ async fn site_shell(
                 <meta property="og:description" content=(description)>
                 <meta property="og:url" content=(canonical_url)>
                 <meta property="og:type" content=(og_type)>
-                <link rel="stylesheet" href=(stylesheet_href)>
+                <link rel="stylesheet" href=(STYLESHEET)>
                 <link
                     rel="icon"
-                    href="/favicon.ico?v=f544a69c"
+                    href=(FAVICON)
                     type="image/x-icon"
                     sizes="16x16 32x32 48x48"
                 >
@@ -971,29 +971,5 @@ async fn site_shell(
                 </div>
             </body>
         </html>
-    }
-}
-
-fn stylesheet_href() -> String {
-    let hash = std::env::current_exe()
-        .ok()
-        .and_then(|executable| executable.parent().map(std::path::Path::to_owned))
-        .and_then(|directory| {
-            [directory.join("hash.txt"), directory.join("../hash.txt")]
-                .into_iter()
-                .find_map(|path| std::fs::read_to_string(path).ok())
-        })
-        .and_then(|hashes| {
-            hashes.lines().find_map(|line| {
-                let (name, hash) = line.trim().split_once(':')?;
-                (name == "css")
-                    .then(|| hash.trim().to_string())
-                    .filter(|hash| !hash.is_empty())
-            })
-        });
-
-    match hash {
-        Some(hash) => format!("/pkg/web.{hash}.css"),
-        None => STYLESHEET_PATH.to_string(),
     }
 }

--- a/crates/site/server/src/topcoat_runtime.rs
+++ b/crates/site/server/src/topcoat_runtime.rs
@@ -1,18 +1,15 @@
 //! Parallel Topcoat runtime shell used during the framework migration.
 
-use std::path::PathBuf;
-
 use infra::{DynArtifactReader, DynArtifactSnapshot};
 use topcoat::{
     Result,
     asset::{AssetConfig, RouterBuilderAssetExt},
     context::{Cx, app_context, try_request_context},
     router::{
-        Body, LayerFn, LayerFuture, Method, Next, Path, Router, StatusCode, content::Json,
-        error::internal_server_error, request, response::Response, route, tower::TowerRoute,
+        Body, LayerFn, LayerFuture, Next, Path, Router, StatusCode, content::Json,
+        error::internal_server_error, request, response::Response, route,
     },
 };
-use tower_http::services::ServeDir;
 
 use crate::{
     article_index::{read_article_index, read_article_index_from_snapshot},
@@ -96,22 +93,6 @@ pub fn create_topcoat_router(
     validators_enabled: bool,
     assets: AssetConfig,
 ) -> Router {
-    create_topcoat_router_with_site_root(
-        artifact_reader,
-        validators_enabled,
-        PathBuf::from("target/site"),
-        assets,
-    )
-}
-
-fn create_topcoat_router_with_site_root(
-    artifact_reader: DynArtifactReader,
-    validators_enabled: bool,
-    site_root: PathBuf,
-    assets: AssetConfig,
-) -> Router {
-    let static_files = ServeDir::new(site_root);
-
     Router::builder()
         .route(health)
         .route(readiness)
@@ -120,14 +101,6 @@ fn create_topcoat_router_with_site_root(
         .route(topcoat_pages::article_page)
         .route(topcoat_pages::category_page)
         .route(topcoat_pages::about)
-        // Reuse the current generated asset directory during the parallel-runtime period. The
-        // final asset pipeline will replace this compatibility mount before Leptos is removed.
-        .route(TowerRoute::new(
-            Method::GET,
-            "/pkg/{*rest}",
-            static_files.clone(),
-        ))
-        .route(TowerRoute::new(Method::GET, "/favicon.ico", static_files))
         // The framework-neutral decision filters APIs, static assets, and unsuccessful responses.
         // One global layer also avoids nested prefix layers acquiring more than one snapshot.
         .layer(LayerFn::new(None::<&Path>, artifact_conditional_get))
@@ -167,10 +140,7 @@ mod tests {
         router::{Body, HeaderMap, Router, StatusCode, header, request::Request, to_bytes},
     };
 
-    use super::{
-        create_topcoat_router as create_topcoat_router_with_assets,
-        create_topcoat_router_with_site_root as create_topcoat_router_with_site_root_and_assets,
-    };
+    use super::create_topcoat_router as create_topcoat_router_with_assets;
 
     struct TestResponse {
         status: StatusCode,
@@ -209,6 +179,18 @@ mod tests {
                         hash: "test".to_string(),
                         content_type: "text/javascript".to_string(),
                     },
+                    ManifestEntry {
+                        id: topcoat_pages::STYLESHEET.id(),
+                        file: "tailwind-test.css".to_string(),
+                        hash: "test".to_string(),
+                        content_type: "text/css".to_string(),
+                    },
+                    ManifestEntry {
+                        id: topcoat_pages::FAVICON.id(),
+                        file: "favicon-test.ico".to_string(),
+                        hash: "test".to_string(),
+                        content_type: "image/x-icon".to_string(),
+                    },
                 ],
             },
         )
@@ -219,19 +201,6 @@ mod tests {
         validators_enabled: bool,
     ) -> Router {
         create_topcoat_router_with_assets(artifact_reader, validators_enabled, test_asset_config())
-    }
-
-    fn create_topcoat_router_with_site_root(
-        artifact_reader: DynArtifactReader,
-        validators_enabled: bool,
-        site_root: PathBuf,
-    ) -> Router {
-        create_topcoat_router_with_site_root_and_assets(
-            artifact_reader,
-            validators_enabled,
-            site_root,
-            test_asset_config(),
-        )
     }
 
     #[derive(Clone)]
@@ -1133,9 +1102,11 @@ mod tests {
         assert!(
             response
                 .body
-                .contains("<link rel=\"stylesheet\" href=\"/pkg/web")
+                .contains("<link rel=\"stylesheet\" href=\"/_topcoat/assets/tailwind-test.css\">")
         );
-        assert!(response.body.contains(".css\">"));
+        assert!(response.body.contains(
+            "<link rel=\"icon\" href=\"/_topcoat/assets/favicon-test.ico\" type=\"image/x-icon\""
+        ));
         assert!(response.body.contains(">Fixture About</h1>"));
         assert!(
             response
@@ -1278,42 +1249,6 @@ mod tests {
 
         assert_eq!(response.status, StatusCode::OK);
         assert_eq!(snapshot_calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn topcoat_serves_transitional_static_assets() {
-        let temp_dir = tempdir().unwrap();
-        std::fs::create_dir_all(temp_dir.path().join("pkg")).unwrap();
-        std::fs::write(temp_dir.path().join("pkg/web.css"), "body { color: red; }").unwrap();
-        std::fs::write(temp_dir.path().join("favicon.ico"), b"icon").unwrap();
-        let router = create_topcoat_router_with_site_root(
-            fixture_reader(),
-            false,
-            temp_dir.path().to_path_buf(),
-        );
-
-        let stylesheet = response(
-            &router,
-            Request::builder()
-                .uri("/pkg/web.css")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-        let favicon = response(
-            &router,
-            Request::builder()
-                .uri("/favicon.ico")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await;
-
-        assert_eq!(stylesheet.status, StatusCode::OK);
-        assert_eq!(stylesheet.content_type.as_deref(), Some("text/css"));
-        assert_eq!(stylesheet.body, "body { color: red; }");
-        assert_eq!(favicon.status, StatusCode::OK);
-        assert_eq!(favicon.body, "icon");
     }
 
     #[tokio::test]

--- a/crates/site/web/README.md
+++ b/crates/site/web/README.md
@@ -11,4 +11,4 @@ browser E2E は web crate 単体ではなく、server と artifact reader を含
 - theme tokenとbase styleは`style/tailwind.css`をsource of truthにする
 - artifactの`inner_html`は`.content-prose`で囲み、`style/content.css`のplain CSSだけを適用する
 
-`cargo-leptos`は`style/tailwind.css`を直接compileします。Sass、Stylance、CSS moduleの生成工程はありません。依存のinstall・更新確認はrepository rootの`mise run web-*`を使います。`mise run build-project`は`web-install`を先に実行するため、fresh checkoutから単独でbuildできます。
+現行productionのLeptos buildは`style/tailwind.css`を`cargo-leptos`でcompileします。移行用Topcoat runtimeは同じ入力をTopcoatのstandalone Tailwind build integrationで生成し、Topcoat asset bundleから配信します。通常Topcoat E2EはNode / BunのCSS build toolへ依存しません。Sass、Stylance、CSS moduleの生成工程はありません。production用web依存のinstall・更新確認はrepository rootの`mise run web-*`を使い、`mise run build-project`は`web-install`を先に実行します。

--- a/crates/site/web/bun.lock
+++ b/crates/site/web/bun.lock
@@ -6,7 +6,6 @@
       "devDependencies": {
         "@tailwindcss/cli": "4.3.3",
         "tailwindcss": "4.3.3",
-        "tw-animate-css": "^1.4.0",
       },
     },
   },
@@ -140,8 +139,6 @@
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
-    "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 

--- a/crates/site/web/package.json
+++ b/crates/site/web/package.json
@@ -2,7 +2,6 @@
   "type": "module",
   "devDependencies": {
     "@tailwindcss/cli": "4.3.3",
-    "tailwindcss": "4.3.3",
-    "tw-animate-css": "^1.4.0"
+    "tailwindcss": "4.3.3"
   }
 }

--- a/crates/site/web/style/tailwind.css
+++ b/crates/site/web/style/tailwind.css
@@ -1,7 +1,6 @@
-@import "tailwindcss";
-@import "tw-animate-css";
-@import "./content.css";
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600;700&display=swap");
+@import "tailwindcss";
+@import "./content.css";
 
 :root {
   --radius: 0.5rem;

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -385,7 +385,7 @@ home、about、category、articleの公開routeは`SsrMode::Async`で描画す�
   - article、about、category landing、home fragmentの生成HTMLだけを`.content-prose`配下で整形するplain CSS
   - heading、code、table、image、bookmark、math spanとKaTeX描画結果など`publish` artifactの表現を担当する
 
-`cargo-leptos`は`tailwind-input-file`からCSSを生成する。Sass、Stylance、routeごとのCSS module生成工程は持たない。これによりRust componentのlayoutと、ビルド時に生成されるartifact本文のstyle境界を分離する。
+現行productionのLeptos buildは`cargo-leptos`の`tailwind-input-file`からCSSを生成する。移行用Topcoat runtimeは同じ入力をTopcoatのstandalone Tailwind build integrationで生成し、Topcoat asset bundleからcontent-hash付きURLで配信する。通常fixture E2Eと`dev-topcoat-shell`は`cargo leptos build`もNode / BunのCSS build toolも実行しない。Sass、Stylance、routeごとのCSS module生成工程は持たず、どちらのruntimeでもRust componentのlayoutと、ビルド時に生成されるartifact本文のstyle境界を分離する。
 
 ## Reader 経路
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,7 +16,7 @@ mise run test-e2e
 
 依存の更新と確認には `mise run e2e-update` / `mise run e2e-outdated` を使います。
 
-テストは `fixtures/site` の固定 artifact だけを読みます。private Obsidian submodule、S3、AWS credentials には依存しません。Playwright が `127.0.0.1:8008` でTopcoat移行サーバーを起動し、home、about、category、article、404 status、metadata、client-side route遷移をChromiumで検証します。
+テストは `fixtures/site` の固定 artifact だけを読みます。private Obsidian submodule、S3、AWS credentials には依存しません。Playwright が `127.0.0.1:8008` でTopcoat移行サーバーを起動し、home、about、category、article、404 status、metadata、client-side route遷移をChromiumで検証します。通常E2Eのserver buildはTopcoatのTailwind integrationとasset bundlerを使い、`cargo leptos build`やLeptos JS / WASMを生成しません。
 
 失敗時の trace は `e2e/test-results` に保存されます。
 

--- a/e2e/run-server.sh
+++ b/e2e/run-server.sh
@@ -4,7 +4,6 @@ set -eu
 if [ "${OKAWAK_BLOG_E2E_REUSE_BUILD:-false}" != "true" ] \
   || [ ! -x ./target/debug/topcoat-server ] \
   || [ ! -s ./target/debug/assets/manifest.toml ]; then
-  cargo leptos build -p server
   topcoat asset bundle --package server --bin topcoat-server
 fi
 exec ./target/debug/topcoat-server

--- a/e2e/tests/artifact-routes.spec.ts
+++ b/e2e/tests/artifact-routes.spec.ts
@@ -111,11 +111,13 @@ test("site declares and serves its favicon", async ({ page, request }) => {
   await expect(iconLink).toHaveCount(1);
   await expect(iconLink).toHaveAttribute(
     "href",
-    "/favicon.ico?v=f544a69c",
+    /^\/_topcoat\/assets\/favicon-[a-f0-9]+\.ico$/,
   );
   await expect(iconLink).toHaveAttribute("sizes", "16x16 32x32 48x48");
 
-  const response = await request.get("/favicon.ico?v=f544a69c");
+  const faviconHref = await iconLink.getAttribute("href");
+  expect(faviconHref).not.toBeNull();
+  const response = await request.get(faviconHref!);
   expect(response.status()).toBe(200);
   expect(response.headers()["content-type"]).toMatch(/^image\//);
   expect((await response.body()).byteLength).toBeGreaterThan(0);
@@ -717,8 +719,8 @@ test("client navigation reloads when shell asset fingerprints change", async ({ 
     const response = await route.fetch();
     const currentBody = await response.text();
     const body = currentBody.replace(
-      /href="\/pkg\/[^"]+\.css"/,
-      'href="/pkg/deployed-shell.css"',
+      /href="\/_topcoat\/assets\/[^"]+\.css"/,
+      'href="/_topcoat/assets/deployed-shell.css"',
     );
     expect(body).not.toBe(currentBody);
     await route.fulfill({ response, body });

--- a/mise.toml
+++ b/mise.toml
@@ -127,7 +127,6 @@ cargo leptos serve -p server
 
 [tasks.dev-topcoat-shell]
 description = "Run the transitional Topcoat runtime shell with fixture artifacts"
-depends = ["build-project"]
 env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "e2e/fixtures/site", OKAWAK_BLOG_TOPCOAT_ADDR = "127.0.0.1:8009" }
 run = '''
 topcoat asset bundle --package server --bin topcoat-server --release

--- a/scripts/check_tool_versions.sh
+++ b/scripts/check_tool_versions.sh
@@ -13,10 +13,11 @@ leptosfmt_version="$(sed -nE 's/^"github:bram209\/leptosfmt" = "([^"]+)"$/\1/p' 
 topcoat_cli_version="$(sed -nE 's/^"cargo:topcoat-cli" = "([^"]+)"$/\1/p' mise.toml)"
 topcoat_framework_version="$(sed -nE 's/^topcoat = \{ version = "=([^"]+)".*/\1/p' Cargo.toml)"
 tailwind_version="$(sed -nE 's/^LEPTOS_TAILWIND_VERSION = "v([^"]+)"$/\1/p' mise.toml)"
+topcoat_tailwind_version="$(sed -nE 's/^[[:space:]]*\.version\("([^"]+)"\)$/\1/p' crates/site/server/build.rs)"
 tailwind_cli_version="$(sed -nE 's/.*"@tailwindcss\/cli": "([^"]+)".*/\1/p' crates/site/web/package.json)"
 tailwind_package_version="$(sed -nE 's/.*"tailwindcss": "([^"]+)".*/\1/p' crates/site/web/package.json)"
 
-for version in "$mise_bun_version" "$cargo_leptos_version" "$leptosfmt_version" "$topcoat_cli_version" "$topcoat_framework_version" "$tailwind_version"; do
+for version in "$mise_bun_version" "$cargo_leptos_version" "$leptosfmt_version" "$topcoat_cli_version" "$topcoat_framework_version" "$tailwind_version" "$topcoat_tailwind_version"; do
   [ -n "$version" ] || fail "required version is missing from project configuration"
 done
 
@@ -26,6 +27,8 @@ done
   || fail "Tailwind CLI $tailwind_cli_version does not match LEPTOS_TAILWIND_VERSION $tailwind_version"
 [ "$tailwind_version" = "$tailwind_package_version" ] \
   || fail "Tailwind package $tailwind_package_version does not match LEPTOS_TAILWIND_VERSION $tailwind_version"
+[ "$tailwind_version" = "$topcoat_tailwind_version" ] \
+  || fail "Topcoat Tailwind $topcoat_tailwind_version does not match LEPTOS_TAILWIND_VERSION $tailwind_version"
 [ "$(bun --version)" = "$mise_bun_version" ] \
   || fail "active Bun $(bun --version) does not match mise $mise_bun_version"
 [ "$(cargo leptos --version | awk '{print $2}')" = "$cargo_leptos_version" ] \


### PR DESCRIPTION
## 概要

Issue #182 の段階移行として、Topcoat runtime のCSSとfaviconをTopcoat asset bundleへ移します。通常のfixture E2Eと`dev-topcoat-shell`は`cargo leptos build`やNode/BunのCSS build toolを必要としなくなります。

## 変更内容

- Topcoat Tailwind build integrationで既存の`tailwind.css`を生成
- CSS・faviconをcontent-hash付きTopcoat asset URLで配信
- 旧`target/site`の`/pkg`・favicon compatibility mountを撤去
- 通常E2Eの`cargo leptos build`依存を撤去
- 未使用の`tw-animate-css`を削除し、version整合チェックを追加
- 移行中のproduction Leptos buildとの責務を文書化

## 確認

- `mise run format`
- `mise run versions-check`
- `mise run check`
- `mise run clippy`
- `mise run test`
- `mise run test-e2e`（32件 + empty-home 1件）
- `topcoat asset bundle --package server --bin topcoat-server`

Refs #182