### PR TITLE
feat: switch production runtime to Topcoat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
       - name: Validate service scripts
-        run: bash service/tests/systemd_units_test.sh
+        run: mise run test-service
 
       - name: Cache Cargo dependencies
         uses: actions/cache@v6
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Prepare Rust toolchain
-        run: rustup target add wasm32-unknown-unknown
+        run: rustup show
 
       - name: Cache Cargo dependencies
         uses: actions/cache@v6
@@ -88,9 +88,6 @@ jobs:
 
       - name: Set up shared build tools
         uses: jdx/mise-action@v4
-
-      - name: Install web dependencies
-        run: mise run web-install
 
       - name: Run fixture browser E2E
         env:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -166,9 +166,6 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
 
-      - name: Install web dependencies
-        run: mise run web-install
-
       - name: Upload and validate immutable release
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## リポジトリの位置付け
 
-`okawak_blog` は、private な Obsidian Markdown を公開 artifact へ変換し、Leptos SSR で配信する静的コンテンツ公開基盤である。主役は常駐 API や CMS ではなく、ビルド時の`publish` pipelineである。
+`okawak_blog` は、private な Obsidian Markdown を公開 artifact へ変換し、Topcoat SSR で配信する静的コンテンツ公開基盤である。主役は常駐 API や CMS ではなく、ビルド時の`publish` pipelineである。
 
 参照優先順位:
 
@@ -32,8 +32,8 @@
 - `crates/domain`: 公開コンテンツの純粋なdomain model・ルールと、`publish` / readerが共有する契約。I/O、`async`、AWS SDK、Axum、Leptos を持ち込まない。WASM 互換を意識する
 - `crates/publish`: 単一の`publish` crate。`lib.rs`は内部module宣言とcrate外向けAPIのre-exportに限定する。`pipeline` moduleが公開処理をorchestrationし、`vault` moduleをローカル入力境界、`links` moduleを公開URL索引とWikiLink event解決の境界、`render` moduleをcontent描画の境界、`artifacts` moduleをartifact構築・書込み・validationの境界とする。`render`内ではcontent kind別の組み立て、共通本文処理、Markdown event生成とHTML変換、URLとraw HTMLの安全化、bookmark構文・card生成とOGP metadata取得を分離する。`publish`専用処理をcrate外へ公開せず、外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に絞る
 - `crates/site/infra`: server が artifact を読む外部境界（local / S3、設定、将来のcache）。vault読取、Markdown変換、uploadを置かない
-- `crates/site/server`: Axum + Leptos SSR host、reader注入、API、health/readiness、release-aware conditional GET
-- `crates/site/web`: Leptos UI / route / metadataと、artifact内のmath spanに対するKaTeX描画。SSR時もstorage実装へ直接依存しない
+- `crates/site/server`: Topcoat SSR host、reader注入、API、health/readiness、release-aware conditional GET。完全移行中のTopcoat page / componentもここに置く
+- `crates/site/web`: Topcoatと共有するstyle / generated content script、および完全撤去までのlegacy Leptos UI。storage実装へ直接依存しない
 - `e2e`: repository root直下のbrowser E2E。通常CIはprivate submoduleやAWSに依存しないfixtureで検証し、実S3 smoke testはローカル手動確認とupload workflowの公開前gateに使う
 - `service`: systemd、Cloudflare Tunnel、運用補助
 - `terraform`: 読み取り専用。編集せず、このdirectoryでcommandを実行しない

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 https://www.okawak.net
 
-`okawak_blog` は、Obsidian で書いた Markdown を Rust 製の`publish` pipelineが公開成果物へ変換して S3 に配置し、それを VPS 上の単一バイナリ Leptos SSR サーバーと Cloudflare Tunnel で公開する、静的コンテンツ公開基盤 + SSR 表示基盤です。
+`okawak_blog` は、Obsidian で書いた Markdown を Rust 製の`publish` pipelineが公開成果物へ変換して S3 に配置し、それを VPS 上の単一バイナリ Topcoat SSR サーバーと Cloudflare Tunnel で公開する、静的コンテンツ公開基盤 + SSR 表示基盤です。
 
 ## 関連文書
 
@@ -19,7 +19,7 @@ https://www.okawak.net
 - 記事ソースはこの public リポジトリへ直接 commit せず、git submodule として参照する
 - GitHub Actions またはローカル実行の`publish`が公開成果物を生成する
 - 生成した HTML / index JSON を S3 に配置する
-- Leptos SSR サーバーが S3 上の成果物を読んで配信する
+- Topcoat SSR サーバーが S3 上の成果物を読んで配信する
 - VPS + `systemd` + Cloudflare Tunnel で単純に運用できる構成を保つ
 
 ## これは何ではないか
@@ -47,7 +47,7 @@ https://www.okawak.net
 4. Markdown を公開用 HTML に変換する
 5. 記事一覧やカテゴリ一覧などの index データを生成する
 6. 成果物を S3 にアップロードする
-7. Leptos SSR サーバーがそれを読んで公開する
+7. Topcoat SSR サーバーがそれを読んで公開する
 
 この境界に合わせて、`publish`側の実装は `crates/publish/` に、公開成果物を読む blog 側の実装は `crates/site/` に寄せます。`crates/domain/` は両者で共有する契約と純粋ルールを置く場所として扱います。
 
@@ -71,9 +71,9 @@ okawak_blog/
 │   ├── domain/               # 公開成果物契約と純粋ルール
 │   ├── publish/              # publish CLIと内部module
 │   └── site/
-│       ├── infra/            # Leptos サーバー側の S3 / cache / runtime adapter
+│       ├── infra/            # Topcoat サーバー側の S3 / cache / runtime adapter
 │       ├── server/           # 公開成果物を読む統合バックエンド
-│       └── web/              # Leptos SSR 公開 UI
+│       └── web/              # 移行中の共有style/scriptとlegacy Leptos UI
 ├── e2e/                      # 公開サイト全体の browser E2E
 ├── docs/
 │   └── architecture/
@@ -85,9 +85,9 @@ okawak_blog/
 
 - `crates/domain`: 公開成果物契約、site page contract、純粋関数を中心にした共有ドメイン層
 - `crates/publish`: `pipeline` moduleが、`vault`によるObsidian入力、`render`によるMarkdown変換とbookmark enrichment、`artifacts`による成果物生成を統括する単一の`publish` crate。外部APIはpublish entrypoint、bookmark enricher注入、`PublishError` / `Result`に限定する
-- `crates/site/infra`: Leptos サーバーが公開成果物を読むための S3 / cache / runtime adapter。開発と本番はS3 readerを使い、local readerは自動test用に残す
+- `crates/site/infra`: Topcoat サーバーが公開成果物を読むための S3 / cache / runtime adapter。開発と本番はS3 readerを使い、local readerは自動test用に残す
 - `crates/site/server`: S3 上の成果物を読んで配信し、release-aware ETag / Last-Modifiedを扱う統合バックエンド
-- `crates/site/web`: Leptos SSR の公開 UI
+- `crates/site/web`: Topcoatと共有するstyle / generated content script、および完全撤去までのlegacy Leptos UI
 - `e2e`: server / web / artifact reader をまたぐ、固定 artifact ベースの browser E2E
 
 ## 公開成果物のイメージ
@@ -119,7 +119,7 @@ Obsidian repo
   -> publish
   -> HTML / index JSON を生成
   -> AWS S3
-  -> Leptos SSR server
+  -> Topcoat SSR server
   -> Browser
 ```
 
@@ -169,7 +169,7 @@ category: "tech"
 ## 運用モデル
 
 - VPS 上で Rust 製サーバーバイナリを `systemd` service として起動する
-- Leptos SSR serverはVPSの`127.0.0.1:8008`だけで待ち受ける
+- Topcoat SSR serverはVPSの`127.0.0.1:8008`だけで待ち受ける
 - `cloudflared`を`systemd` serviceとして起動し、外向きTunnel経由でCloudflareへ接続する
 - HTTPS終端とpublic hostnameはCloudflareで管理し、originの80/443をInternetへ公開しない
 - アプリケーション本体は単一バイナリとして扱う
@@ -200,7 +200,7 @@ mise install
 mise run versions-check
 ```
 
