### PR TITLE
refactor: warn on unreachable site exports

### DIFF
--- a/crates/site/infra/src/lib.rs
+++ b/crates/site/infra/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unreachable_pub)]
+
 //! Artifact storage boundary for the site runtime.
 
 mod cache;

--- a/crates/site/server/src/lib.rs
+++ b/crates/site/server/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unreachable_pub)]
+
 //! Site runtime composition and HTTP boundary.
 
 mod api;

--- a/crates/site/web/src/content_enhancement.rs
+++ b/crates/site/web/src/content_enhancement.rs
@@ -1,18 +1,19 @@
 //! Progressive enhancement resources for generated artifact content.
 
-pub const KATEX_STYLESHEET_URL: &str =
+pub(crate) const KATEX_STYLESHEET_URL: &str =
     "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css";
-pub const KATEX_STYLESHEET_INTEGRITY: &str =
+pub(crate) const KATEX_STYLESHEET_INTEGRITY: &str =
     "sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP";
-pub const KATEX_SCRIPT_URL: &str = "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js";
-pub const KATEX_SCRIPT_INTEGRITY: &str =
+pub(crate) const KATEX_SCRIPT_URL: &str =
+    "https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.js";
+pub(crate) const KATEX_SCRIPT_INTEGRITY: &str =
     "sha384-cMkvdD8LoxVzGF/RPUKAcvmm49FQ0oxwDF3BGKtDXcEc+T1b2N+teh/OJfpU0jr6";
-pub const HIGHLIGHT_STYLESHEET_URL: &str =
+pub(crate) const HIGHLIGHT_STYLESHEET_URL: &str =
     "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css";
-pub const HIGHLIGHT_SCRIPT_URL: &str =
+pub(crate) const HIGHLIGHT_SCRIPT_URL: &str =
     "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js";
 
-pub const MATH_RENDER_SCRIPT: &str = r#"
+pub(crate) const MATH_RENDER_SCRIPT: &str = r#"
 window.okawakRenderMath = function(root) {
 if (!window.katex) return;
 
@@ -61,7 +62,7 @@ attempt();
 };
 "#;
 
-pub const CODE_HIGHLIGHT_SCRIPT: &str = r#"
+pub(crate) const CODE_HIGHLIGHT_SCRIPT: &str = r#"
 window.okawakHighlightCode = function(root) {
 if (!window.hljs) return;
 const scope = root || document.body;

--- a/crates/site/web/src/format.rs
+++ b/crates/site/web/src/format.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime};
 
 /// Formats an artifact date for human-readable presentation.
-pub fn format_display_date(value: &str) -> String {
+pub(crate) fn format_display_date(value: &str) -> String {
     let date = DateTime::parse_from_rfc3339(value)
         .map(|date_time| date_time.date_naive())
         .or_else(|_| NaiveDate::parse_from_str(value, "%Y-%m-%d"))

--- a/crates/site/web/src/lib.rs
+++ b/crates/site/web/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unreachable_pub)]
+
 extern crate self as web;
 
 mod article_card;


### PR DESCRIPTION
## 概要

site配下3crateのlib.rsでunreachable_pub lintを有効化します。

- infra / web / serverへ#![warn(unreachable_pub)]を追加
- lintで検出したweb内部専用9項目をpub(crate)へ縮小
- crate外APIとruntime動作は変更なし

## 検証

- mise run format
- mise run check
- mise run clippy
- mise run test