### PR TITLE
docs: finalize Topcoat runtime checks

### DIFF
--- a/docs/operations/cloudflare-tunnel.md
+++ b/docs/operations/cloudflare-tunnel.md
@@ -165,7 +165,7 @@ curl --fail --output /dev/null \
 curl --fail https://www.okawak.net/api/ready
 ```
 
-DashboardではTunnelが`Healthy`で、connectorが接続済みであることを確認します。ブラウザではhome、category、article、戻る・進む操作を確認し、WASM初期化errorがないことも確認します。
+DashboardではTunnelが`Healthy`で、connectorが接続済みであることを確認します。ブラウザではhome、category、article、戻る・進む操作を確認し、Topcoat client runtimeのerrorがないことも確認します。
 
 ## 障害対応
 

--- a/docs/operations/production-setup.md
+++ b/docs/operations/production-setup.md
@@ -124,7 +124,7 @@ curl --fail https://www.okawak.net/api/ready
 - apexと`www`のPublished applicationが同じlocalhost originを指す
 - DNSがProxiedでTunnel IDを指す
 
-ブラウザでhome、category、article、CSS、client-side navigationを確認し、consoleにWASM初期化errorがないことを確認します。
+ブラウザでhome、category、article、CSS、client-side navigationを確認し、consoleにTopcoat client runtimeのerrorがないことを確認します。
 
 ## 7. 定常運用
 


### PR DESCRIPTION
## Summary

- replace the remaining Leptos-era WASM initialization checks in operational docs
- describe browser verification in terms of the current Topcoat client runtime

## Verification

- `git diff --check`
- repository-wide migration terminology audit

Part of #182.