-共通実行tool（Bun、cargo-leptos、leptosfmt）は`mise.toml`をsource of truthとし、`mise.lock`にはmacOS arm64、GitHub Actions Linux x64、VPSが識別するLinux platform aliasの解決済みrelease assetを記録します。Rust toolchainは`rust-toolchain.toml`、Cargo / Bun依存は各manifestとlockfile、GitHub Actionsはworkflow内の最新major指定を正とします。
+共通実行tool（Bun、Topcoat CLI、完全撤去までのcargo-leptos / leptosfmt）は`mise.toml`をsource of truthとし、`mise.lock`にはmacOS arm64、GitHub Actions Linux x64、VPSが識別するLinux platform aliasの解決済みrelease assetを記録します。Rust toolchainは`rust-toolchain.toml`、Cargo / Bun依存は各manifestとlockfile、GitHub Actionsはworkflow内の最新major指定を正とします。
 
 web UIはRust/UI由来のprimitiveとTailwind CSSを主系にします。theme tokenとsite chromeは`crates/site/web/style/tailwind.css`、artifact由来の生成HTMLは同ファイルからimportする`style/content.css`で管理します。Sass / Stylanceは使用しません。
 
@@ -208,19 +208,19 @@ private Obsidian repoを使う`publish`側の開発では、`mise run dev-local`
 `mise run pull` は deploy 用に `main` の更新だけを行い、submodule も更新したい場合は `mise run pull-with-submodules` を使います。
 `crates/site/web/package.json` の依存のインストール/更新確認は root から `mise run web-install` / `mise run web-update` / `mise run web-outdated` で行えます。
 
-`cargo-leptos`が取得するTailwind CLIのバージョンは、`mise.toml`の`LEPTOS_TAILWIND_VERSION`で固定します。Bun管理のTailwind依存は`crates/site/web/package.json`を正とし、`mise run versions-check`が両者とE2EのBun versionを照合します。GitHub Actionsは`jdx/mise-action`経由で同じlocked toolchainを導入します。
+production CSSはTopcoatのstandalone Tailwind integrationで生成し、そのversionを`mise.toml`の`LEPTOS_TAILWIND_VERSION`、Topcoat build script、移行中のBun / cargo-leptos設定間で一致させます。`mise run versions-check`がこれらとE2EのBun versionを照合し、GitHub Actionsは`jdx/mise-action`経由で同じlocked toolchainを導入します。
 
 共通toolを更新するときは、`mise.toml`のversionを更新して`mise lock --platform macos-arm64,linux-x64`を実行します。Bun package、Rust crate、Rust toolchain、GitHub Actionsの更新はそれぞれの標準manifestとDependabotで管理します。
 browser E2E の依存管理にも Bun を使います。初回は `mise run e2e-install-browser`、実行は `mise run test-e2e` を使ってください。E2E は root の `e2e/` に置き、通常CIではprivate Obsidian submoduleやS3に依存しない固定artifactで実行します。S3への公開はGitHub Actionsの`Publish Obsidian to S3`を`main`から手動実行します。workflowは対象commitのRust CI成功と最新`main`であることを先に確認し、immutable releaseを実S3 smoke testで検証します。pointer切替直前にも最新`main`を再確認してから`current.json`を更新します。ローカルからS3へ直接syncする経路は標準の公開手順にしません。
 
 開発端末では、local previewに`mise run dev-local`、S3 readerの本番相当確認に`mise run dev`または`mise run test-e2e-s3`を使います。S3用taskはAWS CLIを実行せず、AWS SDKが設定済みprofileまたは環境変数credentialを読みます。bucketやcredentialは保存せず、`AWS_PROFILE`、region、`OKAWAK_BLOG_ARTIFACT_BUCKET`、必要な場合だけ`OKAWAK_BLOG_ARTIFACT_PREFIX`を実行時に渡します。詳細は[e2e/README.md](./e2e/README.md)を参照してください。
 
-`mise run dev-local`は次を順に行います。submoduleの同期または`publish`が失敗した場合、Leptos開発サーバーは起動しません。
+`mise run dev-local`は次を順に行います。submoduleの同期または`publish`が失敗した場合、Topcoat開発サーバーは起動しません。
 
 - private Obsidian submoduleをremoteの最新状態へ同期する
 - `publish`を通常の厳格モードで実行する
 - `crates/publish/dist/site`へartifactを生成する
-- `OKAWAK_BLOG_ARTIFACT_SOURCE=local`でLeptos開発サーバーを起動する
+- Topcoat asset bundleを生成し、`OKAWAK_BLOG_ARTIFACT_SOURCE=local`でTopcoat開発サーバーを起動する
 
 `mise run dev`は次のenvを自動で設定します。
 
@@ -228,6 +228,8 @@ browser E2E の依存管理にも Bun を使います。初回は `mise run e2e-
 - `OKAWAK_BLOG_SITE_ORIGIN=http://127.0.0.1:8008`
 
 `OKAWAK_BLOG_ARTIFACT_BUCKET`は必須で、任意のprefixやAWS credentialとともに実行時に渡します。固定fixtureを使う`test-e2e`は、外部状態に依存しないCI回帰テストとして別に維持します。`mise run build-project`はdeploy用のbuildで、artifactやprivate submoduleには依存しません。
+
+production deployは`mise run build-deployment`で`target/release/topcoat-server`と`target/assets-staged`を生成します。`mise run quick-deploy`はservice停止中にbinaryとcontent-hash付きasset bundleを同じreleaseへ切り替え、health / readinessが失敗した場合は両方を旧releaseへ戻します。Topcoat runtimeはLeptos JavaScript / WebAssemblyを生成・配信しません。
 
 主要コマンドは以下です。
 

--- a/crates/site/server/Cargo.toml
+++ b/crates/site/server/Cargo.toml
@@ -58,7 +58,8 @@ tower = { workspace = true, features = ["util"] }
 topcoat = { workspace = true, default-features = false, features = ["tailwind"] }
 
 [package.metadata.leptos]
-# Keep cargo-leptos on the production Leptos binary while the Topcoat binary is developed in parallel.
+# Keep legacy cargo-leptos pointed at the old binary until the Leptos source is removed.
+# Production build and deployment use `topcoat-server`.
 bin-target = "server"
 
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name

--- a/crates/site/server/src/bin/topcoat_server.rs
+++ b/crates/site/server/src/bin/topcoat_server.rs
@@ -1,12 +1,12 @@
-//! Temporary Topcoat entry point that runs alongside the Leptos server.
+//! Production entry point for the Topcoat SSR server.
 
 use infra::{ArtifactSourceConfig, build_artifact_reader};
 use server::http_cache::artifact_validators_enabled;
 use server::topcoat_runtime::create_topcoat_router;
 use topcoat::asset::AssetBundle;
 
-const DEFAULT_ADDR: &str = "127.0.0.1:8009";
-const ADDR_ENV: &str = "OKAWAK_BLOG_TOPCOAT_ADDR";
+const DEFAULT_ADDR: &str = "127.0.0.1:8008";
+const ADDR_ENV: &str = "OKAWAK_BLOG_ADDR";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let router = create_topcoat_router(artifact_reader, validators_enabled, assets.into());
     let listener = tokio::net::TcpListener::bind(&addr).await?;
 
-    println!("Starting Topcoat migration server on http://{addr}");
+    println!("Starting Topcoat blog server on http://{addr}");
     println!("Artifact source: {}", artifact_source.kind());
 
     topcoat::serve(listener, router).await?;

