### PR TITLE
test: move server router tests to integration suite

### DIFF
--- a/crates/site/server/src/router.rs
+++ b/crates/site/server/src/router.rs
@@ -86,7 +86,3 @@ pub fn create_router(
         .assets(assets)
         .build()
 }
-
-#[cfg(test)]
-#[path = "router_tests.rs"]
-mod tests;

--- a/crates/site/server/tests/router.rs
+++ b/crates/site/server/tests/router.rs
@@ -23,7 +23,7 @@ use topcoat::{
     router::{Body, HeaderMap, Router, StatusCode, header, request::Request, to_bytes},
 };
 
-use super::create_router as create_router_with_assets;
+use server::router::create_router as create_router_with_assets;
 
 struct TestResponse {
     status: StatusCode,

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -93,6 +93,7 @@ okawak_blog/
   - `router` moduleによるroute / layer / assetのcomposition
   - `page_loader` moduleによるartifactとstorage非依存page contractの接続
   - `http_cache` moduleによるrelease-aware ETagとconditional GET
+  - `tests/router.rs`による公開routerのcrate外integration test
 - `crates/site/web`
   - Topcoat UI component、公開route、metadata、site定数
   - client-side navigationと生成コンテンツ用script、Tailwind CSS入力、favicon asset


### PR DESCRIPTION
## 概要

serverのrouter integration testをproduction source treeからCargo標準のtests directoryへ移動します。

- src/router_tests.rsをtests/router.rsへ移動
- router.rsのcfg(test) module宣言を削除
- 外部crateとしてserver::router::create_routerを検証
- architectureのtest配置を更新

## 検証

- mise run format
- mise run test-server
- mise run check
- mise run clippy