--- a/crates/site/web/README.md
+++ b/crates/site/web/README.md
@@ -11,4 +11,4 @@ browser E2E は web crate 単体ではなく、server と artifact reader を含
 - theme tokenとbase styleは`style/tailwind.css`をsource of truthにする
 - artifactの`inner_html`は`.content-prose`で囲み、`style/content.css`のplain CSSだけを適用する
 
-現行productionのLeptos buildは`style/tailwind.css`を`cargo-leptos`でcompileします。移行用Topcoat runtimeは同じ入力をTopcoatのstandalone Tailwind build integrationで生成し、Topcoat asset bundleから配信します。通常Topcoat E2EはNode / BunのCSS build toolへ依存しません。Sass、Stylance、CSS moduleの生成工程はありません。production用web依存のinstall・更新確認はrepository rootの`mise run web-*`を使い、`mise run build-project`は`web-install`を先に実行します。
+productionは`style/tailwind.css`をTopcoatのstandalone Tailwind build integrationで生成し、Topcoat asset bundleから配信します。build、通常E2E、S3 smokeは`cargo-leptos`やNode / BunのCSS build toolへ依存せず、Leptos JavaScript / WebAssemblyを生成しません。Sass、Stylance、CSS moduleの生成工程はありません。完全撤去まで残るlegacy Leptos依存のinstall・更新確認にはrepository rootの`mise run web-*`を使います。

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-`okawak_blog` は、Obsidian で書いた Markdown を公開成果物へ変換し、それを Leptos SSR で配信するための静的コンテンツ公開基盤 + SSR 表示基盤である。
+`okawak_blog` は、Obsidian で書いた Markdown を公開成果物へ変換し、それを Topcoat SSR で配信するための静的コンテンツ公開基盤 + SSR 表示基盤である。
 
 このリポジトリは一般的なブログ CMS ではない。主役は常駐 API サーバーではなく、`publish`による公開成果物生成パイプラインである。
 
@@ -83,21 +83,16 @@ okawak_blog/
   - local reader
   - S3 reader
 - `crates/site/server`
-  - production `server` binaryによるAxum + Leptos SSRのホスト
-  - 移行用`topcoat-server` binaryによるTopcoat SSR、Topcoat runtime asset、client-side route遷移のホスト
-  - reader の生成とLeptos contextまたはTopcoat request contextへの注入
+  - production `topcoat-server` binaryによるTopcoat SSR、Topcoat runtime asset、client-side route遷移のホスト
+  - reader の生成とTopcoat app / request contextへの注入
   - 互換用の記事一覧 API
   - process liveness (`/api/health`) と artifact readiness (`/api/ready`)
   - release-aware ETag と conditional GET
 - `crates/site/web`
-  - 現行productionのLeptos UIとroute定義
-  - Leptos server function による page document の組み立て
-  - SSR feature 時のみ `ArtifactReader` 境界を利用
-  - metadata / canonical / Open Graph 生成
-  - `publish`が生成する`.math-inline` / `.math-display`に対するclient-side KaTeX描画
-  - Topcoat移行中も共有するsite定数、生成コンテンツ用script、Tailwind CSS入力
+  - Topcoatと共有するsite定数、生成コンテンツ用script、Tailwind CSS入力
+  - 完全撤去まで残るlegacy Leptos UI、route、server function
 - `e2e`
-  - `crates/site/server`と`crates/site/infra`をまたぐTopcoat移行サーバーのbrowser E2E
+  - `crates/site/server`と`crates/site/infra`をまたぐproduction Topcoat serverのbrowser E2E
   - 通常CIではprivate Obsidian submoduleやS3に依存しない固定artifact fixture
   - 実S3の検証は専用Playwright configを使い、ローカル手動確認とrelease公開前smoke testへ分離
   - Bunで依存を管理し、Playwright + Chromiumで公開route、metadata、client-side route遷移、Topcoat interactionを検証
@@ -362,13 +357,11 @@ flowchart LR
 - `StaticPageDocument`
   - `about` などの固定ページ用contract
 
-`site/web` はこの page contract をもとに metadata と UI を組み立てる。SSR feature では Leptos context から `DynArtifactReader` を受け取り、server function の開始時にsnapshotを1回取得してpage documentを組み立てる。local / S3 などの storage 実装詳細には依存しない。hydrate build は `infra` に依存しない。
+`site/server`のTopcoat pageはこのpage contractをもとにmetadataとUIを組み立てる。`DynArtifactReader`はTopcoat app contextへ登録し、各requestのconditional GET判定とpage document構築で同じsnapshotをrequest contextから共有する。local / S3などのstorage実装詳細はpage componentへ持ち込まない。
 
-公開 route の page document 読み込みは Leptos server function を正式経路とする。`site/server` は reader を生成して context に注入し、SSR と server function をホストする。手書きの `/api/page/*` は持たず、404 と storage error の扱いは各 server function に集約する。`/api/articles` は page document を組み立てない互換 endpoint として維持する。
+公開routeのpage document読取はTopcoat async componentを正式経路とする。手書きの`/api/page/*`は持たず、404とstorage errorのstatus / error viewをroute境界で統一する。`/api/articles`はpage documentを組み立てない互換endpointとして維持する。
 
-移行用`topcoat-server`は同じpage contractと`DynArtifactReader`をTopcoat request contextから利用し、公開route、metadata、status、client-side route遷移の互換性を固定artifact E2Eで検証する。移行完了まではproduction entrypointを`server` binaryとし、通常E2Eを先行して`topcoat-server`へ切り替える。
-
-home、about、category、articleの公開routeは`SsrMode::Async`で描画する。title、canonical、Open Graph metadataがartifactの内容に依存するため、非同期resourceの解決前に`<head>`をstreamingしない。各routeではblocking resourceを使い、metadataと本文を同じ`Suspense`境界で組み立てる。
+production `topcoat-server`はhome、about、category、articleをSSRし、title、canonical、Open Graph metadataと本文を同じsnapshotから初期HTMLへ組み立てる。legacy Leptos route / server functionは完全撤去までsourceに残るが、production build、通常E2E、S3 smokeのentrypointには使わない。
 
 ## UI styling境界
 
@@ -385,7 +378,7 @@ home、about、category、articleの公開routeは`SsrMode::Async`で描画す�
   - article、about、category landing、home fragmentの生成HTMLだけを`.content-prose`配下で整形するplain CSS
   - heading、code、table、image、bookmark、math spanとKaTeX描画結果など`publish` artifactの表現を担当する
 
-現行productionのLeptos buildは`cargo-leptos`の`tailwind-input-file`からCSSを生成する。移行用Topcoat runtimeは同じ入力をTopcoatのstandalone Tailwind build integrationで生成し、Topcoat asset bundleからcontent-hash付きURLで配信する。通常fixture E2Eと`dev-topcoat-shell`は`cargo leptos build`もNode / BunのCSS build toolも実行しない。Sass、Stylance、routeごとのCSS module生成工程は持たず、どちらのruntimeでもRust componentのlayoutと、ビルド時に生成されるartifact本文のstyle境界を分離する。
+productionは`style/tailwind.css`をTopcoatのstandalone Tailwind build integrationで生成し、CSS、JavaScript、faviconをTopcoat asset bundleからcontent-hash付きURLで配信する。production build、fixture E2E、S3 smoke、`dev` / `dev-local`は`cargo leptos build`もNode / BunのCSS build toolも実行せず、Leptos loader / WebAssemblyを生成・配信しない。Sass、Stylance、routeごとのCSS module生成工程は持たず、Rust componentのlayoutと、ビルド時に生成されるartifact本文のstyle境界を分離する。
 
 ## Reader 経路
 
@@ -454,7 +447,7 @@ Obsidian submodule
   -> local reader
 ```
 
-`dev-local`はprivate Obsidian submoduleに未commit差分がないことを確認してremoteの最新commitをcheckoutし、`publish`の通常の厳格モードが成功した場合だけLeptos serverを起動する。同期時にlocal merge commitは作らない。同期または`publish`に失敗した場合はserverを起動しない。local readerにはmemory cacheを適用しないため、生成済みartifactの更新を即時に読める。ただし起動中にsource Markdownを変更した場合、`publish`の再実行は明示的に行う。
+`dev-local`はprivate Obsidian submoduleに未commit差分がないことを確認してremoteの最新commitをcheckoutし、`publish`の通常の厳格モードとTopcoat asset bundle生成が成功した場合だけTopcoat serverを起動する。同期時にlocal merge commitは作らない。同期、`publish`、bundleのいずれかに失敗した場合はserverを起動しない。local readerにはmemory cacheを適用しないため、生成済みartifactの更新を即時に読める。ただし起動中にsource Markdownを変更した場合、`publish`の再実行は明示的に行う。
 
 AWS認証、immutable release pointer、S3 cacheを含む本番相当のreader境界はS3用taskで確認する。
 
@@ -479,6 +472,8 @@ Obsidian submodule
   -> Cloudflare Tunnel
   -> Browser
 ```
+
+application deployはTopcoat release binaryとasset bundleを同じrelease単位で扱う。`build-deployment`は稼働中のdirectoryへ書かず、`target/release/topcoat-server`と`target/assets-staged`を生成する。activationはservice停止中にbinaryを`bin/okawak_blog`、bundleをbinary隣接の`bin/assets`へ切り替える。stagingはmanifest内のCSS、JavaScript、faviconと各参照fileを検証し、WebAssemblyを拒否する。起動後のhealth / readinessが失敗した場合は旧binaryと旧bundleを復元し、失敗bundleを`bin/assets.failed`へ保存する。
 
 `cloudflared`はVPSからCloudflareへ外向き接続し、originの80/443は公開しない。public hostnameとTunnel routeはCloudflare Dashboardで管理し、OCI TerraformはReserved Public IP、SSH用ingress、Tunnel用egressなどのOCI resourceだけを管理する。S3 upload は Rust アプリに持たせず、workflow の責務として扱う。
 

--- a/docs/operations/cloudflare-tunnel.md
+++ b/docs/operations/cloudflare-tunnel.md
@@ -2,7 +2,7 @@
 
 ## 現行構成
 
-VPSのLeptos SSR serverは`127.0.0.1:8008`で待ち受け、`cloudflared`が外向きTunnel経由でCloudflareへ接続します。VPSの80/443はInternetへ公開しません。
+VPSのTopcoat SSR serverは`127.0.0.1:8008`で待ち受け、`cloudflared`が外向きTunnel経由でCloudflareへ接続します。VPSの80/443はInternetへ公開しません。
 
 ```text
 Browser

--- a/docs/operations/production-setup.md
+++ b/docs/operations/production-setup.md
@@ -65,7 +65,7 @@ OCI Terraformは現在local stateを使います。stateとbackupをrepository�
 
 ## 4. VPSへapplicationを配置する
 
-VPSのOS、SSH、一般的なbuild tool、運用userの準備手順はこの文書の対象外です。repositoryが`/opt/okawak_blog`にあり、[runtime serviceのVPS build tool override](../../service/README.md#vps-build-tool-override)が有効であることを前提とします。
+VPSのOS、SSH、一般的なbuild tool、運用userの準備手順はこの文書の対象外です。repositoryが`/opt/okawak_blog`にあり、[runtime serviceのVPS build tool設定](../../service/README.md#vps-build-tool)が有効であることを前提とします。
 
 IAM Roles Anywhereのhelper、AWS config、client certificate、private keyを先に配置します。[AWS runtime認証](./aws-runtime-auth.md)のVPS手順でcaller identityとS3 readを確認します。
 
@@ -82,9 +82,9 @@ curl --fail http://127.0.0.1:8008/api/health
 curl --fail http://127.0.0.1:8008/api/ready
 ```
 
-`production-deploy`は`origin/main`をpullし、web依存をinstallしてから、liveの`target/site`とは別の`target/site-staged`へrelease buildします。CSS、JavaScript、WebAssemblyには同じbuildで生成したhash付きファイル名を使います。staging bundleが完成した後だけapplication serviceを停止し、site directory、server binary、`bin/hash.txt`を切り替えて起動します。起動後はhealth / readinessを確認し、失敗時は直前のsiteとbinaryを復元します。これによりbuild途中のassetを稼働中serverが配信せず、異なるbuildのJavaScriptとWebAssemblyが同じURLを共有しません。Cloudflare Tunnelは独立したserviceとして維持します。
+`production-deploy`は`origin/main`をpullし、Topcoat release binaryをbuildして、稼働中の`bin/assets`とは別の`target/assets-staged`へcontent-hash付きCSS、JavaScript、faviconを生成します。staging bundleはmanifest参照とfile実体を検証し、WebAssemblyを拒否します。bundleが完成した後だけapplication serviceを停止し、`bin/okawak_blog`と`bin/assets`を同じreleaseへ切り替えて起動します。起動後はhealth / readinessを確認し、失敗時は直前のbinaryとasset bundleを復元します。Cloudflare Tunnelは独立したserviceとして維持します。
 
-失敗したstaging siteを保存できた場合は`target/site-failed`へ残します。原因を確認して不要になった後に削除してから、`mise run production-deploy`を再実行します。
+失敗したasset bundleを保存できた場合は`bin/assets.failed`へ残します。原因を確認して不要になった後に削除してから、`mise run production-deploy`を再実行します。
 
 ## 5. Cloudflare Tunnelを構築する
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,6 +1,6 @@
 # Browser E2E
 
-公開サイト全体を対象とする Playwright E2E です。Topcoat移行サーバーと`crates/site/infra`のartifact readerを通し、公開routeとclient-side interactionを検証するため、リポジトリルートに置いています。production entrypointがLeptos SSRの移行期間中も、通常E2Eは先行して`topcoat-server`を対象にします。
+公開サイト全体を対象とする Playwright E2E です。productionと同じTopcoat serverと`crates/site/infra`のartifact readerを通し、公開routeとclient-side interactionを検証するため、リポジトリルートに置いています。
 
 依存管理には、web crate と同じく Bun を使います。通常はリポジトリルートから `mise` task を実行してください。
 
@@ -16,13 +16,13 @@ mise run test-e2e
 
 依存の更新と確認には `mise run e2e-update` / `mise run e2e-outdated` を使います。
 
-テストは `fixtures/site` の固定 artifact だけを読みます。private Obsidian submodule、S3、AWS credentials には依存しません。Playwright が `127.0.0.1:8008` でTopcoat移行サーバーを起動し、home、about、category、article、404 status、metadata、client-side route遷移をChromiumで検証します。通常E2Eのserver buildはTopcoatのTailwind integrationとasset bundlerを使い、`cargo leptos build`やLeptos JS / WASMを生成しません。
+テストは `fixtures/site` の固定 artifact だけを読みます。private Obsidian submodule、S3、AWS credentials には依存しません。Playwright が `127.0.0.1:8008` でproduction Topcoat serverを起動し、home、about、category、article、404 status、metadata、client-side route遷移をChromiumで検証します。通常E2Eのserver buildはTopcoatのTailwind integrationとasset bundlerを使い、`cargo leptos build`やLeptos JS / WASMを生成しません。
 
 失敗時の trace は `e2e/test-results` に保存されます。
 
 ## 実S3を確認する
 
-通常の固定artifact E2Eとは分離した`test-e2e-s3`は、現行productionのLeptos `server` binaryを起動し、AWS SDKの標準credential chainでS3を読み、`/api/ready`、home、article index、実articleのSSR表示とmetadataを確認します。`current.json`からreleaseを選択した場合はETag / Last-Modifiedと条件付きGETも検証します。ローカルからの手動確認に加え、S3 upload workflowがimmutable releaseを公開する前のsmoke testにも使います。
+通常の固定artifact E2Eとは分離した`test-e2e-s3`は、productionと同じTopcoat `topcoat-server` binaryを起動し、AWS SDKの標準credential chainでS3を読み、`/api/ready`、home、article index、実articleのSSR表示とmetadataを確認します。`current.json`からreleaseを選択した場合はETag / Last-Modifiedと条件付きGETも検証します。ローカルからの手動確認に加え、S3 upload workflowがimmutable releaseを公開する前のsmoke testにも使います。
 
 bucket名やcredentialはrepositoryへ保存せず、実行時に渡してください。task自身はAWS CLIを実行せず、server内のAWS SDKがcredentialを読みます。`aws configure --profile blog-s3`などでshared config / credentials fileへ設定済みなら`AWS_PROFILE=blog-s3`で選択でき、省略時はdefault profileが使われます。regionは`AWS_REGION`、`AWS_DEFAULT_REGION`、またはprofileで設定できます。
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
       OKAWAK_BLOG_ARTIFACT_SOURCE: "local",
       OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT: fixtureRoot,
       OKAWAK_BLOG_SITE_ORIGIN: baseURL,
-      OKAWAK_BLOG_TOPCOAT_ADDR: "127.0.0.1:8008",
+      OKAWAK_BLOG_ADDR: "127.0.0.1:8008",
     },
     url: `${baseURL}/api/health`,
     reuseExistingServer: false,

--- a/e2e/playwright.empty-home.config.ts
+++ b/e2e/playwright.empty-home.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
       OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT: fixtureRoot,
       OKAWAK_BLOG_E2E_REUSE_BUILD: "true",
       OKAWAK_BLOG_SITE_ORIGIN: baseURL,
-      OKAWAK_BLOG_TOPCOAT_ADDR: "127.0.0.1:8008",
+      OKAWAK_BLOG_ADDR: "127.0.0.1:8008",
     },
     url: `${baseURL}/api/health`,
     reuseExistingServer: false,

--- a/e2e/run-production-server.sh
+++ b/e2e/run-production-server.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
 set -eu
 
-if [ "${OKAWAK_BLOG_E2E_REUSE_BUILD:-false}" != "true" ] \
-  || [ ! -x ./target/debug/server ]; then
-  cargo leptos build -p server
-fi
-exec ./target/debug/server
+exec sh e2e/run-server.sh

--- a/mise.local.toml.example
+++ b/mise.local.toml.example
@@ -1,5 +1,5 @@
-# Oracle Linux 9 VPS only.
-# Copy this file to mise.local.toml after installing cargo-leptos from source.
+# Oracle Linux 9 VPS only, until the legacy Leptos tool definition is removed.
+# Copy this file to mise.local.toml so production setup skips cargo-leptos.
 
 [settings]
 disable_tools = ["github:leptos-rs/cargo-leptos"]

--- a/mise.toml
+++ b/mise.toml
@@ -9,22 +9,22 @@ PROJECT_NAME = "okawak_blog"
 SERVICE_NAME = "okawak_blog"
 SERVICE_FILE = "service/okawak_blog.service"
 BIN_DIR = "./bin"
-TARGET_BIN = "./target/release/server"
-TARGET_HASH_FILE = "./target/release/hash.txt"
-DEPLOY_STAGED_SITE = "./target/site-staged"
+TARGET_BIN = "./target/release/topcoat-server"
+TARGET_ASSET_DIR = "./target/release/assets"
+DEPLOY_STAGED_ASSETS = "./target/assets-staged"
 LEPTOS_TAILWIND_VERSION = "v4.3.3"
 
 [tasks.check-deps]
-description = "Check if required tools are installed"
-depends = ["versions-check"]
+description = "Check if the production Topcoat build tools are installed"
 run = '''
 set -e
 echo "Checking dependencies..."
 mise --version
-bun --version
-cargo leptos --version
-leptosfmt --version
+cargo --version
 topcoat fmt --version
+expected_topcoat_version="$(sed -nE 's/^"cargo:topcoat-cli" = "([^"]+)"$/\1/p' mise.toml)"
+actual_topcoat_version="$(topcoat fmt --version | awk '{print $2}')"
+[ "$actual_topcoat_version" = "$expected_topcoat_version" ]
 '''
 
 [tasks.web-install]
@@ -108,26 +108,27 @@ find crates/site/web -name '*.rs' -exec leptosfmt {} +
 '''
 
 [tasks.dev]
-description = "Run the local Leptos development server with S3 artifacts"
-env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "s3", OKAWAK_BLOG_SITE_ORIGIN = "http://127.0.0.1:8008" }
+description = "Run the local Topcoat development server with S3 artifacts"
+env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "s3", OKAWAK_BLOG_SITE_ORIGIN = "http://127.0.0.1:8008", OKAWAK_BLOG_ADDR = "127.0.0.1:8008" }
 run = '''
 : "${OKAWAK_BLOG_ARTIFACT_BUCKET:?OKAWAK_BLOG_ARTIFACT_BUCKET is required}"
-cargo leptos serve -p server
+topcoat asset bundle --package server --bin topcoat-server
+./target/debug/topcoat-server
 '''
 
 [tasks.dev-local]
 description = "Publish the local Obsidian source and serve its generated artifacts"
-depends = ["web-install"]
-env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "crates/publish/dist/site", OKAWAK_BLOG_SITE_ORIGIN = "http://127.0.0.1:8008" }
+env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "crates/publish/dist/site", OKAWAK_BLOG_SITE_ORIGIN = "http://127.0.0.1:8008", OKAWAK_BLOG_ADDR = "127.0.0.1:8008" }
 run = '''
 mise run sync-obsidian
 cargo run -p publish
-cargo leptos serve -p server
+topcoat asset bundle --package server --bin topcoat-server
+./target/debug/topcoat-server
 '''
 
 [tasks.dev-topcoat-shell]
-description = "Run the transitional Topcoat runtime shell with fixture artifacts"
-env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "e2e/fixtures/site", OKAWAK_BLOG_TOPCOAT_ADDR = "127.0.0.1:8009" }
+description = "Run the Topcoat runtime with fixture artifacts"
+env = { OKAWAK_BLOG_ARTIFACT_SOURCE = "local", OKAWAK_BLOG_ARTIFACT_LOCAL_ROOT = "e2e/fixtures/site", OKAWAK_BLOG_ADDR = "127.0.0.1:8009" }
 run = '''
 topcoat asset bundle --package server --bin topcoat-server --release
 # Asset IDs are tied to the exact binary scanned by the bundler.
@@ -139,21 +140,19 @@ description = "Clean the Cargo build artifacts"
 run = "cargo clean"
 
 [tasks.build-project]
-description = "Build the integrated Leptos project for deployment"
-depends = ["check-deps", "web-install"]
-run = "cargo leptos build -p server --release"
+description = "Build the integrated Topcoat binary and asset bundle for deployment"
+depends = ["check-deps"]
+run = "topcoat asset bundle --package server --bin topcoat-server --release"
 
 [tasks.build-deployment]
 description = "Build a production release outside the live site directory"
-depends = ["check-deps", "web-install"]
-run = '''
-LEPTOS_SITE_ROOT="$DEPLOY_STAGED_SITE" cargo leptos build -p server --release
-'''
+depends = ["check-deps"]
+run = "topcoat asset bundle --package server --bin topcoat-server --release --out \"$DEPLOY_STAGED_ASSETS\""
 
 [tasks.build-server]
-description = "Build the server binary only"
+description = "Build the Topcoat server binary only"
 depends = ["check-deps"]
-run = "cargo build --release -p server"
+run = "cargo build --release -p server --bin topcoat-server"
 
 [tasks.pull]
 description = "Pull the latest changes from origin/main"
@@ -179,11 +178,12 @@ sudo cp -f "$SERVICE_FILE" "/etc/systemd/system/$SERVICE_NAME.service"
 '''
 
 [tasks.bin]
-description = "Copy the existing built server binary and asset hash manifest into ./bin"
+description = "Copy the existing Topcoat server binary and asset bundle into ./bin"
 run = '''
 sudo mkdir -p "$BIN_DIR"
-sudo cp "$TARGET_BIN" "$BIN_DIR/$SERVICE_NAME"
-sudo cp "$TARGET_HASH_FILE" "$BIN_DIR/hash.txt"
+sudo install -m 0755 "$TARGET_BIN" "$BIN_DIR/$SERVICE_NAME"
+sudo rm -rf -- "$BIN_DIR/assets"
+sudo cp -R "$TARGET_ASSET_DIR" "$BIN_DIR/assets"
 sudo chown -R root:root "$BIN_DIR"
 '''
 
@@ -236,6 +236,13 @@ run = "echo 'ci-flow completed'"
 [tasks.test]
 description = "Run tests for all workspace crates"
 run = "cargo test --workspace"
+
+[tasks.test-service]
+description = "Validate systemd units and staged deployment rollback"
+run = '''
+bash service/tests/systemd_units_test.sh
+bash service/tests/staged_deployment_test.sh
+'''
 
 [tasks.test-domain]
 description = "Run domain layer tests"

--- a/scripts/activate_staged_deployment.sh
+++ b/scripts/activate_staged_deployment.sh
@@ -2,33 +2,31 @@
 
 set -Eeuo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$repo_root"
 
 service_name="${SERVICE_NAME:-okawak_blog}"
 service_file="${SERVICE_FILE:-service/okawak_blog.service}"
-target_bin="${TARGET_BIN:-./target/release/server}"
-target_hash_file="${TARGET_HASH_FILE:-./target/release/hash.txt}"
+systemd_unit_dir="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+target_bin="${TARGET_BIN:-./target/release/topcoat-server}"
 bin_dir="${BIN_DIR:-./bin}"
-staged_site="${DEPLOY_STAGED_SITE:-./target/site-staged}"
-live_site="./target/site"
-rollback_site="./target/site-rollback"
-failed_site="./target/site-failed"
+staged_assets="${DEPLOY_STAGED_ASSETS:-./target/assets-staged}"
+live_assets="$bin_dir/assets"
+rollback_assets="$bin_dir/assets.rollback"
+failed_assets="$bin_dir/assets.failed"
 installed_bin="$bin_dir/$service_name"
 rollback_bin="$bin_dir/$service_name.rollback"
-installed_hash_file="$bin_dir/hash.txt"
-rollback_hash_file="$bin_dir/hash.txt.rollback"
+probe_attempts="${DEPLOY_PROBE_ATTEMPTS:-15}"
 
 service_was_active=false
-live_site_moved=false
-site_swapped=false
+live_assets_moved=false
+assets_swapped=false
 binary_change_started=false
 had_installed_bin=false
-had_installed_hash_file=false
 
 fail() {
   echo "staged-deploy: $*" >&2
-  exit 1
+  return 1
 }
 
 path_exists() {
@@ -51,22 +49,17 @@ rollback() {
     else
       sudo rm -f "$installed_bin"
     fi
-    if [[ "$had_installed_hash_file" == true ]]; then
-      sudo mv -f "$rollback_hash_file" "$installed_hash_file"
-    else
-      sudo rm -f "$installed_hash_file"
-    fi
   else
-    sudo rm -f "$rollback_bin" "$rollback_hash_file"
+    sudo rm -f "$rollback_bin"
   fi
 
-  if [[ "$site_swapped" == true ]]; then
-    if ! path_exists "$failed_site"; then
-      mv "$live_site" "$failed_site"
+  if [[ "$assets_swapped" == true ]]; then
+    if ! path_exists "$failed_assets"; then
+      sudo mv "$live_assets" "$failed_assets"
     fi
   fi
-  if [[ "$live_site_moved" == true ]]; then
-    mv "$rollback_site" "$live_site"
+  if [[ "$live_assets_moved" == true ]]; then
+    sudo mv "$rollback_assets" "$live_assets"
   fi
 
   sudo systemctl daemon-reload
@@ -74,24 +67,38 @@ rollback() {
     sudo systemctl start "$service_name.service"
   fi
 
-  echo "staged-deploy: failed release is preserved at $failed_site when available" >&2
+  echo "staged-deploy: failed asset bundle is preserved at $failed_assets when available" >&2
   exit "$status"
 }
 
-path_exists "$staged_site" || fail "staged site is missing: $staged_site"
-[[ -d "$staged_site/pkg" ]] || fail "staged pkg directory is missing"
-[[ -f "$staged_site/favicon.ico" ]] || fail "staged favicon is missing"
+path_exists "$staged_assets" || fail "staged asset bundle is missing: $staged_assets"
+[[ -f "$staged_assets/manifest.toml" ]] || fail "asset manifest is missing"
 [[ -x "$target_bin" ]] || fail "server binary is missing: $target_bin"
-[[ -f "$target_hash_file" ]] || fail "asset hash manifest is missing: $target_hash_file"
-find "$staged_site/pkg" -maxdepth 1 -type f -name '*.js' -print -quit | grep -q . \
-  || fail "staged JavaScript bundle is missing"
-find "$staged_site/pkg" -maxdepth 1 -type f -name '*.wasm' -print -quit | grep -q . \
-  || fail "staged WebAssembly bundle is missing"
+grep -q '^content_type = "text/css"$' "$staged_assets/manifest.toml" \
+  || fail "staged CSS asset is missing"
+grep -q '^content_type = "text/javascript"$' "$staged_assets/manifest.toml" \
+  || fail "staged JavaScript asset is missing"
+grep -q '^content_type = "image/x-icon"$' "$staged_assets/manifest.toml" \
+  || fail "staged favicon asset is missing"
+if find "$staged_assets" -maxdepth 1 -type f -name '*.wasm' -print -quit | grep -q . \
+  || grep -q '^content_type = "application/wasm"$' "$staged_assets/manifest.toml"; then
+  fail "staged asset bundle must not contain WebAssembly"
+fi
 
-path_exists "$rollback_site" && fail "rollback site already exists: $rollback_site"
-path_exists "$failed_site" && fail "failed site already exists: $failed_site"
+asset_count=0
+while IFS= read -r asset_file; do
+  [[ -n "$asset_file" ]] || continue
+  [[ "$asset_file" != */* && "$asset_file" != "." && "$asset_file" != ".." ]] \
+    || fail "asset manifest contains an unsafe filename: $asset_file"
+  [[ -f "$staged_assets/$asset_file" ]] \
+    || fail "manifest asset is missing: $asset_file"
+  ((asset_count += 1))
+done < <(sed -nE 's/^file = "([^"]+)"$/\1/p' "$staged_assets/manifest.toml")
+((asset_count > 0)) || fail "asset manifest contains no files"
+
+path_exists "$rollback_assets" && fail "rollback asset bundle already exists: $rollback_assets"
+path_exists "$failed_assets" && fail "failed asset bundle already exists: $failed_assets"
 path_exists "$rollback_bin" && fail "rollback binary already exists: $rollback_bin"
-path_exists "$rollback_hash_file" && fail "rollback hash manifest already exists: $rollback_hash_file"
 
 if sudo systemctl is-active --quiet "$service_name.service"; then
   service_was_active=true
@@ -100,35 +107,31 @@ fi
 trap 'rollback $? $LINENO' ERR
 
 sudo install -o root -g root -m 0644 \
-  "$service_file" "/etc/systemd/system/$service_name.service"
+  "$service_file" "$systemd_unit_dir/$service_name.service"
 sudo systemctl daemon-reload
 sudo systemctl stop "$service_name.service"
 
-if path_exists "$live_site"; then
-  mv "$live_site" "$rollback_site"
-  live_site_moved=true
-fi
-mv "$staged_site" "$live_site"
-site_swapped=true
-
 sudo mkdir -p "$bin_dir"
+if path_exists "$live_assets"; then
+  sudo mv "$live_assets" "$rollback_assets"
+  live_assets_moved=true
+fi
+sudo mv "$staged_assets" "$live_assets"
+assets_swapped=true
+sudo chown -R root:root "$live_assets"
+
 if path_exists "$installed_bin"; then
   sudo cp -p "$installed_bin" "$rollback_bin"
   had_installed_bin=true
 fi
-if path_exists "$installed_hash_file"; then
-  sudo cp -p "$installed_hash_file" "$rollback_hash_file"
-  had_installed_hash_file=true
-fi
 binary_change_started=true
 sudo install -o root -g root -m 0755 "$target_bin" "$installed_bin"
-sudo install -o root -g root -m 0644 "$target_hash_file" "$installed_hash_file"
 
 sudo systemctl daemon-reload
 sudo systemctl start "$service_name.service"
 
 ready=false
-for _ in {1..15}; do
+for ((attempt = 1; attempt <= probe_attempts; attempt += 1)); do
   if curl --fail --silent --show-error --output /dev/null \
     http://127.0.0.1:8008/api/health \
     && curl --fail --silent --show-error --output /dev/null \
@@ -141,14 +144,11 @@ done
 [[ "$ready" == true ]] || fail "health/readiness checks did not pass"
 
 trap - ERR
-if [[ "$live_site_moved" == true ]]; then
-  rm -rf -- "$rollback_site"
+if [[ "$live_assets_moved" == true ]]; then
+  sudo rm -rf -- "$rollback_assets"
 fi
 if [[ "$had_installed_bin" == true ]]; then
   sudo rm -f "$rollback_bin"
-fi
-if [[ "$had_installed_hash_file" == true ]]; then
-  sudo rm -f "$rollback_hash_file"
 fi
 
 echo "staged-deploy: release activated and health/readiness checks passed"

--- a/service/README.md
+++ b/service/README.md
@@ -1,23 +1,24 @@
 # Runtime service
 
-本番のLeptos SSR serverは`okawak_blog.service`で起動し、S3 artifact readerを使います。
+本番のTopcoat SSR serverは`okawak_blog.service`で起動し、S3 artifact readerを使います。
 
 本番環境の構成順序は[本番環境の初期構築](../docs/operations/production-setup.md)、IAM Roles Anywhereの検証、certificate更新、障害切り分けは[AWS runtime認証](../docs/operations/aws-runtime-auth.md)を一次手順とします。
 
-## VPS build tool override
+## VPS build tool
 
-Oracle Linux 9のglibcでは、miseのGitHub backendが配布する`cargo-leptos 0.3.7`を実行できません。本番VPSだけは同じversionをsourceからbuildし、repository固有のlocal configでmise配布版を無効化します。CIと開発端末は`mise.toml`と`mise.lock`のGNU版を引き続き使用します。
+production buildはTopcoat CLIを使い、`cargo-leptos`、Leptos hydration JavaScript、WebAssemblyを生成しません。Topcoat CLIのversionは`mise.toml`と`mise.lock`でframeworkと同じ0.6.2へ固定します。
+
+Leptos完全撤去までの間は、Oracle Linux 9で実行できない旧`cargo-leptos`のmise tool定義だけがrepositoryに残ります。本番VPSではrepository固有のlocal configでそのtoolを無効化します。sourceからの`cargo-leptos` installは不要です。
 
 VPSの運用userで次を実行します。
 
 ```bash
-cargo install --locked cargo-leptos --version 0.3.7
 cd /opt/okawak_blog
 install -m 0644 mise.local.toml.example mise.local.toml
 mise settings set locked true
 ```
 
-`mise.local.toml`はGit管理外です。`[settings].disable_tools`はmise配布版の`cargo-leptos`だけを無効化します。`mise settings set locked true`は運用userのglobal settingへ保存され、tracked `mise.lock`以外の解決を継続的に禁止します。lockfileにmusl用entryが含まれていても、musl版を選択する設定ではありません。
+`mise.local.toml`はGit管理外です。`[settings].disable_tools`は移行中に残るmise配布版の`cargo-leptos`だけを無効化します。`mise settings set locked true`は運用userのglobal settingへ保存され、tracked `mise.lock`以外の解決を継続的に禁止します。
 
 新しいSSH sessionで設定と選択binaryを確認します。
 
@@ -25,15 +26,14 @@ mise settings set locked true
 cd /opt/okawak_blog
 mise settings get disable_tools
 mise settings get locked
-command -v cargo-leptos
-cargo leptos --version
+topcoat fmt --version
 mise run check-deps
 git status --short
 ```
 
-`command -v cargo-leptos`がmiseのinstall directoryではなく運用userのCargo bin directoryを示し、versionが`0.3.7`、Git差分が空であれば正常です。`mise run build-project`とproduction用のstaged buildは`web-install`にも依存するため、fresh checkoutでもBun依存を個別に導入する必要はありません。
+Topcoat CLIが0.6.2で、`mise run check-deps`が成功し、Git差分が空であれば正常です。`mise run build-project`とproduction用のstaged buildはTopcoatのstandalone Tailwind integrationを使うため、`cargo-leptos`やBun package installへ依存しません。
 
-`mise run production-deploy`は稼働中の`target/site`を直接buildしません。`target/site-staged`にhash付きCSS / JavaScript / WebAssemblyを揃え、service停止後にsite、binary、binaryと同じdirectoryでLeptosが読む`bin/hash.txt`を同じreleaseへ切り替えます。起動後のhealth / readinessが失敗した場合は旧releaseを復元し、調査用の失敗siteを`target/site-failed`へ残します。
+`mise run production-deploy`は稼働中のasset directoryを直接buildしません。`target/assets-staged`にhash付きCSS / JavaScript / faviconを揃え、service停止後に`bin/okawak_blog`と、Topcoatがbinaryの隣から読む`bin/assets`を同じreleaseへ切り替えます。stagingはWebAssemblyを拒否します。起動後のhealth / readinessが失敗した場合は旧binaryと旧assetsを復元し、調査用の失敗bundleを`bin/assets.failed`へ残します。
 
 ## AWS credentials
 

--- a/service/okawak_blog.service
+++ b/service/okawak_blog.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=okawak Blog - Leptos Rust Web Application
+Description=okawak Blog - Topcoat Rust Web Application
 Wants=network-online.target
 After=network-online.target
 
@@ -22,6 +22,7 @@ Environment=OKAWAK_BLOG_ARTIFACT_SOURCE=s3
 Environment=OKAWAK_BLOG_ARTIFACT_BUCKET=okawak-blog-resources-bucket
 Environment=OKAWAK_BLOG_ARTIFACT_CACHE_TTL_SECONDS=5
 Environment=OKAWAK_BLOG_SITE_ORIGIN=https://www.okawak.net
+Environment=OKAWAK_BLOG_ADDR=127.0.0.1:8008
 
 StateDirectory=okawak_blog
 StateDirectoryMode=0700

--- a/service/tests/staged_deployment_test.sh
+++ b/service/tests/staged_deployment_test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+activation_script="$repo_root/scripts/activate_staged_deployment.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+
+fail() {
+  echo "staged-deployment-test: $*" >&2
+  exit 1
+}
+
+write_command_stubs() {
+  local stub_dir="$1"
+
+  mkdir -p "$stub_dir"
+  cat >"$stub_dir/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+  cat >"$stub_dir/install" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+args=()
+while (($# > 0)); do
+  case "$1" in
+    -o|-g)
+      shift 2
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+/usr/bin/install "${args[@]}"
+EOF
+  cat >"$stub_dir/chown" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  cat >"$stub_dir/systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "is-active" ]]; then
+  [[ "${STUB_SERVICE_ACTIVE:-false}" == "true" ]]
+  exit
+fi
+printf '%s\n' "$*" >>"$STUB_SYSTEMCTL_LOG"
+EOF
+  cat >"$stub_dir/curl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${STUB_CURL_FAIL:-false}" == "true" ]]; then
+  exit 22
+fi
+exit 0
+EOF
+  cat >"$stub_dir/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$stub_dir"/*
+}
+
+write_bundle() {
+  local bundle_dir="$1"
+
+  mkdir -p "$bundle_dir"
+  cat >"$bundle_dir/manifest.toml" <<'EOF'
+version = 1
+
+[[assets]]
+id = 1
+file = "tailwind-new.css"
+hash = "css"
+content_type = "text/css"
+
+[[assets]]
+id = 2
+file = "navigation-new.js"
+hash = "navigation"
+content_type = "text/javascript"
+
+[[assets]]
+id = 3
+file = "favicon-new.ico"
+hash = "favicon"
+content_type = "image/x-icon"
+EOF
+  printf 'new css\n' >"$bundle_dir/tailwind-new.css"
+  printf 'new js\n' >"$bundle_dir/navigation-new.js"
+  printf 'new icon\n' >"$bundle_dir/favicon-new.ico"
+}
+
+prepare_case() {
+  local case_dir="$1"
+
+  mkdir -p \
+    "$case_dir/bin/assets" \
+    "$case_dir/systemd" \
+    "$case_dir/target/release"
+  write_command_stubs "$case_dir/stubs"
+  write_bundle "$case_dir/target/assets-staged"
+  printf 'unit\n' >"$case_dir/service.service"
+  printf 'old binary\n' >"$case_dir/bin/okawak_blog"
+  printf 'old asset\n' >"$case_dir/bin/assets/old.css"
+  printf '#!/usr/bin/env bash\necho new binary\n' >"$case_dir/target/release/topcoat-server"
+  chmod +x "$case_dir/bin/okawak_blog" "$case_dir/target/release/topcoat-server"
+  : >"$case_dir/systemctl.log"
+}
+
+run_activation() {
+  local case_dir="$1"
+  local curl_fail="$2"
+
+  PATH="$case_dir/stubs:$PATH" \
+    REPO_ROOT="$case_dir" \
+    SERVICE_FILE="$case_dir/service.service" \
+    SYSTEMD_UNIT_DIR="$case_dir/systemd" \
+    TARGET_BIN="$case_dir/target/release/topcoat-server" \
+    BIN_DIR="$case_dir/bin" \
+    DEPLOY_STAGED_ASSETS="$case_dir/target/assets-staged" \
+    DEPLOY_PROBE_ATTEMPTS=1 \
+    STUB_SERVICE_ACTIVE=true \
+    STUB_CURL_FAIL="$curl_fail" \
+    STUB_SYSTEMCTL_LOG="$case_dir/systemctl.log" \
+    bash "$activation_script"
+}
+
+success_case="$test_root/success"
+prepare_case "$success_case"
+run_activation "$success_case" false
+cmp -s "$success_case/target/release/topcoat-server" "$success_case/bin/okawak_blog" \
+  || fail "successful activation did not install the new binary"
+[[ -f "$success_case/bin/assets/tailwind-new.css" ]] \
+  || fail "successful activation did not install the new assets"
+[[ ! -e "$success_case/bin/assets/old.css" ]] \
+  || fail "successful activation retained the old assets"
+[[ ! -e "$success_case/bin/assets.rollback" ]] \
+  || fail "successful activation retained rollback assets"
+[[ ! -e "$success_case/bin/assets.failed" ]] \
+  || fail "successful activation created failed assets"
+
+rollback_case="$test_root/rollback"
+prepare_case "$rollback_case"
+if run_activation "$rollback_case" true; then
+  fail "failed probes unexpectedly completed activation"
+fi
+grep -qx 'old binary' "$rollback_case/bin/okawak_blog" \
+  || fail "probe failure did not restore the old binary"
+[[ -f "$rollback_case/bin/assets/old.css" ]] \
+  || fail "probe failure did not restore the old assets"
+[[ -f "$rollback_case/bin/assets.failed/tailwind-new.css" ]] \
+  || fail "probe failure did not preserve the failed assets"
+grep -qx 'start okawak_blog.service' "$rollback_case/systemctl.log" \
+  || fail "probe failure did not restart the previously active service"
+
+wasm_case="$test_root/wasm"
+prepare_case "$wasm_case"
+printf 'wasm\n' >"$wasm_case/target/assets-staged/client.wasm"
+cat >>"$wasm_case/target/assets-staged/manifest.toml" <<'EOF'
+
+[[assets]]
+id = 4
+file = "client.wasm"
+hash = "wasm"
+content_type = "application/wasm"
+EOF
+if run_activation "$wasm_case" false; then
+  fail "WebAssembly bundle unexpectedly passed deployment validation"
+fi
+grep -qx 'old binary' "$wasm_case/bin/okawak_blog" \
+  || fail "preflight failure changed the installed binary"
+[[ -f "$wasm_case/bin/assets/old.css" ]] \
+  || fail "preflight failure changed the installed assets"
+[[ -d "$wasm_case/target/assets-staged" ]] \
+  || fail "preflight failure consumed the staged assets"
+
+echo "staged-deployment-test: all cases passed"

--- a/service/tests/systemd_units_test.sh
+++ b/service/tests/systemd_units_test.sh
@@ -9,6 +9,7 @@ grep -qx 'User=okawak' "$service_unit"
 grep -qx 'Environment=AWS_PROFILE=blog-s3' "$service_unit"
 grep -qx 'Environment=AWS_CONFIG_FILE=/etc/okawak_blog/aws/config' "$service_unit"
 grep -qx 'Environment=AWS_EC2_METADATA_DISABLED=true' "$service_unit"
+grep -qx 'Environment=OKAWAK_BLOG_ADDR=127.0.0.1:8008' "$service_unit"
 if grep -q '^Environment=AWS_SHARED_CREDENTIALS_FILE=' "$service_unit"; then
   echo "production service must not use static AWS credentials" >&2
   exit 1


### PR DESCRIPTION
## 概要

Issue #182 のproduction切替sliceとして、build・deploy・service・S3 smokeのentrypointをLeptos `server`からTopcoat `topcoat-server`へ切り替えます。legacy Leptos source/dependencyの削除は後続PRに分離します。

## 変更内容

- production/dev/dev-local/S3 smokeをTopcoat binary + asset bundleへ切替
- production listen契約を`OKAWAK_BLOG_ADDR`、既定`127.0.0.1:8008`へ統一
- staged deployを`topcoat-server` + `assets/manifest.toml`単位へ変更
- CSS / JavaScript / faviconとmanifest参照fileをpreflightし、WASMを拒否
- probe失敗時に旧binary + 旧asset bundleを復元し、失敗bundleを保存
- deploy成功・probe失敗rollback・WASM拒否のshell testを追加
- CI/browser E2E/upload workflowから不要なweb install / WASM準備を除去
- architecture / README / production runbook / systemdをTopcoat productionへ更新

## 確認

- `mise run build-deployment`
- `mise run build-project`
- Topcoat release binaryの既定port実HTTP（health / readiness / `/about`）
- `mise run test-service`
- `mise run format`
- `mise run versions-check`
- `mise run check`
- `mise run clippy`
- `mise run test`
- `mise run test-e2e`（32件 + empty-home 1件）
- `bunx tsc --noEmit`

実S3 smokeはcredentialを必要とするためローカルでは実行せず、同じTopcoat runnerへ更新した公開workflow gateで維持します。

Refs #182